### PR TITLE
fix: clarify provider rate-limits and improve model fallbacks

### DIFF
--- a/.github/workflows/fugue-task-router.yml
+++ b/.github/workflows/fugue-task-router.yml
@@ -391,7 +391,7 @@ jobs:
           RESP_PROVIDER=""
           # Try OpenAI first if provider is codex
           if [[ "${PROVIDER}" == "codex" && -n "${OPENAI_API_KEY}" ]]; then
-            OPENAI_MODEL_CANDIDATES=("gpt-5.3-codex-spark" "gpt-5.3-codex" "gpt-5.2-codex")
+            OPENAI_MODEL_CANDIDATES=("gpt-5.3-codex-spark" "gpt-5.3-codex" "gpt-5.2-codex" "gpt-5.1-codex" "gpt-4.1" "gpt-4o-mini")
             for OPENAI_MODEL in "${OPENAI_MODEL_CANDIDATES[@]}"; do
               REQ="$(jq -n --arg model "${OPENAI_MODEL}" --arg s "${SYS_PROMPT}" --arg u "${USER_PROMPT}" '{model:$model,messages:[{role:"system",content:$s},{role:"user",content:$u}],temperature:0.2}')"
               raw="$(curl -sS -w "\n%{http_code}" https://api.openai.com/v1/chat/completions \

--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -276,8 +276,8 @@ jobs:
           content=""
 
           if [[ "${PROVIDER}" == "codex" ]]; then
-            # Prefer spark when available, but fall back to widely-available Codex models.
-            candidates=("${MODEL}" "gpt-5.3-codex" "gpt-5.2-codex" "gpt-5.1-codex")
+            # Prefer Codex models first, then generic OpenAI fallbacks for compatibility.
+            candidates=("${MODEL}" "gpt-5.3-codex" "gpt-5.2-codex" "gpt-5.1-codex" "gpt-4.1" "gpt-4o-mini")
             for m in "${candidates[@]}"; do
               chosen_model="${m}"
               req="$(jq -n \
@@ -343,6 +343,24 @@ jobs:
             skipped_flag="true"
           fi
 
+          optional_error_note=""
+          optional_provider_label=""
+          if [[ "${PROVIDER}" == "gemini" && "${http_code}" != "200" ]]; then
+            optional_provider_label="Gemini"
+            if [[ "${http_code}" == "429" ]]; then
+              optional_error_note="Gemini API rate limited (HTTP 429)"
+            else
+              optional_error_note="Gemini API error (HTTP ${http_code})"
+            fi
+          elif [[ "${PROVIDER}" == "xai" && "${http_code}" != "200" ]]; then
+            optional_provider_label="xAI"
+            if [[ "${http_code}" == "429" ]]; then
+              optional_error_note="xAI API rate limited (HTTP 429)"
+            else
+              optional_error_note="xAI API error (HTTP ${http_code})"
+            fi
+          fi
+
           # Extract JSON even if wrapped in ```json fences.
           extracted="$(jq -Rn --arg s "${content}" '
             ($s | gsub("\r"; "") | gsub("^\\s+|\\s+$"; "")) as $t |
@@ -359,7 +377,18 @@ jobs:
             if type == "string" then (fromjson? // .) else . end
           ' 2>/dev/null || true)"
 
-          if [[ -n "${normalized}" ]] && echo "${normalized}" | jq -e 'type == "object"' >/dev/null 2>&1; then
+          if [[ -n "${optional_error_note}" ]]; then
+            parsed="$(jq -n \
+              --arg note "${optional_error_note}" \
+              --arg provider "${optional_provider_label}" \
+              '{
+                risk:"MEDIUM",
+                approve:false,
+                findings:[$note],
+                recommendation:("Retry later or reduce " + $provider + " specialist lane pressure"),
+                rationale:"Optional specialist lane skipped due to provider-side throttling/error"
+              }')"
+          elif [[ -n "${normalized}" ]] && echo "${normalized}" | jq -e 'type == "object"' >/dev/null 2>&1; then
             parsed="${normalized}"
           else
             parsed="$(jq -n --arg c "${content}" '{risk:"MEDIUM",approve:false,findings:["Could not parse JSON object from model output"],recommendation:"Manual review required",rationale:($c|tostring)}')"
@@ -495,6 +524,11 @@ jobs:
             contradiction_section="Approve side: ${approve_agents}
           Reject side: ${reject_agents}"
           fi
+          skipped_agents="$(jq -r '
+            [ .[] | select(.skipped == true) |
+              "- \(.name) [\(.provider)] (http=\(.http_code)): \((.findings | join(" | ")))"
+            ] | if length==0 then "- none" else join("\n") end
+          ' all-results.json)"
 
           cat > integrated-comment.md <<COMMENT_EOF
           ## Tutti Integrated Review
@@ -514,6 +548,9 @@ jobs:
 
           **Rule d: Contradictions (present both sides)**
           ${contradiction_section}
+
+          **Optional lanes skipped**
+          ${skipped_agents}
 
           **Consensus summary**
           - approvals: ${approve_count}/${total_count}


### PR DESCRIPTION
## Summary
- mark optional Gemini/xAI lane failures with explicit provider error findings (e.g. HTTP 429) instead of generic parse failures
- include a new "Optional lanes skipped" section in Tutti integrated comments for auditability
- extend Codex model fallback candidates in both `fugue-tutti-router` and `fugue-task-router` to reduce 404-only outcomes

## Why
Recent canary runs showed Gemini lanes were being skipped due to provider-side 429s, but output looked like generic parsing failures. This change makes behavior explicit and easier to operate safely.

## Validation
- workflow YAML parse checks passed
- logic remains non-blocking: optional specialist lanes are still excluded from consensus totals when unavailable
