### PR TITLE
fix(canary): stabilize tutti dispatch and timeout reporting

### DIFF
--- a/.github/workflows/fugue-orchestrator-canary.yml
+++ b/.github/workflows/fugue-orchestrator-canary.yml
@@ -210,6 +210,22 @@ jobs:
             url="$("${cmd[@]}")"
             local issue_num="${url##*/}"
             gh issue edit "${issue_num}" --repo "${repo}" --add-label "tutti" >/dev/null
+            local has_tutti="false"
+            local label_attempt=1
+            local issue_json
+            while [[ "${label_attempt}" -le 10 ]]; do
+              issue_json="$(gh_api_retry "repos/${repo}/issues/${issue_num}" 4 || echo '{}')"
+              has_tutti="$(echo "${issue_json}" | jq -r '[.labels[]? | .name] | index("tutti") != null' 2>/dev/null || echo "false")"
+              if [[ "${has_tutti}" == "true" ]]; then
+                break
+              fi
+              sleep 2
+              label_attempt="$((label_attempt + 1))"
+            done
+            if [[ "${has_tutti}" != "true" ]]; then
+              echo "Failed to confirm 'tutti' label before dispatch for issue #${issue_num}." >&2
+              return 1
+            fi
             gh workflow run fugue-tutti-caller.yml \
               --repo "${repo}" \
               -f issue_number="${issue_num}" >/dev/null
@@ -344,7 +360,7 @@ jobs:
               failures="$((failures + 1))"
             fi
           else
-            conclude_issue "${regular_issue}" "${expected_regular_main}" "${expected_regular_assist_effective}" "${expected_regular_profile}" "${expected_regular_runner}" "" "" "" "" "" "" "false" "regular" "timeout-no-integrated-review"
+            conclude_issue "${regular_issue}" "${expected_regular_main}" "${expected_regular_assist_effective}" "${expected_regular_profile}" "${expected_regular_runner}" "" "" "" "" "" "false" "regular" "timeout-no-integrated-review"
             failures="$((failures + 1))"
           fi
 
@@ -385,7 +401,7 @@ jobs:
               failures="$((failures + 1))"
             fi
           else
-            conclude_issue "${force_issue}" "${expected_force_main}" "${expected_force_assist_effective}" "${expected_force_profile}" "${expected_force_runner}" "" "" "" "" "" "" "false" "force" "timeout-no-integrated-review"
+            conclude_issue "${force_issue}" "${expected_force_main}" "${expected_force_assist_effective}" "${expected_force_profile}" "${expected_force_runner}" "" "" "" "" "" "false" "force" "timeout-no-integrated-review"
             failures="$((failures + 1))"
           fi
 

--- a/.github/workflows/fugue-task-router.yml
+++ b/.github/workflows/fugue-task-router.yml
@@ -345,9 +345,9 @@ jobs:
             body_assist_provider="$(echo "${body}" | sed -nE 's/^[[:space:]]*assist[[:space:]]+orchestrator[[:space:]_-]*provider[[:space:]]*:[[:space:]]*(claude|codex|none)[[:space:]]*$/\1/ip' | head -n1 | tr '[:upper:]' '[:lower:]')"
           fi
 
-          orchestrator_lib_dir=".fugue-orchestrator/scripts/lib"
+          orchestrator_lib_dir="scripts/lib"
           if [[ ! -d "${orchestrator_lib_dir}" ]]; then
-            orchestrator_lib_dir="scripts/lib"
+            orchestrator_lib_dir=".fugue-orchestrator/scripts/lib"
           fi
 
           nl_main_hint=""

--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -1608,9 +1608,9 @@ jobs:
             return 1
           }
 
-          orchestrator_lib_dir=".fugue-orchestrator/scripts/lib"
+          orchestrator_lib_dir="scripts/lib"
           if [[ ! -d "${orchestrator_lib_dir}" ]]; then
-            orchestrator_lib_dir="scripts/lib"
+            orchestrator_lib_dir=".fugue-orchestrator/scripts/lib"
           fi
 
           force_claude="$(echo "${FORCE_CLAUDE:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"


### PR DESCRIPTION
## Summary
- wait until the `tutti` label is observable before dispatching `fugue-tutti-caller` from canary issues
- fix canary timeout failure reporting argument order (`case`/`reason`)
- prefer in-repo `scripts/lib` before checked-out `.fugue-orchestrator/scripts/lib` to avoid library drift

## Why
Recent canary failures showed `timeout-no-integrated-review` caused by dispatch races and library-version drift across workflow jobs. This patch removes those failure modes while preserving fallback behavior for external repos.

## Validation
- inspected failed canary/mainframe runs and confirmed root causes
- verified workflow diffs and argument mapping locally
