### PR TITLE
fix(router): honor caller offline-policy override in router

### DIFF
--- a/.github/workflows/fugue-tutti-caller.yml
+++ b/.github/workflows/fugue-tutti-caller.yml
@@ -91,6 +91,7 @@ jobs:
       force_claude: ${{ steps.ctx.outputs.force_claude }}
       self_hosted_online_count: ${{ steps.ctx.outputs.self_hosted_online_count }}
       subscription_runner_label: ${{ steps.ctx.outputs.subscription_runner_label }}
+      subscription_offline_policy: ${{ steps.ctx.outputs.subscription_offline_policy }}
       trust_subject: ${{ steps.ctx.outputs.trust_subject }}
       allow_processing_rerun: ${{ steps.ctx.outputs.allow_processing_rerun }}
       vote_instruction: ${{ steps.ctx.outputs.vote_instruction }}
@@ -909,6 +910,7 @@ jobs:
             echo "has_implement_confirmed=${has_implement_confirmed}"
             echo "self_hosted_online_count=${self_hosted_online_count}"
             echo "subscription_runner_label=${subscription_runner_label}"
+            echo "subscription_offline_policy=${subscription_offline_policy}"
             echo "trust_subject=${trust_subject}"
             echo "target_repo=${target_repo}"
             echo "orchestrator_provider=${requested_main_provider}"
@@ -1091,6 +1093,7 @@ jobs:
       force_claude: "${{ needs.ctx.outputs.force_claude }}"
       multi_agent_mode_override: "${{ needs.ctx.outputs.multi_agent_mode_override }}"
       multi_agent_mode_lock: "${{ needs.ctx.outputs.multi_agent_mode_lock }}"
+      subscription_offline_policy_override: "${{ needs.ctx.outputs.subscription_offline_policy }}"
       trust_subject: "${{ needs.ctx.outputs.trust_subject }}"
       allow_processing_rerun: "${{ needs.ctx.outputs.allow_processing_rerun }}"
       extra_issue_instruction: "${{ needs.ctx.outputs.vote_instruction }}"

--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -67,6 +67,11 @@ on:
         required: false
         type: string
         default: "false"
+      subscription_offline_policy_override:
+        description: "Optional offline policy override for this run (hold|continuity)"
+        required: false
+        type: string
+        default: ""
       extra_issue_instruction:
         description: "Optional additional instruction text (for example from /vote comments)"
         required: false
@@ -170,6 +175,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TRUST_SUBJECT_INPUT: ${{ inputs.trust_subject || '' }}
           ALLOW_PROCESSING_RERUN_INPUT: ${{ inputs.allow_processing_rerun || 'false' }}
+          SUBSCRIPTION_OFFLINE_POLICY_OVERRIDE_INPUT: ${{ inputs.subscription_offline_policy_override || '' }}
           EXTRA_ISSUE_INSTRUCTION_INPUT: ${{ inputs.extra_issue_instruction || '' }}
           CI_EXECUTION_ENGINE: ${{ vars.FUGUE_CI_EXECUTION_ENGINE || 'subscription' }}
           SUBSCRIPTION_OFFLINE_POLICY: ${{ vars.FUGUE_SUBSCRIPTION_OFFLINE_POLICY || 'continuity' }}
@@ -233,6 +239,10 @@ jobs:
           subscription_offline_policy="$(echo "${SUBSCRIPTION_OFFLINE_POLICY:-continuity}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           if [[ "${subscription_offline_policy}" != "hold" && "${subscription_offline_policy}" != "continuity" ]]; then
             subscription_offline_policy="continuity"
+          fi
+          subscription_offline_policy_override="$(echo "${SUBSCRIPTION_OFFLINE_POLICY_OVERRIDE_INPUT:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+          if [[ "${subscription_offline_policy_override}" == "hold" || "${subscription_offline_policy_override}" == "continuity" ]]; then
+            subscription_offline_policy="${subscription_offline_policy_override}"
           fi
           emergency_continuity_mode="$(echo "${EMERGENCY_CONTINUITY_MODE:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           if [[ "${emergency_continuity_mode}" != "true" ]]; then
@@ -1554,6 +1564,7 @@ jobs:
           FORCE_CLAUDE: ${{ inputs.force_claude }}
           MULTI_AGENT_MODE_OVERRIDE: ${{ inputs.multi_agent_mode_override }}
           MULTI_AGENT_MODE_LOCK: ${{ inputs.multi_agent_mode_lock }}
+          SUBSCRIPTION_OFFLINE_POLICY_OVERRIDE_INPUT: ${{ inputs.subscription_offline_policy_override || '' }}
           DEFAULT_MAIN_ORCHESTRATOR_PROVIDER: ${{ vars.FUGUE_MAIN_ORCHESTRATOR_PROVIDER || vars.FUGUE_ORCHESTRATOR_PROVIDER || 'codex' }}
           DEFAULT_ASSIST_ORCHESTRATOR_PROVIDER: ${{ vars.FUGUE_ASSIST_ORCHESTRATOR_PROVIDER || 'claude' }}
           CODEX_MAIN_MODEL: ${{ vars.FUGUE_CODEX_MAIN_MODEL || 'gpt-5-codex' }}
@@ -1658,6 +1669,10 @@ jobs:
           subscription_offline_policy="$(echo "${SUBSCRIPTION_OFFLINE_POLICY:-continuity}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           if [[ "${subscription_offline_policy}" != "hold" && "${subscription_offline_policy}" != "continuity" ]]; then
             subscription_offline_policy="continuity"
+          fi
+          subscription_offline_policy_override="$(echo "${SUBSCRIPTION_OFFLINE_POLICY_OVERRIDE_INPUT:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+          if [[ "${subscription_offline_policy_override}" == "hold" || "${subscription_offline_policy_override}" == "continuity" ]]; then
+            subscription_offline_policy="${subscription_offline_policy_override}"
           fi
           api_strict_mode="$(echo "${API_STRICT_MODE:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           if [[ "${api_strict_mode}" != "true" ]]; then


### PR DESCRIPTION
## Summary
- pass caller-resolved subscription offline policy into tutti-router
- add subscription_offline_policy_override input to fugue-tutti-router
- apply override in router prepare and resolve-orchestrator policy resolution paths

## Why
Canary dispatch already sends subscription_offline_policy_override=continuity, but router re-read repo vars (hold) and re-paused under offline self-hosted conditions, causing timeout-no-integrated-review.

## Validation
- YAML parse check for both modified workflows
- verified override appears in caller -> router call path and router policy normalization
