### PR TITLE
fix(tutti): use input issue number for reusable context

### DIFF
--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -73,8 +73,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_call" ]]; then
-            ISSUE_NUMBER="${{ inputs.issue_number }}"
+          ISSUE_NUMBER="${{ inputs.issue_number }}"
+          if [[ -n "${ISSUE_NUMBER}" ]]; then
             issue_json="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}")"
           else
             issue_json="$(jq -c '.issue' "${GITHUB_EVENT_PATH}")"


### PR DESCRIPTION
## Summary
- in `fugue-tutti-router` prepare step, resolve issue context from `inputs.issue_number` when present instead of relying on `GITHUB_EVENT_NAME == workflow_call`

## Why
When `fugue-task-router` dispatches `fugue-tutti-caller` via `workflow_dispatch`, the nested reusable workflow may not satisfy the strict event-name check and can fall back to event payload issue parsing, resulting in `should_run=false`.

## Validation
- YAML parse check for `.github/workflows/fugue-tutti-router.yml`
