### PR TITLE
fix(ci): avoid shell expansion in codex-review PR comment

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -287,14 +287,16 @@ jobs:
             printf '%s\n' '<details>'
             printf '%s\n\n' '<summary>:mag: Code Review Details</summary>'
             printf '%s\n' '```json'
-            printf '%s\n' "${{ steps.code_review.outputs.result }}"
+            cat /tmp/code_review.json
+            printf '\n'
             printf '%s\n\n' '```'
             printf '%s\n\n' '</details>'
 
             printf '%s\n' '<details>'
             printf '%s\n\n' '<summary>:shield: Security Analysis Details</summary>'
             printf '%s\n' '```json'
-            printf '%s\n' "${{ steps.security_review.outputs.result }}"
+            cat /tmp/security_review.json
+            printf '\n'
             printf '%s\n\n' '```'
             printf '%s\n\n' '</details>'
 


### PR DESCRIPTION
Codex Review workflow was failing under `set -u` when model output contained `${VAR}`-like strings.

Change: build the PR comment via `printf` instead of a heredoc that embeds raw JSON outputs, preventing bash from expanding `$...` sequences.