### PR TITLE
fix(gha24): harden mainframe orchestration

### DIFF
--- a/.github/workflows/fugue-codex-implement.yml
+++ b/.github/workflows/fugue-codex-implement.yml
@@ -118,6 +118,21 @@ jobs:
       codex_exit: ${{ steps.codex.outputs.exit_code }}
 
     steps:
+      - name: Guard PAT for cross-repo operations
+        if: ${{ needs.prepare.outputs.target_repo != github.repository }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_REPO_PAT: ${{ secrets.TARGET_REPO_PAT }}
+          ISSUE_NUMBER: ${{ needs.prepare.outputs.issue_number }}
+          TARGET_REPO: ${{ needs.prepare.outputs.target_repo }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${TARGET_REPO_PAT}" ]]; then
+            gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --body "Cannot implement into ${TARGET_REPO}: missing secret TARGET_REPO_PAT. Escalating to humans."
+            gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "needs-human" --remove-label "processing" || true
+            exit 0
+          fi
+
       - name: Checkout target repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/fugue-task-router.yml
+++ b/.github/workflows/fugue-task-router.yml
@@ -62,12 +62,16 @@ jobs:
           HAS_FUGUE="$(echo "${issue_json}" | jq -r '[.labels[].name] | index("fugue-task") != null')"
           HAS_TUTTI="$(echo "${issue_json}" | jq -r '[.labels[].name] | index("tutti") != null')"
           HAS_PROCESSING="$(echo "${issue_json}" | jq -r '[.labels[].name] | index("processing") != null')"
+          HAS_GHA24="$(echo "${issue_json}" | jq -r '((.body // "") | test("^##\\s*GHA24\\s*Task"; "m"))')"
 
           SHOULD_RUN="true"
           SKIP_REASON=""
           if [[ "${HAS_FUGUE}" != "true" ]]; then
             SHOULD_RUN="false"
             SKIP_REASON="missing-fugue-task-label"
+          elif [[ "${HAS_GHA24}" == "true" ]]; then
+            SHOULD_RUN="false"
+            SKIP_REASON="handled-by-gha24"
           elif [[ "${HAS_TUTTI}" == "true" ]]; then
             SHOULD_RUN="false"
             SKIP_REASON="handled-by-tutti"
@@ -89,6 +93,7 @@ jobs:
             echo "has_fugue=${HAS_FUGUE}"
             echo "has_tutti=${HAS_TUTTI}"
             echo "has_processing=${HAS_PROCESSING}"
+            echo "has_gha24=${HAS_GHA24}"
             echo "should_run=${SHOULD_RUN}"
             echo "skip_reason=${SKIP_REASON}"
           } >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/fugue-tutti-caller.yml
+++ b/.github/workflows/fugue-tutti-caller.yml
@@ -10,6 +10,10 @@ permissions:
   pull-requests: write
   actions: read
 
+concurrency:
+  group: fugue-mainframe-${{ github.repository }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   resolve-target:
     if: >-

--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -140,7 +140,9 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --remove-label "completed" \
             --remove-label "needs-review" \
-            --remove-label "needs-human" || true
+            --remove-label "needs-human" \
+            --remove-label "vote-approved" \
+            --remove-label "vote-rejected" || true
           gh issue edit "${{ steps.ctx.outputs.issue_number }}" \
             --repo "${GITHUB_REPOSITORY}" \
             --add-label "processing"
@@ -454,8 +456,7 @@ jobs:
 
           if [[ "${APPROVE_COUNT}" -ge "${threshold}" ]]; then
             if [[ "${HAS_CODEX_IMPLEMENT}" == "true" ]]; then
-              gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "vote-approved"
-              gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --body "Tutti vote: ${APPROVE_COUNT}/${TOTAL_COUNT} approval (>=2/3). Marked as vote-approved; implementation may proceed."
+              gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --body "Tutti vote: ${APPROVE_COUNT}/${TOTAL_COUNT} approval (>=2/3). Approved to execute; implementation may proceed."
             else
               gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "completed"
               gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --body "Tutti vote: ${APPROVE_COUNT}/${TOTAL_COUNT} approval (>=2/3). Auto-execution approved."
@@ -463,6 +464,5 @@ jobs:
             fi
           else
             gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "needs-review"
-            gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "vote-rejected" || true
             gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --body "Tutti vote: ${APPROVE_COUNT}/${TOTAL_COUNT} approval (<2/3). Marked for review."
           fi

--- a/.github/workflows/fugue-watchdog.yml
+++ b/.github/workflows/fugue-watchdog.yml
@@ -70,8 +70,39 @@ jobs:
             echo "last_time=${LAST_TIME}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Get latest successful mainframe run
+        id: mainframe_success
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          RUNS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/fugue-tutti-caller.yml/runs?status=success&per_page=1")"
+          LAST_TIME="$(echo "${RUNS_JSON}" | jq -r '.workflow_runs[0].created_at // empty')"
+
+          if [[ -z "${LAST_TIME}" ]]; then
+            echo "stale=true" >> "${GITHUB_OUTPUT}"
+            echo "hours_since=9999" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          NOW_EPOCH="$(date -u +%s)"
+          LAST_EPOCH="$(date -u -d "${LAST_TIME}" +%s)"
+          DIFF_HOURS="$(( (NOW_EPOCH - LAST_EPOCH) / 3600 ))"
+
+          STALE="false"
+          if [[ "${DIFF_HOURS}" -ge 3 ]]; then
+            STALE="true"
+          fi
+
+          {
+            echo "stale=${STALE}"
+            echo "hours_since=${DIFF_HOURS}"
+            echo "last_time=${LAST_TIME}"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Discord alert when unhealthy
-        if: ${{ steps.connectivity.outputs.openai_ok != 'true' || steps.connectivity.outputs.zai_ok != 'true' || steps.last_success.outputs.stale == 'true' }}
+        if: ${{ steps.connectivity.outputs.openai_ok != 'true' || steps.connectivity.outputs.zai_ok != 'true' || steps.last_success.outputs.stale == 'true' || steps.mainframe_success.outputs.stale == 'true' }}
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
@@ -82,7 +113,9 @@ jobs:
           openai_ok: ${{ steps.connectivity.outputs.openai_ok }}
           zai_ok: ${{ steps.connectivity.outputs.zai_ok }}
           router_hours_since_success: ${{ steps.last_success.outputs.hours_since }}
-          router_last_success_at: ${{ steps.last_success.outputs.last_time }}"
+          router_last_success_at: ${{ steps.last_success.outputs.last_time }}
+          mainframe_hours_since_success: ${{ steps.mainframe_success.outputs.hours_since }}
+          mainframe_last_success_at: ${{ steps.mainframe_success.outputs.last_time }}"
 
           PAYLOAD="$(jq -n --arg content "${MSG}" '{content:$content}')"
           curl -fsS -X POST "${DISCORD_WEBHOOK_URL}" \

--- a/scripts/gha24
+++ b/scripts/gha24
@@ -88,7 +88,9 @@ if [[ "${MODE_EXPLICIT}" != "true" ]]; then
   fi
 fi
 
-LABELS="fugue-task,tutti"
+# Create the issue first, then add the `tutti` label as a second step.
+# This avoids multiple `issues:labeled` triggers firing at creation time.
+LABELS="fugue-task"
 if [[ "${IMPLEMENT}" == "true" ]]; then
   LABELS="${LABELS},codex-implement"
 fi
@@ -96,6 +98,23 @@ fi
 BODY="$(cat <<EOF
 ## GHA24 Task
 ${TASK}
+
+## Spec (minimal)
+### Goal
+${TASK}
+
+### Must not
+- Do not touch unrelated files
+- Do not leak secrets
+- Do not perform destructive operations (delete/rotate/disable) unless explicitly requested
+
+### Acceptance criteria
+- [ ] Change matches Goal
+- [ ] No unintended file changes
+- [ ] CI/lint/tests pass if present
+
+### Rollback
+- Revert the PR
 
 ## Target repo
 \`${TARGET_REPO}\`
@@ -109,6 +128,9 @@ URL="$(gh issue create --repo "${ORCHESTRATOR_REPO}" \
   --title "${TASK}" \
   --label "${LABELS}" \
   --body "${BODY}")"
+
+ISSUE_NUM="${URL##*/}"
+gh issue edit "${ISSUE_NUM}" --repo "${ORCHESTRATOR_REPO}" --add-label "tutti" >/dev/null
 
 echo "Created: ${URL}"
 echo "Orchestrator repo: ${ORCHESTRATOR_REPO}"


### PR DESCRIPTION
Backyard 24h operation hardening with minimal state-machine complexity.

Changes
- `scripts/gha24`: create the issue first, then add label `tutti` as a second step to avoid multiple `issues:labeled` triggers at creation time.
- `scripts/gha24`: include a minimal spec skeleton (Goal / Must not / Acceptance / Rollback) in the issue body (implement-mode friendly).
- `fugue-task-router.yml`: skip GHA24 issues (body starts with `## GHA24 Task`) so the generic router never races / blocks the mainframe path.
- `fugue-tutti-caller.yml`: add workflow-level concurrency keyed by issue number.
- `fugue-tutti-router.yml`: remove `vote-approved`/`vote-rejected` label writes (comments remain as audit log) and always clear any legacy vote labels.
- `fugue-codex-implement.yml`: fail-fast when implementing into a different target repo without `TARGET_REPO_PAT`.
- `fugue-watchdog.yml`: monitor the mainframe workflow (`fugue-tutti-caller.yml`) freshness in addition to the generic router.
