### PR TITLE
fix(canary): wire offline-policy override into caller dispatch

### DIFF
--- a/.github/workflows/fugue-orchestrator-canary.yml
+++ b/.github/workflows/fugue-orchestrator-canary.yml
@@ -283,9 +283,17 @@ jobs:
               echo "Failed to confirm 'tutti' label before dispatch for issue #${issue_num}." >&2
               return 1
             fi
-            gh workflow run fugue-tutti-caller.yml \
+            local dispatch_offline_policy=""
+            if [[ "${canary_offline_policy_override}" == "hold" || "${canary_offline_policy_override}" == "continuity" ]]; then
+              dispatch_offline_policy="${canary_offline_policy_override}"
+            fi
+            local run_cmd=(gh workflow run fugue-tutti-caller.yml \
               --repo "${repo}" \
-              -f issue_number="${issue_num}" >/dev/null
+              -f issue_number="${issue_num}")
+            if [[ -n "${dispatch_offline_policy}" ]]; then
+              run_cmd+=(-f subscription_offline_policy_override="${dispatch_offline_policy}")
+            fi
+            "${run_cmd[@]}" >/dev/null
             echo "${issue_num}"
           }
 

--- a/.github/workflows/fugue-tutti-caller.yml
+++ b/.github/workflows/fugue-tutti-caller.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: "false"
+      subscription_offline_policy_override:
+        description: "Optional offline policy override for this dispatch (hold|continuity)"
+        required: false
+        type: string
+        default: ""
       vote_instruction_b64:
         description: "Optional /vote instruction payload (base64-encoded)"
         required: false
@@ -100,6 +105,7 @@ jobs:
           ISSUE_NUMBER_FROM_DISPATCH: ${{ github.event.inputs.issue_number || '' }}
           TRUST_SUBJECT_INPUT: ${{ github.event.inputs.trust_subject || '' }}
           ALLOW_PROCESSING_RERUN_INPUT: ${{ github.event.inputs.allow_processing_rerun || 'false' }}
+          SUBSCRIPTION_OFFLINE_POLICY_OVERRIDE_INPUT: ${{ github.event.inputs.subscription_offline_policy_override || '' }}
           VOTE_INSTRUCTION_B64_INPUT: ${{ github.event.inputs.vote_instruction_b64 || '' }}
           ISSUE_NUMBER_FROM_ISSUE: ${{ github.event.issue.number || '' }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -201,6 +207,10 @@ jobs:
           subscription_offline_policy="$(echo "${SUBSCRIPTION_OFFLINE_POLICY:-hold}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           if [[ "${subscription_offline_policy}" != "hold" && "${subscription_offline_policy}" != "continuity" ]]; then
             subscription_offline_policy="hold"
+          fi
+          subscription_offline_policy_override="$(echo "${SUBSCRIPTION_OFFLINE_POLICY_OVERRIDE_INPUT:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+          if [[ "${subscription_offline_policy_override}" == "hold" || "${subscription_offline_policy_override}" == "continuity" ]]; then
+            subscription_offline_policy="${subscription_offline_policy_override}"
           fi
           emergency_continuity_mode="$(echo "${EMERGENCY_CONTINUITY_MODE:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           if [[ "${emergency_continuity_mode}" != "true" ]]; then


### PR DESCRIPTION
## Summary
- add `subscription_offline_policy_override` input to `fugue-tutti-caller` workflow_dispatch
- apply this override in caller context resolution (`hold|continuity`)
- pass canary's offline override setting to the caller dispatch run

## Why
After enabling canary-side offline continuity, caller still used repo `hold` policy and paused without integrated review.
This change makes canary override effective end-to-end.

## Validation
- YAML parse check for both workflows passed
- will verify by running live canary after merge and confirming regular/force integrated comments
