### PR TITLE
fix: harden claude/codex orchestrator switching

### DIFF
--- a/.github/workflows/fugue-caller.yml
+++ b/.github/workflows/fugue-caller.yml
@@ -25,3 +25,5 @@ jobs:
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      XAI_API_KEY: ${{ secrets.XAI_API_KEY }}

--- a/.github/workflows/fugue-task-router.yml
+++ b/.github/workflows/fugue-task-router.yml
@@ -391,7 +391,7 @@ jobs:
           RESP_PROVIDER=""
           # Try OpenAI first if provider is codex
           if [[ "${PROVIDER}" == "codex" && -n "${OPENAI_API_KEY}" ]]; then
-            OPENAI_MODEL_CANDIDATES=("gpt-5.3-codex-spark" "gpt-5.3-codex" "gpt-5.2-codex")
+            OPENAI_MODEL_CANDIDATES=("gpt-5.3-codex-spark" "gpt-5.3-codex" "gpt-5.2-codex" "gpt-5.1-codex")
             for OPENAI_MODEL in "${OPENAI_MODEL_CANDIDATES[@]}"; do
               REQ="$(jq -n --arg model "${OPENAI_MODEL}" --arg s "${SYS_PROMPT}" --arg u "${USER_PROMPT}" '{model:$model,messages:[{role:"system",content:$s},{role:"user",content:$u}],temperature:0.2}')"
               raw="$(curl -sS -w "\n%{http_code}" https://api.openai.com/v1/chat/completions \
@@ -461,9 +461,11 @@ jobs:
           gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --body "${ANSWER}"
 
           if [[ "${TIER}" == "0" || "${TIER}" == "1" ]]; then
+            gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --remove-label "needs-review" --remove-label "needs-human" || true
             gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "completed"
             gh issue close "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}"
           else
+            gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --remove-label "completed" --remove-label "needs-human" || true
             gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "needs-review"
           fi
 
@@ -473,6 +475,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           ISSUE_NUMBER="${{ steps.ctx.outputs.issue_number }}"
+          gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --remove-label "completed" --remove-label "needs-review" || true
           gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --body "自動実行不可。人間の承認が必要です。"
           gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "needs-human"
 

--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -571,7 +571,9 @@ jobs:
           fi
 
   resolve-orchestrator:
-    if: ${{ github.actor != 'github-actions[bot]' && needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.trusted == 'true' }}
+    # Allow bot-triggered workflow_dispatch (from task-router handoff) to resolve
+    # the matrix; otherwise run-agents/integrate/finalize are skipped.
+    if: ${{ needs.prepare.outputs.should_run == 'true' && needs.prepare.outputs.trusted == 'true' }}
     needs: [prepare]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/fugue-watchdog.yml
+++ b/.github/workflows/fugue-watchdog.yml
@@ -63,11 +63,13 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
         run: |
           set +e
           OPENAI_OK="false"
           ZAI_OK="false"
+          GEMINI_OK="skipped"
           XAI_OK="skipped"
 
           curl -fsS --connect-timeout 5 --max-time 15 --retry 2 --retry-delay 2 --retry-all-errors \
@@ -80,6 +82,13 @@ jobs:
             -H "Authorization: Bearer ${ZAI_API_KEY}" >/dev/null 2>&1
           [[ $? -eq 0 ]] && ZAI_OK="true"
 
+          if [[ -n "${GEMINI_API_KEY:-}" ]]; then
+            GEMINI_OK="false"
+            curl -fsS --connect-timeout 5 --max-time 15 --retry 2 --retry-delay 2 --retry-all-errors \
+              "https://generativelanguage.googleapis.com/v1beta/models?key=${GEMINI_API_KEY}" >/dev/null 2>&1
+            [[ $? -eq 0 ]] && GEMINI_OK="true"
+          fi
+
           if [[ -n "${XAI_API_KEY:-}" ]]; then
             XAI_OK="false"
             curl -fsS --connect-timeout 5 --max-time 15 --retry 2 --retry-delay 2 --retry-all-errors \
@@ -91,6 +100,7 @@ jobs:
           {
             echo "openai_ok=${OPENAI_OK}"
             echo "zai_ok=${ZAI_OK}"
+            echo "gemini_ok=${GEMINI_OK}"
             echo "xai_ok=${XAI_OK}"
           } >> "${GITHUB_OUTPUT}"
 
@@ -165,6 +175,7 @@ jobs:
 
           openai_ok="${{ steps.connectivity.outputs.openai_ok }}"
           zai_ok="${{ steps.connectivity.outputs.zai_ok }}"
+          gemini_ok="${{ steps.connectivity.outputs.gemini_ok }}"
           xai_ok="${{ steps.connectivity.outputs.xai_ok }}"
           router_stale="${{ steps.last_success.outputs.stale }}"
           mainframe_stale="${{ steps.mainframe_success.outputs.stale }}"
@@ -180,7 +191,7 @@ jobs:
           reasons=()
 
           # Connectivity issues can be transient. Only alert frequently if there is pending work.
-          if [[ "${openai_ok}" != "true" || "${zai_ok}" != "true" || ( "${xai_ok}" != "true" && "${xai_ok}" != "skipped" ) ]]; then
+          if [[ "${openai_ok}" != "true" || "${zai_ok}" != "true" || ( "${gemini_ok}" != "true" && "${gemini_ok}" != "skipped" ) || ( "${xai_ok}" != "true" && "${xai_ok}" != "skipped" ) ]]; then
             if [[ "${pending_count}" != "0" || "${mainframe_pending_count}" != "0" ]]; then
               # With pending work, alert at most every 3 hours.
               if (( 10#${hour_utc} % 3 == 0 )); then
@@ -215,6 +226,7 @@ jobs:
           reasons: ${reasons[*]:-none}
           openai_ok: ${openai_ok}
           zai_ok: ${zai_ok}
+          gemini_ok: ${gemini_ok}
           xai_ok: ${xai_ok}
           pending_count: ${pending_count}
           mainframe_pending_count: ${mainframe_pending_count}


### PR DESCRIPTION
## Summary\n- allow bot-triggered handoff runs to resolve orchestrator matrix in tutti router\n- pass optional GEMINI/XAI secrets through fugue-caller to task-router\n- align task-router codex model fallback to include gpt-5.1-codex\n- add gemini connectivity monitoring to watchdog\n- normalize terminal labels in task-router to avoid mixed states\n\n## Why\nPrevents handoff stalls and improves cross-provider reliability when switching between claude and codex orchestrator profiles.\n\n## Validation\n- YAML parse check for edited workflows (Ruby YAML.load_file)\n- reviewed diff for the four workflow files only\n