### PR TITLE
fix(canary): continue verification when subscription runner is offline

### DIFF
--- a/.github/workflows/fugue-orchestrator-canary.yml
+++ b/.github/workflows/fugue-orchestrator-canary.yml
@@ -21,6 +21,7 @@ jobs:
       CLAUDE_MAIN_ASSIST_POLICY: ${{ vars.FUGUE_CLAUDE_MAIN_ASSIST_POLICY || 'codex' }}
       CI_EXECUTION_ENGINE: ${{ vars.FUGUE_CI_EXECUTION_ENGINE || 'subscription' }}
       SUBSCRIPTION_OFFLINE_POLICY: ${{ vars.FUGUE_SUBSCRIPTION_OFFLINE_POLICY || 'hold' }}
+      CANARY_OFFLINE_POLICY_OVERRIDE: ${{ vars.FUGUE_CANARY_OFFLINE_POLICY_OVERRIDE || 'continuity' }}
       EMERGENCY_CONTINUITY_MODE: ${{ vars.FUGUE_EMERGENCY_CONTINUITY_MODE || 'false' }}
       SUBSCRIPTION_RUNNER_LABEL: ${{ vars.FUGUE_SUBSCRIPTION_RUNNER_LABEL || 'fugue-subscription' }}
       EMERGENCY_ASSIST_POLICY: ${{ vars.FUGUE_EMERGENCY_ASSIST_POLICY || 'none' }}
@@ -105,6 +106,10 @@ jobs:
           if [[ "${subscription_offline_policy}" != "hold" && "${subscription_offline_policy}" != "continuity" ]]; then
             subscription_offline_policy="hold"
           fi
+          canary_offline_policy_override="$(normalize "${CANARY_OFFLINE_POLICY_OVERRIDE:-continuity}")"
+          if [[ "${canary_offline_policy_override}" != "inherit" && "${canary_offline_policy_override}" != "hold" && "${canary_offline_policy_override}" != "continuity" ]]; then
+            canary_offline_policy_override="continuity"
+          fi
           emergency_continuity_mode="$(normalize "${EMERGENCY_CONTINUITY_MODE:-false}")"
           if [[ "${emergency_continuity_mode}" != "true" ]]; then
             emergency_continuity_mode="false"
@@ -154,8 +159,13 @@ jobs:
               online_count="$((10#${online_count}))"
             fi
             if [[ "${subscription_offline_policy}" == "hold" ]] && (( online_count == 0 )); then
-              echo "Canary skipped: subscription strict hold policy active and no online self-hosted runner for label ${subscription_runner_label}."
-              exit 0
+              if [[ "${canary_offline_policy_override}" == "continuity" ]]; then
+                echo "Canary override: no online self-hosted runner for label ${subscription_runner_label}; forcing continuity mode for verification."
+                subscription_offline_policy="continuity"
+              elif [[ "${canary_offline_policy_override}" == "inherit" || "${canary_offline_policy_override}" == "hold" ]]; then
+                echo "Canary skipped: subscription strict hold policy active and no online self-hosted runner for label ${subscription_runner_label}."
+                exit 0
+              fi
             fi
           fi
           if (( online_count > 0 )); then

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ export ANTHROPIC_API_KEY="your-anthropic-key" # optional (Claude assist lane)
 # gh variable set FUGUE_SUBSCRIPTION_RUNNER_LABEL    --body fugue-subscription -R <owner/repo> # subscription strictで必須とするrunner label
 # gh variable set FUGUE_SUBSCRIPTION_CLI_TIMEOUT_SEC --body 180     -R <owner/repo> # per-lane timeout (seconds)
 # gh variable set FUGUE_SUBSCRIPTION_OFFLINE_POLICY  --body continuity -R <owner/repo> # hold|continuity (subscriptionでrunner不在時)
