### PR TITLE
feat(mobile): issue template for fugue-task

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/fugue-task.yml
+++ b/.github/ISSUE_TEMPLATE/fugue-task.yml
@@ -1,0 +1,47 @@
+name: FUGUE Task (Mobile / Natural Language)
+description: Smartphone-first entrypoint. Adds label fugue-task automatically.
+title: "task: "
+labels:
+  - fugue-task
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template automatically applies label `fugue-task`.
+
+        Mainframe handoff (GHA24) keywords:
+        - Add `完遂` / `自走` / `最後まで` to request the mainframe path (adds `tutti`, and by default `codex-implement`)
+        - Add `レビューのみ` / `実装不要` to suppress PR creation
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What outcome do you want? (write in natural language)
+      placeholder: |
+        完遂
+        目的: ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: must_not
+    attributes:
+      label: Must not
+      description: Constraints / things the automation must not do.
+      placeholder: |
+        Must not: ...
+        (例) レビューのみ / PR作成しない
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria (optional)
+      description: Concrete checks to know it's done.
+      placeholder: |
+        - ...
+    validations:
+      required: false
+

--- a/docs/gha24-mainframe-flow.md
+++ b/docs/gha24-mainframe-flow.md
@@ -17,7 +17,7 @@ Capture how a GHA24 request gets into the existing FUGUE mainframe path (tutti v
 - **Watchdog.** `.github/workflows/fugue-watchdog.yml` runs hourly to keep the mainframe healthy: it checks OpenAI/Z.ai connectivity, verifies that both `fugue-task-router` and `fugue-tutti-caller` have had a successful run in the last 3 hours, posts a Discord alert if anything is stale, and works through open `fugue-task` issues that lack `processing`/`completed` labels by retriggering the router.
 
 ## Mobile quick start
-- Create a GitHub Issue and add label `fugue-task`.
+- Create a GitHub Issue using the template **FUGUE Task (Mobile / Natural Language)** (auto-adds label `fugue-task`), or manually add label `fugue-task`.
 - In the body, include:
   - `完遂` (hands off to GHA24 mainframe)
   - Optional: `レビューのみ` (do not add `codex-implement`)


### PR DESCRIPTION
Add an issue template that auto-applies label `fugue-task` so GitHub Mobile users can start the pipeline without manually selecting labels.

Also updates `docs/gha24-mainframe-flow.md` Mobile quick start to reference the template.