### PR TITLE
fix(caller): isolate dispatch concurrency from label events

### DIFF
--- a/.github/workflows/fugue-tutti-caller.yml
+++ b/.github/workflows/fugue-tutti-caller.yml
@@ -32,7 +32,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: fugue-mainframe-${{ github.repository }}-${{ github.event.issue.number || github.event.inputs.issue_number || github.run_id }}
+  group: fugue-mainframe-${{ github.repository }}-${{ github.event.issue.number || github.event.inputs.issue_number || github.run_id }}-${{ github.event_name == 'issues' && format('label-{0}', github.event.label.name) || 'dispatch' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- split `fugue-tutti-caller` concurrency group by trigger channel (`issues` label lane vs `workflow_dispatch`)
- keep `cancel-in-progress: true`, but prevent label-event runs from canceling dispatch-driven canary/mainframe runs

## Why
Canary run `22487100963` showed the regular case timing out without integrated review because dispatch runs were canceled by subsequent `issues:labeled` runs for the same issue.

## Expected effect
- canary regular/force workflow_dispatch runs complete deterministically
- label churn still deduplicates within the same label lane