+# gh variable set FUGUE_CANARY_OFFLINE_POLICY_OVERRIDE --body continuity -R <owner/repo> # inherit|hold|continuity (canary専用: runner不在時の扱い)
 # gh variable set FUGUE_CANARY_LABEL_WAIT_ATTEMPTS   --body 10      -R <owner/repo> # canary issue label反映待機リトライ回数
 # gh variable set FUGUE_CANARY_LABEL_WAIT_SLEEP_SEC  --body 2       -R <owner/repo> # canary issue label反映待機秒
 # gh variable set FUGUE_CANARY_WAIT_FAST_ATTEMPTS    --body 12      -R <owner/repo> # canary統合コメント待機(高速フェーズ)試行回数
@@ -216,6 +217,7 @@ export ANTHROPIC_API_KEY="your-anthropic-key" # optional (Claude assist lane)
 # NOTE: `gha24` が事前フォールバックした場合は、Issueに監査コメントが自動投稿されます。
 # NOTE: `fugue-watchdog` は Claude state を自動復帰（degraded/exhausted -> ok）できますが、cooldown + 安定性条件を満たす場合のみ実行されます。
 # NOTE: `fugue-orchestrator-canary` が毎日、実Issueベースで regular/force の切替E2Eを自動検証します。
+# NOTE: canaryは既定で `FUGUE_CANARY_OFFLINE_POLICY_OVERRIDE=continuity` として、subscription runner 不在でも検証継続します（`hold` または `inherit` で従来どおりスキップ可能）。
 # NOTE: canaryは regular/force ケースの統合コメント待機を並列化し、待機上限は fast/slow 2段（上記 `FUGUE_CANARY_WAIT_*`）で調整できます。
 # NOTE: `fugue-orchestration-weekly-review` が週次で assist昇格率と high-risk時の昇格カバレッジを status issue に投稿します。
 

--- a/docs/requirements-codex-main-claude-assist.md
+++ b/docs/requirements-codex-main-claude-assist.md
@@ -117,6 +117,7 @@ Required/optional repo variables:
 - `FUGUE_SUBSCRIPTION_RUNNER_LABEL` (default `fugue-subscription`; required self-hosted label for `subscription-strict` lane execution)
 - `FUGUE_SUBSCRIPTION_CLI_TIMEOUT_SEC` (default `180`; timeout seconds for each `codex` / `claude` CLI lane in `subscription` mode)
 - `FUGUE_SUBSCRIPTION_OFFLINE_POLICY` (`hold|continuity`, default `continuity`; behavior when `subscription` is requested but no required-label self-hosted runner is online)
+- `FUGUE_CANARY_OFFLINE_POLICY_OVERRIDE` (`inherit|hold|continuity`, default `continuity`; canary-only override for runner-offline behavior under `subscription`)
 - `FUGUE_CANARY_LABEL_WAIT_ATTEMPTS` (default `10`; retry count while waiting for `tutti` label reflection before canary dispatch, clamped `1..60`)
 - `FUGUE_CANARY_LABEL_WAIT_SLEEP_SEC` (default `2`; sleep seconds between canary label reflection checks, clamped `1..30`)
 - `FUGUE_CANARY_WAIT_FAST_ATTEMPTS` (default `12`; fast-phase polling attempts for integrated review resolution in canary, clamped `1..60`)


### PR DESCRIPTION
## Summary
- add `FUGUE_CANARY_OFFLINE_POLICY_OVERRIDE` (default: `continuity`) to `fugue-orchestrator-canary`
- when `FUGUE_SUBSCRIPTION_OFFLINE_POLICY=hold` and no required self-hosted runner is online, canary now forces continuity verification by default instead of exiting early
- keep opt-out behavior (`hold` or `inherit`) for cases where skip is desired

## Why
`success` canary runs were possible without real regular/force verification under `hold + runner=0`.
This change ensures production canary remains a real verification signal even during self-hosted runner outages.

## Validation
- YAML parse check passed
- will verify via live canary run after merge
