### PR TITLE
feat(ci): staged orchestration gate and canary-lite mode

### DIFF
--- a/.github/workflows/fugue-orchestration-gate.yml
+++ b/.github/workflows/fugue-orchestration-gate.yml
@@ -1,0 +1,152 @@
+name: fugue-orchestration-gate
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/fugue-orchestration-gate.yml'
+      - '.github/workflows/fugue-orchestrator-canary.yml'
+      - '.github/workflows/fugue-tutti-caller.yml'
+      - '.github/workflows/fugue-tutti-router.yml'
+      - '.github/workflows/fugue-task-router.yml'
+      - 'scripts/lib/build-agent-matrix.sh'
+      - 'scripts/lib/execution-profile-policy.sh'
+      - 'scripts/lib/orchestrator-policy.sh'
+      - 'scripts/check-agent-matrix-parity.sh'
+      - 'scripts/check-linked-systems-integrity.sh'
+      - 'scripts/sim-orchestrator-switch.sh'
+      - 'scripts/local/run-local-orchestration.sh'
+      - 'scripts/local/run-linked-systems.sh'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/fugue-orchestration-gate.yml'
+      - '.github/workflows/fugue-orchestrator-canary.yml'
+      - '.github/workflows/fugue-tutti-caller.yml'
+      - '.github/workflows/fugue-tutti-router.yml'
+      - '.github/workflows/fugue-task-router.yml'
+      - 'scripts/lib/build-agent-matrix.sh'
+      - 'scripts/lib/execution-profile-policy.sh'
+      - 'scripts/lib/orchestrator-policy.sh'
+      - 'scripts/check-agent-matrix-parity.sh'
+      - 'scripts/check-linked-systems-integrity.sh'
+      - 'scripts/sim-orchestrator-switch.sh'
+      - 'scripts/local/run-local-orchestration.sh'
+      - 'scripts/local/run-linked-systems.sh'
+  workflow_dispatch:
+    inputs:
+      run_canary_lite:
+        description: "Also run blocking canary-lite (dispatches canary workflow in lite mode)"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  fast-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Shell syntax checks
+        run: |
+          set -euo pipefail
+          bash -n scripts/lib/build-agent-matrix.sh
+          bash -n scripts/lib/execution-profile-policy.sh
+          bash -n scripts/lib/orchestrator-policy.sh
+          bash -n scripts/local/run-local-orchestration.sh
+          bash -n scripts/local/run-linked-systems.sh
+          bash -n scripts/sim-orchestrator-switch.sh
+          bash -n scripts/check-agent-matrix-parity.sh
+          bash -n scripts/check-linked-systems-integrity.sh
+
+      - name: Workflow YAML parse checks
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import yaml
+          files = [
+              ".github/workflows/fugue-orchestrator-canary.yml",
+              ".github/workflows/fugue-orchestration-gate.yml",
+              ".github/workflows/fugue-tutti-caller.yml",
+              ".github/workflows/fugue-tutti-router.yml",
+              ".github/workflows/fugue-task-router.yml",
+          ]
+          for p in files:
+              with open(p, "r", encoding="utf-8") as f:
+                  yaml.safe_load(f)
+          print("workflow-yaml-parse-ok")
+          PY
+
+      - name: Matrix parity checks
+        run: |
+          set -euo pipefail
+          chmod +x scripts/lib/build-agent-matrix.sh scripts/check-agent-matrix-parity.sh scripts/check-linked-systems-integrity.sh
+          ./scripts/check-agent-matrix-parity.sh
+          ./scripts/check-linked-systems-integrity.sh
+
+      - name: Deterministic switch simulation
+        run: |
+          set -euo pipefail
+          sim_out="$(mktemp)"
+          ./scripts/sim-orchestrator-switch.sh > "${sim_out}"
+          rows="$(( $(wc -l < "${sim_out}") - 1 ))"
+          if (( rows < 10 )); then
+            echo "Expected at least 10 scenario rows from sim-orchestrator-switch, got ${rows}" >&2
+            cat "${sim_out}" >&2
+            exit 1
+          fi
+          echo "sim-orchestrator-switch rows=${rows}"
+
+  canary-lite:
+    needs: [fast-gate]
+    if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_canary_lite) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Trigger canary lite
+        run: |
+          set -euo pipefail
+          repo="${GITHUB_REPOSITORY}"
+          start_iso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+          gh workflow run fugue-orchestrator-canary.yml \
+            --repo "${repo}" \
+            --ref main \
+            -f canary_mode=lite
+
+          target_sha=""
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            target_sha="${GITHUB_SHA}"
+          fi
+
+          run_id=""
+          for _ in $(seq 1 30); do
+            runs_json="$(gh run list --repo "${repo}" --workflow fugue-orchestrator-canary.yml --event workflow_dispatch --limit 20 --json databaseId,createdAt,headSha)"
+            if [[ -n "${target_sha}" ]]; then
+              run_id="$(echo "${runs_json}" | jq -r --arg start "${start_iso}" --arg sha "${target_sha}" '[.[] | select(.createdAt >= $start and .headSha == $sha)][0].databaseId // empty')"
+            fi
+            if [[ -z "${run_id}" ]]; then
+              run_id="$(echo "${runs_json}" | jq -r --arg start "${start_iso}" '[.[] | select(.createdAt >= $start)][0].databaseId // empty')"
+            fi
+            if [[ -n "${run_id}" ]]; then
+              break
+            fi
+            sleep 3
+          done
+
+          if [[ -z "${run_id}" ]]; then
+            echo "Failed to locate dispatched canary-lite run id." >&2
+            exit 1
+          fi
+
+          echo "Watching canary-lite run ${run_id}"
+          gh run watch "${run_id}" --repo "${repo}" --exit-status
+          gh run view "${run_id}" --repo "${repo}" --json status,conclusion,url,createdAt,updatedAt

