### PR TITLE
fix: ensure claude orchestrator parity and local router resolution

### DIFF
--- a/.github/workflows/fugue-caller.yml
+++ b/.github/workflows/fugue-caller.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   route:
     if: ${{ github.event_name != 'issue_comment' || github.actor != 'github-actions[bot]' }}
-    uses: cursorvers/fugue-orchestrator/.github/workflows/fugue-task-router.yml@v1
+    uses: ./.github/workflows/fugue-task-router.yml
     with:
       issue_number: ${{ github.event.issue.number || github.event.inputs.issue_number }}
     secrets:

--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -655,12 +655,15 @@ jobs:
               ]
             }')"
           else
+            # Keep the same default quorum when switching to claude profile.
             matrix="$(jq -cn '{
               include: [
                 {name:"codex-security-analyst",provider:"codex",api_url:"https://api.openai.com/v1/chat/completions",model:"gpt-5.3-codex",agent_role:"security-analyst"},
+                {name:"codex-code-reviewer",provider:"codex",api_url:"https://api.openai.com/v1/chat/completions",model:"gpt-5.3-codex",agent_role:"code-reviewer"},
+                {name:"codex-general-reviewer",provider:"codex",api_url:"https://api.openai.com/v1/chat/completions",model:"gpt-5.3-codex-spark",agent_role:"general-reviewer"},
                 {name:"glm-code-reviewer",provider:"glm",api_url:"https://api.z.ai/api/coding/paas/v4/chat/completions",model:"glm-5",agent_role:"code-reviewer"},
                 {name:"glm-general-reviewer",provider:"glm",api_url:"https://api.z.ai/api/coding/paas/v4/chat/completions",model:"glm-5",agent_role:"general-reviewer"},
-                {name:"gemini-general-reviewer",provider:"gemini",api_url:"https://generativelanguage.googleapis.com/v1beta/models",model:"gemini-2.0-flash",agent_role:"general-reviewer"}
+                {name:"glm-math-reasoning",provider:"glm",api_url:"https://api.z.ai/api/coding/paas/v4/chat/completions",model:"glm-5",agent_role:"math-reasoning"}
               ]
             }')"
           fi


### PR DESCRIPTION
## Summary\n- make claude orchestrator default quorum match codex (6 lanes: codex3 + glm3)\n- switch fugue-caller reusable workflow reference from pinned @v1 to local workflow path so latest router fixes are always used\n\n## Why\nThis prevents behavior drift when switching orchestrator profile and ensures merged workflow fixes are actually executed.\n\n## Validation\n- YAML parse check for edited workflows\n