### PR TITLE
fix(router): avoid labeled-trigger churn

### DIFF
--- a/.github/workflows/fugue-task-router.yml
+++ b/.github/workflows/fugue-task-router.yml
@@ -13,7 +13,9 @@ on:
       ZAI_API_KEY:
         required: true
   issues:
-    types: [opened, labeled]
+    # Avoid `labeled` here: labels added by automation (processing/proj/tutti) can
+    # create extra runs and cause unnecessary concurrency cancellations.
+    types: [opened]
   issue_comment:
     types: [created]
   workflow_dispatch:


### PR DESCRIPTION
Remove issues:labeled trigger from fugue-task-router.

Reason: automation adds multiple labels (processing/proj/tutti) which can create extra runs and concurrency cancellations. Mobile usage relies on issue templates (label present at creation) and watchdog workflow_dispatch covers later catch-up.