### PR TITLE
fix(ci): codex-review consensus step quoting

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -225,8 +225,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          CODE_TOTAL=$(echo '${{ steps.code_review.outputs.result }}' | jq -r '.total // 4' 2>/dev/null || echo "4")
-          SECURITY_SCORE=$(echo '${{ steps.security_review.outputs.result }}' | jq -r '.score // 2' 2>/dev/null || echo "2")
+          # Parse scores from the temp JSON files to avoid shell-quoting issues
+          # when the review JSON contains apostrophes or other special characters.
+          CODE_TOTAL=$(jq -r '.total // 4' /tmp/code_review.json 2>/dev/null || echo "4")
+          SECURITY_SCORE=$(jq -r '.score // 2' /tmp/security_review.json 2>/dev/null || echo "2")
 
           TOTAL=$((CODE_TOTAL + SECURITY_SCORE))
 


### PR DESCRIPTION
Fix Codex Review workflow failure when review JSON contains apostrophes/special chars.

Change: consensus step now reads scores from /tmp/code_review.json and /tmp/security_review.json instead of embedding JSON into the shell script.