### PR TITLE
fix(tutti): use GLM-only agents (avoid codex 404)

### DIFF
--- a/.github/workflows/fugue-tutti-caller.yml
+++ b/.github/workflows/fugue-tutti-caller.yml
@@ -56,7 +56,7 @@ jobs:
 
           echo "target_repo=${target_repo}" >> "${GITHUB_OUTPUT}"
 
-  # Review mode: 6-parallel agent consensus
+  # Review mode: Tutti consensus (currently 3 parallel agents)
   tutti:
     if: >-
       github.actor != 'github-actions[bot]' &&

--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -163,21 +163,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: codex-architect
-            provider: codex
-            api_url: https://api.openai.com/v1/chat/completions
-            model: gpt-5.3-codex-spark
-            agent_role: architect
-          - name: codex-security-analyst
-            provider: codex
-            api_url: https://api.openai.com/v1/chat/completions
-            model: gpt-5.3-codex-spark
-            agent_role: security-analyst
-          - name: codex-code-reviewer
-            provider: codex
-            api_url: https://api.openai.com/v1/chat/completions
-            model: gpt-5.3-codex-spark
-            agent_role: code-reviewer
           - name: glm-math-reasoning
             provider: glm
             api_url: https://api.z.ai/api/coding/paas/v4/chat/completions

--- a/scripts/gha24
+++ b/scripts/gha24
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# GHA24 - Submit task to FUGUE Tutti (6-parallel agent consensus)
+# GHA24 - Submit task to FUGUE Tutti (agent consensus)
 # Usage: gha24 "task description" [--implement] [--repo owner/repo]
 #
 # Options:


### PR DESCRIPTION
Codex vote agents were consistently failing with HTTP 404 from the OpenAI Chat Completions endpoint, which effectively made Tutti approvals impossible (max 3/6).

To keep the “mainframe” flow simple and low-maintenance, this change makes Tutti vote use only the stable GLM agents for now.

Result:
- Tutti vote can reach threshold again, so GHA24 implement can actually proceed when the vote passes.
