### PR TITLE
fix: allow target repo hints without backticks

### DIFF
--- a/.github/workflows/fugue-task-router.yml
+++ b/.github/workflows/fugue-task-router.yml
@@ -153,6 +153,11 @@ jobs:
             | sed -nE 's/.*`([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)`.*/\1/p' \
             | head -n1)"
 
+          # 1b) Also accept plain "owner/repo" (common on mobile forms).
+          if [[ -z "${target_repo}" ]]; then
+            target_repo="$(printf '%s\n' "${text}" | grep -oE "${owner}/[A-Za-z0-9_.-]+" | head -n1 || true)"
+          fi
+
           # 2) Fallback: repo name in backticks on lines mentioning repo/リポジトリ.
           if [[ -z "${target_repo}" ]]; then
             bare_repo="$(printf '%s\n' "${text}" \

--- a/.github/workflows/fugue-tutti-caller.yml
+++ b/.github/workflows/fugue-tutti-caller.yml
@@ -61,6 +61,11 @@ jobs:
             | sed -nE 's/.*`([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)`.*/\1/p' \
             | head -n1)"
 
+          # 1b) Also accept plain "owner/repo" (common on mobile forms).
+          if [[ -z "${target_repo}" ]]; then
+            target_repo="$(printf '%s\n' "${body}" | grep -oE "${owner}/[A-Za-z0-9_.-]+" | head -n1 || true)"
+          fi
+
           # 2) Fallback: repo name in backticks on lines mentioning repo/リポジトリ.
           if [[ -z "${target_repo}" ]]; then
             bare_repo="$(printf '%s\n' "${body}" \


### PR DESCRIPTION
GitHub Mobile issue forms often produce plain text like cursorvers/cloudflare-workers-hub (without backticks). Parse that as a target repo hint for:
- proj:<repo> labeling + [repo] title prefix
- cross-repo target resolution in mainframe dispatch