### PR TITLE
fix(router): bootstrap implement labels before add-label

### DIFF
--- a/.github/workflows/fugue-task-router.yml
+++ b/.github/workflows/fugue-task-router.yml
@@ -249,6 +249,14 @@ jobs:
           # Prefer provider-agnostic implement intent label while also adding
           # a provider-specific compatibility label for existing tooling.
           if [[ "${wants_implement}" == "true" ]]; then
+            gh label create "implement" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --description "Implementation intent (provider-agnostic)" \
+              --color "1D76DB" >/dev/null 2>&1 || true
+            gh label create "${compat_label}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --description "Implementation intent compatibility label" \
+              --color "0052CC" >/dev/null 2>&1 || true
             gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "implement" >/dev/null
             gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" --add-label "${compat_label}" >/dev/null
           fi

--- a/scripts/gha24
+++ b/scripts/gha24
@@ -99,6 +99,15 @@ compat_label="$( [[ "${provider}" == "claude" ]] && echo "claude-implement" || e
 
 LABELS="fugue-task"
 if [[ "${IMPLEMENT}" == "true" ]]; then
+  gh label create "implement" \
+    --repo "${ORCHESTRATOR_REPO}" \
+    --description "Implementation intent (provider-agnostic)" \
+    --color "1D76DB" >/dev/null 2>&1 || true
+  gh label create "${compat_label}" \
+    --repo "${ORCHESTRATOR_REPO}" \
+    --description "Implementation intent compatibility label" \
+    --color "0052CC" >/dev/null 2>&1 || true
+
   # `implement` is the provider-agnostic intent label.
   # Add a provider-specific compatibility label for existing workflows/tooling.
   LABELS="${LABELS},implement,${compat_label}"


### PR DESCRIPTION
## Summary
- create `implement` and provider compatibility labels (`claude-implement` / `codex-implement`) before adding them in task-router handoff
- make `scripts/gha24 --implement` bootstrap the same labels before issue creation

## Why
Smoke test issue #93 failed in `fugue-task-router` with:
- `'implement' not found`

This blocked the mainframe handoff when label definitions were missing.

## Validation
- YAML parse: `.github/workflows/fugue-task-router.yml`
- shell syntax: `scripts/gha24`