--- a/.github/workflows/fugue-orchestrator-canary.yml
+++ b/.github/workflows/fugue-orchestrator-canary.yml
@@ -4,6 +4,15 @@ on:
   schedule:
     - cron: "43 2 * * *"
   workflow_dispatch:
+    inputs:
+      canary_mode:
+        description: "Run mode: full (regular+force) or lite (regular only)"
+        required: false
+        type: choice
+        options:
+          - full
+          - lite
+        default: full
 
 permissions:
   issues: write
@@ -38,10 +47,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run canary (regular + forced claude)
+      - name: Run canary (mode-aware)
         env:
           GH_TOKEN: ${{ github.token }}
           OPS_TOKEN: ${{ secrets.FUGUE_OPS_PAT || secrets.TARGET_REPO_PAT || '' }}
+          CANARY_MODE_INPUT: ${{ github.event.inputs.canary_mode || '' }}
         run: |
           set -euo pipefail
           gh_api_retry() {
@@ -78,6 +88,8 @@ jobs:
           failures=0
           online_count=0
           self_hosted_online="false"
+          canary_mode="full"
+          run_force_case="true"
 
           normalize() {
             echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g'
@@ -95,6 +107,13 @@ jobs:
           }
 
           claude_state="$(normalize "${CLAUDE_RATE_LIMIT_STATE:-ok}")"
+          canary_mode="$(normalize "${CANARY_MODE_INPUT:-full}")"
+          if [[ "${canary_mode}" != "full" && "${canary_mode}" != "lite" ]]; then
+            canary_mode="full"
+          fi
+          if [[ "${canary_mode}" == "lite" ]]; then
+            run_force_case="false"
+          fi
           role_policy="$(normalize "${CLAUDE_ROLE_POLICY:-flex}")"
           degraded_assist_policy="$(normalize "${CLAUDE_DEGRADED_ASSIST_POLICY:-claude}")"
           main_assist_policy="$(normalize "${CLAUDE_MAIN_ASSIST_POLICY:-codex}")"
@@ -396,8 +415,15 @@ jobs:
             strict_expected="true"
           fi
 
-          regular_issue="$(create_issue "[canary] regular claude request ${ts}" "")"
-          force_issue="$(create_issue "[canary] forced claude request ${ts}" "orchestrator-force:claude")"
+          issue_prefix="[canary]"
+          if [[ "${canary_mode}" == "lite" ]]; then
+            issue_prefix="[canary-lite]"
+          fi
+          regular_issue="$(create_issue "${issue_prefix} regular claude request ${ts}" "")"
+          force_issue=""
+          if [[ "${run_force_case}" == "true" ]]; then
+            force_issue="$(create_issue "${issue_prefix} forced claude request ${ts}" "orchestrator-force:claude")"
+          fi
 
           regular_pair_file="$(mktemp)"
           force_pair_file="$(mktemp)"
@@ -408,8 +434,11 @@ jobs:
 
           wait_for_resolved_orchestrators "${regular_issue}" >"${regular_pair_file}" &
           regular_wait_pid="$!"
-          wait_for_resolved_orchestrators "${force_issue}" >"${force_pair_file}" &
-          force_wait_pid="$!"
+          force_wait_pid=""
+          if [[ "${run_force_case}" == "true" ]]; then
+            wait_for_resolved_orchestrators "${force_issue}" >"${force_pair_file}" &
+            force_wait_pid="$!"
+          fi
 
           regular_pair=""
           regular_wait_ok="false"
@@ -420,7 +449,9 @@ jobs:
 
           force_pair=""
           force_wait_ok="false"
-          if wait "${force_wait_pid}"; then
+          if [[ "${run_force_case}" != "true" ]]; then
+            force_wait_ok="false"
+          elif wait "${force_wait_pid}"; then
             force_pair="$(tail -n1 "${force_pair_file}" | tr -d '\r')"
             force_wait_ok="true"
           fi
@@ -465,7 +496,9 @@ jobs:
             failures="$((failures + 1))"
           fi
 
-          if [[ "${force_wait_ok}" == "true" && -n "${force_pair}" ]]; then
+          if [[ "${run_force_case}" != "true" ]]; then
+            echo "Canary lite mode: skipped forced-claude case."
+          elif [[ "${force_wait_ok}" == "true" && -n "${force_pair}" ]]; then
             force_main="${force_pair%%|*}"
             force_rest="${force_pair#*|}"
             force_assist="${force_rest%%|*}"
@@ -510,4 +543,8 @@ jobs:
             exit 1
           fi
 
-          echo "Canary passed: regular(main=${expected_regular_main},assist_effective=${expected_regular_assist_effective},profile=${expected_regular_profile},runner=${expected_regular_runner}), force(main=${expected_force_main},assist_effective=${expected_force_assist_effective},profile=${expected_force_profile},runner=${expected_force_runner}), strict_expected=${strict_expected}"
+          if [[ "${run_force_case}" == "true" ]]; then
+            echo "Canary passed (${canary_mode}): regular(main=${expected_regular_main},assist_effective=${expected_regular_assist_effective},profile=${expected_regular_profile},runner=${expected_regular_runner}), force(main=${expected_force_main},assist_effective=${expected_force_assist_effective},profile=${expected_force_profile},runner=${expected_force_runner}), strict_expected=${strict_expected}"
+          else
+            echo "Canary passed (${canary_mode}): regular(main=${expected_regular_main},assist_effective=${expected_regular_assist_effective},profile=${expected_regular_profile},runner=${expected_regular_runner}), force=skipped, strict_expected=${strict_expected}"
+          fi

--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ export ANTHROPIC_API_KEY="your-anthropic-key" # optional (Claude assist lane)
 # NOTE: `workflow-risk-policy.sh` が over-compression guard を常時適用し、floor/span 未満なら自動補正します。
 # NOTE: `gha24` が事前フォールバックした場合は、Issueに監査コメントが自動投稿されます。
 # NOTE: `fugue-watchdog` は Claude state を自動復帰（degraded/exhausted -> ok）できますが、cooldown + 安定性条件を満たす場合のみ実行されます。
-# NOTE: `fugue-orchestrator-canary` が毎日、実Issueベースで regular/force の切替E2Eを自動検証します。
+# NOTE: `fugue-orchestration-gate` が PR で Fast Gate（syntax/yaml/parity/sim）を同期実行し、main push で canary-lite（regularのみ）を同期実行します。
+# NOTE: `fugue-orchestrator-canary` は full canary（regular+force）の定期検証です。`workflow_dispatch` では `canary_mode=full|lite` を選択できます。
 # NOTE: canaryは既定で `FUGUE_CANARY_OFFLINE_POLICY_OVERRIDE=continuity` として、subscription runner 不在でも検証継続します（`hold` または `inherit` で従来どおりスキップ可能）。
 # NOTE: canaryは regular/force ケースの統合コメント待機を並列化し、待機上限は fast/slow 2段（上記 `FUGUE_CANARY_WAIT_*`）で調整できます。
 # NOTE: `fugue-orchestration-weekly-review` が週次で assist昇格率と high-risk時の昇格カバレッジを status issue に投稿します。


### PR DESCRIPTION
## Summary
- add `fugue-orchestration-gate.yml` for staged orchestration verification
  - PR: synchronous Fast Gate (shell syntax, workflow YAML parse, matrix parity, deterministic sim)
  - main push: synchronous canary-lite dispatch (`fugue-orchestrator-canary` with `canary_mode=lite`)
- extend `fugue-orchestrator-canary.yml` with `workflow_dispatch` input `canary_mode=full|lite`
  - `full`: existing regular + force behavior
  - `lite`: regular-only path for faster blocking verification
- document staged policy in README

## Why
Current full canary can become a bottleneck under tail failures. This change preserves full coverage in scheduled full canary while reducing synchronization latency for the common path.

## Validation
- workflow YAML parse checks passed
- `scripts/sim-orchestrator-switch.sh` executed successfully (`rows=10`)
