### PR TITLE
fix: mainframe runs even when tutti label is added by automation

### DIFF
--- a/.github/workflows/fugue-codex-implement.yml
+++ b/.github/workflows/fugue-codex-implement.yml
@@ -39,7 +39,6 @@ concurrency:
 
 jobs:
   prepare:
-    if: ${{ github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/fugue-task-router.yml
+++ b/.github/workflows/fugue-task-router.yml
@@ -29,7 +29,9 @@ permissions:
 
 jobs:
   route:
-    if: ${{ github.event_name != 'issue_comment' || github.actor != 'github-actions[bot]' }}
+    # Ignore bot-driven issue label churn (processing/proj labels), but still allow
+    # watchdog-triggered workflow_dispatch to run as github-actions[bot].
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/fugue-tutti-caller.yml
+++ b/.github/workflows/fugue-tutti-caller.yml
@@ -17,7 +17,6 @@ concurrency:
 jobs:
   resolve-target:
     if: >-
-      github.actor != 'github-actions[bot]' &&
       github.event.label.name == 'tutti' &&
       contains(github.event.issue.labels.*.name, 'fugue-task') &&
       contains(github.event.issue.labels.*.name, 'codex-implement')
@@ -63,7 +62,6 @@ jobs:
   # Review mode: Tutti consensus (currently 3 parallel agents)
   tutti:
     if: >-
-      github.actor != 'github-actions[bot]' &&
       github.event.label.name == 'tutti' &&
       contains(github.event.issue.labels.*.name, 'fugue-task') &&
       contains(github.event.issue.labels.*.name, 'tutti')
@@ -77,7 +75,6 @@ jobs:
   # Implement mode: if Tutti says it's safe AND issue requests implementation, run Codex implement immediately.
   codex-implement:
     if: >-
-      github.actor != 'github-actions[bot]' &&
       github.event.label.name == 'tutti' &&
       contains(github.event.issue.labels.*.name, 'fugue-task') &&
       contains(github.event.issue.labels.*.name, 'codex-implement') &&

--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -43,7 +43,6 @@ concurrency:
 
 jobs:
   prepare:
-    if: ${{ github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
@@ -157,7 +156,7 @@ jobs:
           gh issue edit "${ISSUE}" --repo "${GITHUB_REPOSITORY}" --add-label "needs-human" --remove-label "processing" || true
 
   run-agents:
-    if: ${{ github.actor != 'github-actions[bot]' && needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.trusted == 'true' }}
+    if: ${{ needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.trusted == 'true' }}
     needs: [prepare]
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -302,7 +301,7 @@ jobs:
           if-no-files-found: error
 
   integrate:
-    if: ${{ github.actor != 'github-actions[bot]' && needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.trusted == 'true' }}
+    if: ${{ needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.trusted == 'true' }}
     needs: [prepare, run-agents]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -427,7 +426,7 @@ jobs:
             --body-file integrated-comment.md
 
   finalize:
-    if: ${{ github.actor != 'github-actions[bot]' && needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.trusted == 'true' }}
+    if: ${{ needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.trusted == 'true' }}
     needs: [prepare, integrate]
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
Natural-language handoff adds `tutti` (and optional `codex-implement`) via github-actions[bot].

This PR:
- Removes github.actor != github-actions[bot] guards from mainframe workflows so Tutti/Codex can execute after an automated handoff.
- Updates fugue-task-router job gating to ignore bot-driven issue label churn (processing/proj labels) while still allowing watchdog workflow_dispatch runs.