### PR TITLE
chore(sim): enforce codex-spark-only simulation rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,10 @@ Use deterministic simulation before changing orchestration logic:
 scripts/sim-orchestrator-switch.sh
 ```
 
+Simulation common rule:
+- `FUGUE_SIM_CODEX_SPARK_ONLY=true` (default) forces simulation to run `codex-main` and codex multi-agent lanes on `gpt-5.3-codex-spark` for faster turnaround.
+- Set `FUGUE_SIM_CODEX_SPARK_ONLY=false` only when main-model parity testing against `gpt-5-codex` is explicitly required.
+
 Use live rehearsal only when needed and clean up synthetic issues after verification.
 
 ## 9. Shared Skills Baseline (Codex/Claude)

--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ export ANTHROPIC_API_KEY="your-anthropic-key" # optional (Claude assist lane)
 
 # 3.7 Orchestrator切替シミュレーション（ローカル・非破壊）
 # ./scripts/sim-orchestrator-switch.sh | column -t -s $'\t'
+# NOTE: シミュレーションは `FUGUE_SIM_CODEX_SPARK_ONLY=true`（既定）で codex-main/codex multi-agent を `gpt-5.3-codex-spark` に統一し高速化します。
+# NOTE: `gpt-5-codex` との厳密差分検証が必要な場合のみ `FUGUE_SIM_CODEX_SPARK_ONLY=false` を指定してください。
 # NOTE: lane構成のSSOTは `scripts/lib/build-agent-matrix.sh` です。
 # NOTE: ドリフト検知は `./scripts/check-agent-matrix-parity.sh` で実行できます。
 

--- a/docs/requirements-codex-main-claude-assist.md
+++ b/docs/requirements-codex-main-claude-assist.md
@@ -150,6 +150,8 @@ Required/optional repo variables:
 - `FUGUE_GEMINI_FALLBACK_MODEL` (optional, default `gemini-3-flash`; Gemini specialist fallback model)
 - `FUGUE_XAI_MODEL` (optional, default `grok-4`; xAI specialist primary model)
 - Runtime model normalization is enforced by `scripts/lib/model-policy.sh` (stale values are auto-corrected to supported latest-track families).
+- `FUGUE_SIM_CODEX_SPARK_ONLY` (`true|false`, default `true`; deterministic simulation common rule to pin both codex-main and codex multi-agent lanes to codex-spark for faster verification)
+- `FUGUE_SIM_CODEX_SPARK_MODEL` (optional, default `gpt-5.3-codex-spark`; spark-family model used when simulation spark-only rule is active)
 - `FUGUE_IMPLEMENT_REFINEMENT_CYCLES` (`1-5`, default `3`; enforce pre-implementation refinement loops)
 - `FUGUE_IMPLEMENT_DIALOGUE_ROUNDS` (`1-5`, default `2`; implementation collaboration rounds)
 - `FUGUE_IMPLEMENT_DIALOGUE_ROUNDS_CLAUDE` (`1-5`, default `1`; implementation collaboration rounds when main=claude)

--- a/scripts/sim-orchestrator-switch.sh
+++ b/scripts/sim-orchestrator-switch.sh
@@ -46,6 +46,14 @@ fi
 codex_main_model_default="$(echo "${FUGUE_CODEX_MAIN_MODEL:-gpt-5-codex}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
 codex_multi_agent_model_default="$(echo "${FUGUE_CODEX_MULTI_AGENT_MODEL:-gpt-5.3-codex-spark}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
 claude_opus_model_default="$(echo "${FUGUE_CLAUDE_OPUS_MODEL:-claude-sonnet-4-6}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+sim_codex_spark_only="$(echo "${FUGUE_SIM_CODEX_SPARK_ONLY:-true}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+if [[ "${sim_codex_spark_only}" != "false" ]]; then
+  sim_codex_spark_only="true"
+fi
+sim_codex_spark_model="$(echo "${FUGUE_SIM_CODEX_SPARK_MODEL:-gpt-5.3-codex-spark}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+if ! [[ "${sim_codex_spark_model}" =~ ^gpt-5(\.[0-9]+)?-codex-spark$ ]]; then
+  sim_codex_spark_model="gpt-5.3-codex-spark"
+fi
 model_policy_script="$(cd "$(dirname "${BASH_SOURCE[0]}")/lib" && pwd)/model-policy.sh"
 if [[ -x "${model_policy_script}" ]]; then
   eval "$("${model_policy_script}" \
@@ -60,6 +68,12 @@ if [[ -x "${model_policy_script}" ]]; then
   codex_main_model_default="${codex_main_model}"
   codex_multi_agent_model_default="${codex_multi_agent_model}"
   claude_opus_model_default="${claude_model}"
+fi
+# Simulation common rule: keep simulation iterations fast by using codex-spark only
+# unless explicitly disabled.
+if [[ "${sim_codex_spark_only}" == "true" ]]; then
+  codex_main_model_default="${sim_codex_spark_model}"
+  codex_multi_agent_model_default="${sim_codex_spark_model}"
 fi
 claude_sonnet4_model_default="${claude_opus_model_default}"
 claude_sonnet6_model_default="${claude_opus_model_default}"


### PR DESCRIPTION
## Summary
- add a shared simulation rule: `FUGUE_SIM_CODEX_SPARK_ONLY=true` by default
- when enabled, `scripts/sim-orchestrator-switch.sh` pins both codex main/multi-agent models to codex-spark
- add optional override model: `FUGUE_SIM_CODEX_SPARK_MODEL` (spark family only)
- document the rule in AGENTS/README/requirements

## Why
Simulation validation should stay fast; strict main-model parity checks can opt out with `FUGUE_SIM_CODEX_SPARK_ONLY=false`.

## Verification
- `bash -n scripts/sim-orchestrator-switch.sh`
- `FUGUE_SIM_CODEX_SPARK_ONLY=true bash -x scripts/sim-orchestrator-switch.sh` shows:
  - `--codex-main-model gpt-5.3-codex-spark`
  - `--codex-multi-agent-model gpt-5.3-codex-spark`
- `FUGUE_SIM_CODEX_SPARK_ONLY=false ...` restores:
  - `--codex-main-model gpt-5-codex`
