### PR TITLE
feat(gha24): natural-language mainframe handoff (mobile-first)

### DIFF
--- a/.github/workflows/fugue-task-router.yml
+++ b/.github/workflows/fugue-task-router.yml
@@ -103,8 +103,60 @@ jobs:
         run: |
           echo "Skip reason: ${{ steps.ctx.outputs.skip_reason }}"
 
-      - name: Add processing label
+      - name: GHA24 mainframe handoff (natural language)
+        id: handoff
         if: ${{ steps.ctx.outputs.should_run == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+          ISSUE_TITLE: ${{ steps.ctx.outputs.issue_title }}
+          ISSUE_BODY: ${{ steps.ctx.outputs.issue_body }}
+        run: |
+          set -euo pipefail
+
+          title="${ISSUE_TITLE}"
+          body="${ISSUE_BODY}"
+          text="$(printf '%s\n%s\n' "${title}" "${body}")"
+
+          # Natural-language trigger: require an explicit "complete it" intent
+          # to avoid accidentally pushing issues into the GHA24 mainframe.
+          wants_mainframe=false
+          if echo "${text}" | grep -Eqi '(完遂|自走|完了まで|最後まで|full[- ]?auto|#gha24|GHA24)'; then
+            wants_mainframe=true
+          fi
+
+          if [[ "${wants_mainframe}" != "true" ]]; then
+            echo "handoff=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # Mode selection:
+          # - If user explicitly asked for mainframe completion, default to implement.
+          # - Explicit review-only wins over implement.
+          wants_review=false
+          wants_implement=true
+          if echo "${text}" | grep -Eqi '(レビューのみ|指摘のみ|実装しない|実装不要|review only|no implement|no-implement|#review)'; then
+            wants_review=true
+          fi
+          if [[ "${wants_review}" == "true" ]]; then
+            wants_implement=false
+          fi
+
+          # Ensure `codex-implement` label is present before firing `tutti`.
+          if [[ "${wants_implement}" == "true" ]]; then
+            gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "codex-implement" >/dev/null
+          fi
+
+          gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "tutti" >/dev/null
+
+          mode="$( [[ "${wants_implement}" == "true" ]] && echo "implement" || echo "review" )"
+          gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --body "GHA24 mainframe handoff (natural language)\n\n- Mode: ${mode}\n- Action: added label \`tutti\`$([[ \"${wants_implement}\" == \"true\" ]] && echo \" + \`codex-implement\`\" || echo \"\")\n\nNext: Tutti runs and posts the vote/audit comment. If approved and \`codex-implement\` is present, Codex will create a PR."
+
+          echo "handoff=true" >> "${GITHUB_OUTPUT}"
+          echo "mode=${mode}" >> "${GITHUB_OUTPUT}"
+
+      - name: Add processing label
+        if: ${{ steps.ctx.outputs.should_run == 'true' && steps.handoff.outputs.handoff != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -112,7 +164,7 @@ jobs:
 
       - name: Classify intent (Node.js decision table)
         id: classify
-        if: ${{ steps.ctx.outputs.should_run == 'true' }}
+        if: ${{ steps.ctx.outputs.should_run == 'true' && steps.handoff.outputs.handoff != 'true' }}
         env:
           ISSUE_TITLE: ${{ steps.ctx.outputs.issue_title }}
           ISSUE_BODY: ${{ steps.ctx.outputs.issue_body }}
@@ -148,7 +200,7 @@ jobs:
 
       - name: Check author trust
         id: trust
-        if: ${{ steps.ctx.outputs.should_run == 'true' }}
+        if: ${{ steps.ctx.outputs.should_run == 'true' && steps.handoff.outputs.handoff != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -173,7 +225,7 @@ jobs:
 
       - name: Resolve final tier
         id: final
-        if: ${{ steps.ctx.outputs.should_run == 'true' }}
+        if: ${{ steps.ctx.outputs.should_run == 'true' && steps.handoff.outputs.handoff != 'true' }}
         run: |
           BASE_TIER="${{ steps.classify.outputs.tier }}"
           TRUSTED="${{ steps.trust.outputs.trusted }}"
@@ -184,7 +236,7 @@ jobs:
           echo "tier=${FINAL_TIER}" >> "${GITHUB_OUTPUT}"
 
       - name: Execute agent and post result (Tier 0-2)
-        if: ${{ steps.ctx.outputs.should_run == 'true' && steps.final.outputs.tier != '3' }}
+        if: ${{ steps.ctx.outputs.should_run == 'true' && steps.handoff.outputs.handoff != 'true' && steps.final.outputs.tier != '3' }}
         env:
           GH_TOKEN: ${{ github.token }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -250,7 +302,7 @@ jobs:
           fi
 
       - name: Tier 3 fallback
-        if: ${{ steps.ctx.outputs.should_run == 'true' && steps.final.outputs.tier == '3' }}
+        if: ${{ steps.ctx.outputs.should_run == 'true' && steps.handoff.outputs.handoff != 'true' && steps.final.outputs.tier == '3' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/docs/gha24-mainframe-flow.md
+++ b/docs/gha24-mainframe-flow.md
@@ -4,15 +4,23 @@
 Capture how a GHA24 request gets into the existing FUGUE mainframe path (tutti vote → optional Codex implementation) so readers can quickly understand the automation, guardrails, and monitoring around that "mainframe" stage of the pipeline.
 
 ## High-level flow
-1. **Two-step Tutti trigger.** The `scripts/gha24` helper creates the `fugue-task` issue with a minimal spec skeleton, then immediately edits the same issue to add the `tutti` label. Separating creation from the `tutti` label keeps the mainframe path anchored to a single explicit consent action (label `tutti`), and prevents accidental multi-triggering when other labels are present.
+1. **Enter the mainframe path (two options).**
+   - **CLI (two-step):** `scripts/gha24` creates the `fugue-task` issue with a minimal spec skeleton, then immediately edits the same issue to add the `tutti` label. Separating creation from the `tutti` label keeps the mainframe path anchored to a single explicit consent action (label `tutti`), and prevents accidental multi-triggering when other labels are present.
+   - **Mobile / natural language:** Create a plain `fugue-task` issue (no `## GHA24 Task` header) and include an explicit "complete it" phrase like `完遂` / `自走` / `最後まで`. `fugue-task-router` will add `tutti` (and by default also `codex-implement`) and leave an audit comment that it handed off to GHA24.
 2. **Tutti consensus.** Adding label `tutti` fires `.github/workflows/fugue-tutti-caller.yml`, which downloads the issue text, runs the `fugue-tutti-router` agent vote, and only triggers `fugue-codex-implement` once the vote passes with no HIGH-risk findings. The router runs three parallel agents, integrates their JSON results, and posts a summary comment to the originating issue (the comment is the audit log).
-3. **Codex implementation (optional).** When the issue also carries `codex-implement`, the passed vote hands off to `fugue-codex-implement`, which checks whether the target repo is the current repo or a cross-repo target before installing `@openai/codex`, running Codex CLI, and creating a PR.
+3. **Codex implementation (optional).** When the issue carries `codex-implement`, the passed vote hands off to `fugue-codex-implement`, which checks whether the target repo is the current repo or a cross-repo target before installing `@openai/codex`, running Codex CLI, and creating a PR.
 
 ## Guardrails
 - **Spec skeleton.** Every issue created via `scripts/gha24` follows the template under `## GHA24 Task` / `## Spec (minimal)`, so every request documents `Goal`, `Must not` constraints, concrete acceptance criteria, and rollback instructions. The structured checklist keeps machine readers and judges consistent inputs across requests.
-- **Router skip.** `fugue-task-router` short-circuits whenever an issue already carries `tutti`, `processing`, or the `GHA24 Task` header: it only services plain `fugue-task` issues. A similar guard prevents `fugue-tutti-router` from reprocessing the same issue while `processing` is attached, so GHA24 requests stay in their dedicated lane rather than competing with manual Claude-triggered issues.
+- **Router skip.** `fugue-task-router` short-circuits whenever an issue already carries `tutti` or `processing`, and it also skips issues using the `## GHA24 Task` header (those are expected to be driven by `scripts/gha24`). This keeps the "plain fugue-task router" lane and the "GHA24 mainframe" lane from competing. A similar guard prevents `fugue-tutti-router` from reprocessing the same issue while `processing` is attached.
 - **PAT guard.** If a Codex implementation needs to target a repo other than the orchestrator, `fugue-codex-implement` refuses to run unless the optional `TARGET_REPO_PAT` secret is provided. Missing PATs result in a comment, a `needs-human` label, and no further automation, ensuring we never push cross-repo changes without explicit secrets consent.
 - **Watchdog.** `.github/workflows/fugue-watchdog.yml` runs hourly to keep the mainframe healthy: it checks OpenAI/Z.ai connectivity, verifies that both `fugue-task-router` and `fugue-tutti-caller` have had a successful run in the last 3 hours, posts a Discord alert if anything is stale, and works through open `fugue-task` issues that lack `processing`/`completed` labels by retriggering the router.
+
+## Mobile quick start
+- Create a GitHub Issue and add label `fugue-task`.
+- In the body, include:
+  - `完遂` (hands off to GHA24 mainframe)
+  - Optional: `レビューのみ` (do not add `codex-implement`)
 
 ## Observability
 - Tutti summaries, vote tallies, and Codex CLI output live directly on the originating GitHub issue so reviewers can trace decisions.


### PR DESCRIPTION
## What
- Add natural-language GHA24 handoff in `fugue-task-router`: for plain `fugue-task` issues containing 完遂/自走/最後まで (or #gha24), it adds `tutti` (and by default `codex-implement`) before any `processing` label is applied.
- Leave an audit comment indicating the handoff.
- Update `docs/gha24-mainframe-flow.md` with the mobile entrypoint.

## Why
- Smartphone-first operation: no need to run `scripts/gha24` or manually add `tutti` from the phone.
- Avoids the failure mode where `processing` exists before `tutti` (which makes `fugue-tutti-router` skip).

## How to test (GitHub Mobile)
1. Create an Issue and add label `fugue-task`.
2. In the body, write e.g. `完遂` (optionally add `レビューのみ` to suppress PR creation).
3. Confirm the router comments "GHA24 mainframe handoff" and adds label `tutti` (+ `codex-implement` unless review-only).
4. Confirm mainframe runs: Tutti vote comment appears; if approved, Codex implementation creates a PR.
