### PR TITLE
feat: make it obvious which project each task is for

### DIFF
--- a/.github/ISSUE_TEMPLATE/fugue-task.yml
+++ b/.github/ISSUE_TEMPLATE/fugue-task.yml
@@ -13,6 +13,17 @@ body:
         - Add `完遂` / `自走` / `最後まで` to request the mainframe path (adds `tutti`, and by default `codex-implement`)
         - Add `レビューのみ` / `実装不要` to suppress PR creation
 
+        Tip: if you include a target repo in backticks like `cursorvers/cloudflare-workers-hub`, FUGUE will label and prefix the issue title so you can quickly see which project it belongs to.
+
+  - type: input
+    id: target_repo
+    attributes:
+      label: Target repo (optional)
+      description: If the work is for another repo, put owner/repo here.
+      placeholder: cursorvers/fugue-orchestrator
+    validations:
+      required: false
+
   - type: textarea
     id: goal
     attributes:
@@ -44,4 +55,3 @@ body:
         - ...
     validations:
       required: false
-

--- a/.github/workflows/fugue-task-router.yml
+++ b/.github/workflows/fugue-task-router.yml
@@ -44,6 +44,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          COMMENT_BODY=""
+          if [[ "${GITHUB_EVENT_NAME}" == "issue_comment" ]]; then
+            COMMENT_BODY="$(jq -r '.comment.body // ""' "${GITHUB_EVENT_PATH}")"
+          fi
+
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_call" ]]; then
             ISSUE_NUMBER="${{ inputs.issue_number }}"
             issue_json="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}")"
@@ -88,6 +93,9 @@ jobs:
             echo "issue_body<<EOF"
             echo "${BODY}"
             echo "EOF"
+            echo "comment_body<<EOF"
+            echo "${COMMENT_BODY}"
+            echo "EOF"
             echo "author=${AUTHOR}"
             echo "author_association=${AUTHOR_ASSOC}"
             echo "has_fugue=${HAS_FUGUE}"
@@ -102,6 +110,68 @@ jobs:
         if: ${{ steps.ctx.outputs.should_run != 'true' }}
         run: |
           echo "Skip reason: ${{ steps.ctx.outputs.skip_reason }}"
+
+      - name: Annotate target project (label + title prefix)
+        if: ${{ steps.ctx.outputs.should_run == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ steps.ctx.outputs.issue_number }}
+          ISSUE_TITLE: ${{ steps.ctx.outputs.issue_title }}
+          ISSUE_BODY: ${{ steps.ctx.outputs.issue_body }}
+          COMMENT_BODY: ${{ steps.ctx.outputs.comment_body }}
+        run: |
+          set -euo pipefail
+
+          title="${ISSUE_TITLE}"
+          body="${ISSUE_BODY}"
+          comment="${COMMENT_BODY}"
+          text="$(printf '%s\n%s\n%s\n' "${title}" "${body}" "${comment}")"
+
+          owner="${GITHUB_REPOSITORY%%/*}"
+
+          # 1) Prefer fully-qualified owner/repo found inside backticks.
+          target_repo="$(printf '%s\n' "${text}" \
+            | sed -nE 's/.*`([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)`.*/\1/p' \
+            | head -n1)"
+
+          # 2) Fallback: repo name in backticks on lines mentioning repo/リポジトリ.
+          if [[ -z "${target_repo}" ]]; then
+            bare_repo="$(printf '%s\n' "${text}" \
+              | grep -E 'repo|Repo|repository|Repository|リポジトリ|対象|target' \
+              | sed -nE 's/.*`([A-Za-z0-9_.-]+)`.*/\1/p' \
+              | head -n1 || true)"
+            if [[ -n "${bare_repo}" ]]; then
+              target_repo="${owner}/${bare_repo}"
+            fi
+          fi
+
+          # 3) Default to caller repo when no hint exists.
+          if [[ -z "${target_repo}" ]]; then
+            target_repo="${GITHUB_REPOSITORY}"
+          fi
+
+          short="${target_repo#*/}"
+          slug="$(printf '%s' "${short}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_.-]/-/g' | sed 's/--*/-/g' | head -c 40)"
+          if [[ -z "${slug}" ]]; then
+            slug="unknown"
+          fi
+
+          proj_label="proj:${slug}"
+
+          # Create label if missing (idempotent).
+          gh label create "${proj_label}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --description "Target project: ${target_repo}" \
+            --color "0E8A16" >/dev/null 2>&1 || true
+
+          # Apply label to the issue.
+          gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "${proj_label}" >/dev/null || true
+
+          # Prefix title for easy scanning in the issue list (avoid clobbering an existing [..] prefix).
+          if ! echo "${title}" | grep -Eq '^\[[^]]+\]\s'; then
+            new_title="[${slug}] ${title}"
+            gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --title "${new_title}" >/dev/null || true
+          fi
 
       - name: GHA24 mainframe handoff (natural language)
         id: handoff

--- a/docs/gha24-mainframe-flow.md
+++ b/docs/gha24-mainframe-flow.md
@@ -21,6 +21,7 @@ Capture how a GHA24 request gets into the existing FUGUE mainframe path (tutti v
 - In the body, include:
   - `完遂` (hands off to GHA24 mainframe)
   - Optional: `レビューのみ` (do not add `codex-implement`)
+  - Optional: a target repo in backticks, e.g. `cursorvers/cloudflare-workers-hub` (FUGUE will add a `proj:<repo>` label and prefix the issue title for easy scanning)
 
 ## Observability
 - Tutti summaries, vote tallies, and Codex CLI output live directly on the originating GitHub issue so reviewers can trace decisions.


### PR DESCRIPTION
Auto-detect target repo in fugue-task issue text (owner/repo inside backticks), then:
- add a label proj:<repo>
- prefix the issue title with [<repo>] (if it has no existing [..] prefix)

This makes the issue list readable on GitHub Mobile when multiple projects are in flight.