### PR TITLE
feat: integrate protected Google Workspace preflight

### DIFF
--- a/.github/workflows/fugue-codex-implement.yml
+++ b/.github/workflows/fugue-codex-implement.yml
@@ -52,6 +52,46 @@ on:
         required: false
         type: string
         default: "auto"
+      workspace_hint_applied:
+        description: "Whether Google Workspace readonly preflight is relevant"
+        required: false
+        type: string
+        default: "false"
+      workspace_action_hint:
+        description: "Comma-separated Google Workspace action hints"
+        required: false
+        type: string
+        default: ""
+      workspace_domain_hint:
+        description: "Comma-separated Google Workspace domain hints"
+        required: false
+        type: string
+        default: ""
+      workspace_reason:
+        description: "Short explanation for Google Workspace relevance"
+        required: false
+        type: string
+        default: ""
+      workspace_suggested_phases:
+        description: "Comma-separated Kernel phases suggested for Workspace use"
+        required: false
+        type: string
+        default: ""
+      workspace_readonly_actions:
+        description: "Comma-separated readonly Google Workspace actions allowed in CI preflight"
+        required: false
+        type: string
+        default: ""
+      workspace_approval_required_actions:
+        description: "Comma-separated write Google Workspace actions requiring approval"
+        required: false
+        type: string
+        default: ""
+      workspace_readonly_environment:
+        description: "Protected GitHub Environment used for readonly Google Workspace CI preflight"
+        required: false
+        type: string
+        default: "workspace-readonly"
     secrets:
       OPENAI_API_KEY:
         required: false
@@ -257,9 +297,70 @@ jobs:
             echo "skip_reason=${skip_reason}"
           } >> "${GITHUB_OUTPUT}"
 
-  implement:
-    if: ${{ needs.prepare.outputs.should_run == 'true' && needs.credential-guard.outputs.can_run == 'true' }}
+  workspace-preflight:
+    if: ${{ needs.prepare.outputs.should_run == 'true' && needs.credential-guard.outputs.can_run == 'true' && inputs.workspace_hint_applied == 'true' }}
     needs: [prepare, credential-guard]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: ${{ inputs.workspace_readonly_environment }}
+    outputs:
+      workspace_preflight_status: ${{ steps.workspace_preflight.outputs.workspace_preflight_status }}
+      workspace_report_path: ${{ steps.workspace_preflight.outputs.workspace_report_path }}
+      workspace_summary: ${{ steps.workspace_preflight.outputs.workspace_summary }}
+      workspace_artifact_name: ${{ steps.workspace_meta.outputs.workspace_artifact_name }}
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.prepare.outputs.target_repo }}
+          token: ${{ secrets.TARGET_REPO_PAT || github.token }}
+          ref: ${{ inputs.target_branch }}
+          fetch-depth: 1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Google Workspace CLI
+        run: npm install -g @googleworkspace/cli
+
+      - name: Set Workspace artifact metadata
+        id: workspace_meta
+        run: |
+          echo "workspace_artifact_name=googleworkspace-preflight-${{ needs.prepare.outputs.issue_number }}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run Google Workspace readonly preflight
+        id: workspace_preflight
+        env:
+          ISSUE_NUMBER: ${{ needs.prepare.outputs.issue_number }}
+          ISSUE_TITLE: ${{ needs.prepare.outputs.issue_title }}
+          ISSUE_BODY: ${{ needs.prepare.outputs.issue_body }}
+          WORKSPACE_ACTIONS: ${{ inputs.workspace_readonly_actions || inputs.workspace_action_hint }}
+          WORKSPACE_DOMAINS: ${{ inputs.workspace_domain_hint }}
+          WORKSPACE_REASON: ${{ inputs.workspace_reason }}
+          WORKSPACE_SUGGESTED_PHASES: ${{ inputs.workspace_suggested_phases }}
+          OUT_DIR: .fugue/pre-implement
+          RUN_DIR: .fugue/pre-implement/googleworkspace-run
+          REPORT_PATH: .fugue/pre-implement/issue-${{ needs.prepare.outputs.issue_number }}-googleworkspace.md
+          ADAPTER: scripts/lib/googleworkspace-cli-adapter.sh
+          GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON: ${{ secrets.GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON }}
+        run: bash scripts/harness/googleworkspace-preflight-enrich.sh
+
+      - name: Upload Google Workspace preflight artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.workspace_meta.outputs.workspace_artifact_name }}
+          path: |
+            .fugue/pre-implement/issue-${{ needs.prepare.outputs.issue_number }}-googleworkspace.md
+            .fugue/pre-implement/googleworkspace-run
+          if-no-files-found: ignore
+
+  implement:
+    if: ${{ needs.prepare.outputs.should_run == 'true' && needs.credential-guard.outputs.can_run == 'true' && (needs.workspace-preflight.result == 'success' || needs.workspace-preflight.result == 'skipped') }}
+    needs: [prepare, credential-guard, workspace-preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -301,6 +402,13 @@ jobs:
       - name: Create working branch
         run: |
           git checkout -b "${{ needs.prepare.outputs.branch_name }}"
+
+      - name: Download Google Workspace preflight artifact
+        if: ${{ inputs.workspace_hint_applied == 'true' && needs.workspace-preflight.result == 'success' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.workspace-preflight.outputs.workspace_artifact_name }}
+          path: .
 
       - name: Run parallel preflight nodes
         id: preflight_parallel
@@ -502,6 +610,9 @@ jobs:
           RESEARCH_REPORT_PATH: ${{ steps.preflight_parallel.outputs.research_report_path }}
           PLAN_REPORT_PATH: ${{ steps.preflight_parallel.outputs.plan_report_path }}
           CRITIC_REPORT_PATH: ${{ steps.preflight_parallel.outputs.critic_report_path }}
+          WORKSPACE_REPORT_PATH: ${{ needs.workspace-preflight.outputs.workspace_report_path }}
+          WORKSPACE_SUMMARY: ${{ needs.workspace-preflight.outputs.workspace_summary }}
+          WORKSPACE_PREFLIGHT_STATUS: ${{ needs.workspace-preflight.outputs.workspace_preflight_status }}
         run: bash scripts/harness/codex-execute-validate.sh
 
       - name: Commit changes
@@ -574,11 +685,13 @@ jobs:
             ${{ steps.codex.outputs.research_report_path }}
             ${{ steps.codex.outputs.plan_report_path }}
             ${{ steps.codex.outputs.critic_report_path }}
+            ${{ needs.workspace-preflight.outputs.workspace_report_path }}
+            .fugue/pre-implement/googleworkspace-run
           if-no-files-found: ignore
 
   finalize:
     if: always() && needs.prepare.outputs.should_run == 'true' && needs.credential-guard.outputs.can_run == 'true'
-    needs: [prepare, credential-guard, implement]
+    needs: [prepare, credential-guard, workspace-preflight, implement]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -588,24 +701,32 @@ jobs:
           ISSUE_NUMBER: ${{ needs.prepare.outputs.issue_number }}
           PR_URL: ${{ needs.implement.outputs.pr_url }}
           CODEX_EXIT: ${{ needs.implement.outputs.codex_exit }}
+          WORKSPACE_PREFLIGHT_STATUS: ${{ needs.workspace-preflight.outputs.workspace_preflight_status }}
         run: |
           set -euo pipefail
 
           gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
             --remove-label "processing" || true
 
+          workspace_note=""
+          if [[ -n "${WORKSPACE_PREFLIGHT_STATUS}" ]]; then
+            workspace_note="
+
+          Workspace preflight: ${WORKSPACE_PREFLIGHT_STATUS}"
+          fi
+
           if [[ -n "${PR_URL}" ]]; then
             gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
               --body "Codex implementation complete. PR created: ${PR_URL}
 
-          Exit code: ${CODEX_EXIT}"
+          Exit code: ${CODEX_EXIT}${workspace_note}"
             gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
               --add-label "completed"
           elif [[ "${CODEX_EXIT}" != "0" ]]; then
             gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
               --body "Codex implementation stopped before PR creation because mandatory protocol checks failed.
 
-          Exit code: ${CODEX_EXIT}
+          Exit code: ${CODEX_EXIT}${workspace_note}
           Check artifacts for protocol reports and codex output log."
             gh issue edit "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
               --add-label "needs-review"
@@ -613,7 +734,7 @@ jobs:
             gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
               --body "Codex implementation did not produce changes.
 
-          Exit code: ${CODEX_EXIT}
+          Exit code: ${CODEX_EXIT}${workspace_note}
           This may mean: no code changes were needed, the task was unclear, or Codex encountered an error.
 
           Check the workflow run artifacts for the full Codex output log."

--- a/.github/workflows/fugue-tutti-caller.yml
+++ b/.github/workflows/fugue-tutti-caller.yml
@@ -114,6 +114,13 @@ jobs:
       trust_subject: ${{ steps.ctx.outputs.trust_subject }}
       allow_processing_rerun: ${{ steps.ctx.outputs.allow_processing_rerun }}
       handoff_target: ${{ steps.ctx.outputs.handoff_target }}
+      workspace_hint_applied: ${{ steps.ctx.outputs.workspace_hint_applied }}
+      workspace_action_hint: ${{ steps.ctx.outputs.workspace_action_hint }}
+      workspace_domain_hint: ${{ steps.ctx.outputs.workspace_domain_hint }}
+      workspace_reason: ${{ steps.ctx.outputs.workspace_reason }}
+      workspace_suggested_phases: ${{ steps.ctx.outputs.workspace_suggested_phases }}
+      workspace_readonly_actions: ${{ steps.ctx.outputs.workspace_readonly_actions }}
+      workspace_approval_required_actions: ${{ steps.ctx.outputs.workspace_approval_required_actions }}
       vote_instruction: ${{ steps.ctx.outputs.vote_instruction }}
     steps:
       - name: Checkout repository
@@ -517,6 +524,14 @@ jobs:
       risk_tier: "${{ needs.ctx.outputs.risk_tier }}"
       lessons_required: "${{ needs.ctx.outputs.lessons_required }}"
       correction_signal: "${{ needs.ctx.outputs.correction_signal }}"
+      workspace_hint_applied: "${{ needs.ctx.outputs.workspace_hint_applied }}"
+      workspace_action_hint: "${{ needs.ctx.outputs.workspace_action_hint }}"
+      workspace_domain_hint: "${{ needs.ctx.outputs.workspace_domain_hint }}"
+      workspace_reason: "${{ needs.ctx.outputs.workspace_reason }}"
+      workspace_suggested_phases: "${{ needs.ctx.outputs.workspace_suggested_phases }}"
+      workspace_readonly_actions: "${{ needs.ctx.outputs.workspace_readonly_actions }}"
+      workspace_approval_required_actions: "${{ needs.ctx.outputs.workspace_approval_required_actions }}"
+      workspace_readonly_environment: "${{ vars.FUGUE_WORKSPACE_READONLY_ENV || 'workspace-readonly' }}"
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       TARGET_REPO_PAT: ${{ secrets.TARGET_REPO_PAT }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,11 +195,19 @@ Use live rehearsal only when needed and clean up synthetic issues after verifica
   - `scripts/skills/sync-openclaw-skills.sh`
 - Profile details:
   - `docs/fugue-skills-profile.md`
+- Vendor-specific skill profile:
+  - `docs/googleworkspace-skills-profile.md`
+- Vendor-specific manifest:
+  - `config/skills/googleworkspace-cli-baseline.tsv`
+- Vendor-specific sync script:
+  - `scripts/skills/sync-googleworkspace-skills.sh`
 
 Security guardrails:
 - Do not install unpinned third-party skills directly from `main`.
 - Reject skills with unsafe auto-execution guidance (`--yolo`, `--full-auto`) in default profile.
 - Keep Codex and Claude skill sets synchronized from the same manifest so orchestrator switching does not change capabilities.
+- Prefer `SKILL.md + CLI` over MCP by default for Google Workspace because it keeps the active context surface smaller and preserves provider-agnostic parity.
+- Reserve `gws mcp` for MCP-only clients or when structured tool exposure is explicitly required.
 
 ## 10. Shared Workflow Playbook (Codex/Claude)
 

--- a/README.md
+++ b/README.md
@@ -294,6 +294,12 @@ export ANTHROPIC_API_KEY="your-anthropic-key" # optional (Claude assist lane)
 # ./scripts/skills/sync-openclaw-skills.sh --target both --with-optional --dry-run
 # NOTE: third-party skills は pin SHA 取得 + ブロックリスト検査 + managed marker で保護
 
+# 3.10 Google Workspace skills + CLI 同期（Codex/Claude 共通）
+# npm install -g @googleworkspace/cli
+# ./scripts/skills/sync-googleworkspace-skills.sh --target both
+# ./scripts/skills/sync-googleworkspace-skills.sh --target both --with-optional
+# NOTE: Google Workspace は MCP 常用ではなく skills + CLI を第一選択にする
+
 # Note:
 # `orchestrator provider` は Tutti のレーン選択プロファイルです（実装エンジン切替ではありません）。
 # 実装実行エンジンは `fugue-codex-implement`（Codex CLI）で固定です。
@@ -342,6 +348,11 @@ Orchestrator切替（Codex/Claude）時も同一能力を維持するため、FU
 - Profile: `docs/fugue-skills-profile.md`
 - Manifest: `config/skills/fugue-openclaw-baseline.tsv`
 - Sync script: `scripts/skills/sync-openclaw-skills.sh`
+- Google Workspace profile: `docs/googleworkspace-skills-profile.md`
+- Google Workspace Kernel design: `docs/kernel-googleworkspace-integration-design.md`
+- Google Workspace manifest: `config/skills/googleworkspace-cli-baseline.tsv`
+- Google Workspace Kernel policy: `config/integrations/googleworkspace-kernel-policy.json`
+- Google Workspace sync: `scripts/skills/sync-googleworkspace-skills.sh`
 
 ## Shared Workflow Playbook
 

--- a/config/integrations/googleworkspace-kernel-policy.json
+++ b/config/integrations/googleworkspace-kernel-policy.json
@@ -1,0 +1,214 @@
+{
+  "version": 1,
+  "name": "googleworkspace-kernel-policy",
+  "default_adapters": {
+    "readonly": "googleworkspace-cli-readonly",
+    "write": "googleworkspace-cli-write"
+  },
+  "auth_profiles": {
+    "service-account-readonly": {
+      "interactive": false,
+      "allows_side_effects": false,
+      "allowed_actions": [
+        "meeting-prep",
+        "standup-report"
+      ],
+      "notes": [
+        "Use for scheduled or unattended Kernel routines.",
+        "Do not assume Gmail mailbox access."
+      ]
+    },
+    "user-oauth-readonly": {
+      "interactive": true,
+      "allows_side_effects": false,
+      "allowed_actions": [
+        "meeting-prep",
+        "standup-report",
+        "weekly-digest",
+        "gmail-triage"
+      ],
+      "notes": [
+        "Preferred for operator-bound context gathering.",
+        "Use bounded output only."
+      ]
+    },
+    "user-oauth-write": {
+      "interactive": true,
+      "allows_side_effects": true,
+      "allowed_actions": [
+        "gmail-send",
+        "drive-upload",
+        "calendar-insert",
+        "docs-create",
+        "docs-insert-text",
+        "sheets-create",
+        "sheets-append"
+      ],
+      "notes": [
+        "Requires ok_to_execute and human approval.",
+        "Prefer dry-run before actual execution."
+      ]
+    }
+  },
+  "phase_policy": [
+    {
+      "phase": "intake-classify",
+      "adapter_id": "googleworkspace-cli-readonly",
+      "allowed_actions": [],
+      "auth_profiles": [],
+      "requires_ok_to_execute": false,
+      "requires_human_approval": false,
+      "result_class": "route-hint"
+    },
+    {
+      "phase": "preflight-enrich",
+      "adapter_id": "googleworkspace-cli-readonly",
+      "allowed_actions": [
+        "meeting-prep",
+        "standup-report",
+        "weekly-digest",
+        "gmail-triage"
+      ],
+      "auth_profiles": [
+        "service-account-readonly",
+        "user-oauth-readonly"
+      ],
+      "requires_ok_to_execute": false,
+      "requires_human_approval": false,
+      "result_class": "evidence"
+    },
+    {
+      "phase": "scheduled-operator-loop",
+      "adapter_id": "googleworkspace-cli-readonly",
+      "allowed_actions": [
+        "meeting-prep",
+        "standup-report",
+        "weekly-digest"
+      ],
+      "auth_profiles": [
+        "service-account-readonly",
+        "user-oauth-readonly"
+      ],
+      "requires_ok_to_execute": false,
+      "requires_human_approval": false,
+      "result_class": "digest"
+    },
+    {
+      "phase": "execute-dry-run",
+      "adapter_id": "googleworkspace-cli-write",
+      "allowed_actions": [
+        "gmail-send",
+        "drive-upload",
+        "calendar-insert"
+      ],
+      "auth_profiles": [
+        "user-oauth-write"
+      ],
+      "requires_ok_to_execute": false,
+      "requires_human_approval": false,
+      "result_class": "preview"
+    },
+    {
+      "phase": "approved-execute",
+      "adapter_id": "googleworkspace-cli-write",
+      "allowed_actions": [
+        "gmail-send",
+        "drive-upload",
+        "calendar-insert",
+        "docs-create",
+        "docs-insert-text",
+        "sheets-create",
+        "sheets-append"
+      ],
+      "auth_profiles": [
+        "user-oauth-write"
+      ],
+      "requires_ok_to_execute": true,
+      "requires_human_approval": true,
+      "result_class": "receipt"
+    },
+    {
+      "phase": "recovery-rehydrate",
+      "adapter_id": "googleworkspace-cli-readonly",
+      "allowed_actions": [
+        "meeting-prep",
+        "weekly-digest",
+        "gmail-triage"
+      ],
+      "auth_profiles": [
+        "user-oauth-readonly"
+      ],
+      "requires_ok_to_execute": false,
+      "requires_human_approval": false,
+      "result_class": "evidence"
+    }
+  ],
+  "action_policy": {
+    "meeting-prep": {
+      "adapter_id": "googleworkspace-cli-readonly",
+      "side_effect": false,
+      "default_phase": "preflight-enrich",
+      "fallback": "skip-if-auth-unavailable"
+    },
+    "standup-report": {
+      "adapter_id": "googleworkspace-cli-readonly",
+      "side_effect": false,
+      "default_phase": "scheduled-operator-loop",
+      "fallback": "service-account-preferred"
+    },
+    "weekly-digest": {
+      "adapter_id": "googleworkspace-cli-readonly",
+      "side_effect": false,
+      "default_phase": "scheduled-operator-loop",
+      "fallback": "degrade-without-gmail"
+    },
+    "gmail-triage": {
+      "adapter_id": "googleworkspace-cli-readonly",
+      "side_effect": false,
+      "default_phase": "preflight-enrich",
+      "fallback": "skip-with-service-account"
+    },
+    "gmail-send": {
+      "adapter_id": "googleworkspace-cli-write",
+      "side_effect": true,
+      "default_phase": "approved-execute",
+      "requires_dry_run_preview": true
+    },
+    "drive-upload": {
+      "adapter_id": "googleworkspace-cli-write",
+      "side_effect": true,
+      "default_phase": "approved-execute",
+      "requires_dry_run_preview": true
+    },
+    "calendar-insert": {
+      "adapter_id": "googleworkspace-cli-write",
+      "side_effect": true,
+      "default_phase": "approved-execute",
+      "requires_dry_run_preview": true
+    },
+    "docs-create": {
+      "adapter_id": "googleworkspace-cli-write",
+      "side_effect": true,
+      "default_phase": "approved-execute",
+      "requires_dry_run_preview": false
+    },
+    "docs-insert-text": {
+      "adapter_id": "googleworkspace-cli-write",
+      "side_effect": true,
+      "default_phase": "approved-execute",
+      "requires_dry_run_preview": false
+    },
+    "sheets-create": {
+      "adapter_id": "googleworkspace-cli-write",
+      "side_effect": true,
+      "default_phase": "approved-execute",
+      "requires_dry_run_preview": false
+    },
+    "sheets-append": {
+      "adapter_id": "googleworkspace-cli-write",
+      "side_effect": true,
+      "default_phase": "approved-execute",
+      "requires_dry_run_preview": false
+    }
+  }
+}

--- a/config/integrations/peripheral-adapters.json
+++ b/config/integrations/peripheral-adapters.json
@@ -123,6 +123,32 @@
       "path": "../cloudflare-workers-hub-deploy/cockpit-pwa/src/app/page.tsx"
     },
     {
+      "id": "googleworkspace-cli-readonly",
+      "name": "Google Workspace CLI Read Only",
+      "scope": "skill",
+      "kind": "knowledge",
+      "adapter_class": "shell",
+      "authority": "service-adapter",
+      "validation_mode": "smoke",
+      "contract_owner": "external",
+      "preferred_lane": "codex",
+      "protected_interface": false,
+      "path": "scripts/lib/googleworkspace-cli-adapter.sh"
+    },
+    {
+      "id": "googleworkspace-cli-write",
+      "name": "Google Workspace CLI Write",
+      "scope": "skill",
+      "kind": "service",
+      "adapter_class": "shell",
+      "authority": "service-adapter",
+      "validation_mode": "smoke",
+      "contract_owner": "external",
+      "preferred_lane": "codex",
+      "protected_interface": false,
+      "path": "scripts/lib/googleworkspace-cli-adapter.sh"
+    },
+    {
       "id": "slide-specialist",
       "name": "Slide Specialist Workflow",
       "scope": "skill",

--- a/config/skills/googleworkspace-cli-baseline.tsv
+++ b/config/skills/googleworkspace-cli-baseline.tsv
@@ -1,0 +1,21 @@
+# skill_id\tprofile\trationale
+gws-shared	required	Shared auth, global flags, and safety rules for all Google Workspace CLI usage.
+gws-gmail	required	Gmail API surface for read and triage automation.
+gws-gmail-triage	required	Read-only unread inbox summary for operator morning triage.
+gws-calendar	required	Calendar API surface used by meeting-prep and schedule workflows.
+gws-drive	required	Drive API surface for file lookup, sharing, and upload flows.
+gws-docs	required	Docs API surface for memo and report generation workflows.
+gws-sheets	required	Sheets API surface for status tables and report inputs.
+gws-workflow	required	Cross-service workflow entrypoint for higher-level Workspace tasks.
+gws-workflow-meeting-prep	required	Read-only next-meeting summary for exec-assistant style flows.
+gws-workflow-standup-report	required	Morning status synthesis across Workspace surfaces.
+gws-workflow-weekly-digest	required	Weekly readout workflow for FUGUE and Kernel operator digests.
+gws-gmail-send	optional	Write-capable email helper; keep optional because it has side effects.
+gws-drive-upload	optional	Write-capable upload helper; keep optional because it changes Drive state.
+gws-docs-write	optional	Write-capable Docs helper for generated summaries and reports.
+gws-sheets-read	optional	Focused helper for quick table extraction from Sheets.
+gws-sheets-append	optional	Write-capable helper for logging rows into Sheets.
+gws-workflow-email-to-task	optional	Promotes mailbox-driven work into task workflows when needed.
+gws-workflow-file-announce	optional	Announces Drive files to downstream channels and collaborators.
+persona-exec-assistant	optional	Role guide tying together Gmail, Calendar, Drive, and Chat workflows.
+recipe-generate-report-from-sheet	optional	End-to-end reporting pattern from Sheets to Docs and Drive sharing.

--- a/docs/fugue-skills-profile.md
+++ b/docs/fugue-skills-profile.md
@@ -19,6 +19,12 @@ Sync script:
 
 - `scripts/skills/sync-openclaw-skills.sh`
 
+Vendor-specific shared profile:
+
+- Google Workspace: `docs/googleworkspace-skills-profile.md`
+- Google Workspace manifest: `config/skills/googleworkspace-cli-baseline.tsv`
+- Google Workspace sync: `scripts/skills/sync-googleworkspace-skills.sh`
+
 ## Selected Skills
 
 Required profile:

--- a/docs/googleworkspace-service-account-verification-2026-03-07.md
+++ b/docs/googleworkspace-service-account-verification-2026-03-07.md
@@ -1,0 +1,180 @@
+# Google Workspace Service Account Verification
+
+Date:
+
+- 2026-03-07
+
+## Goal
+
+Determine whether the existing Google service account key is sufficient to run
+the new `googleworkspace/cli` integration for `FUGUE` and `Kernel` without
+switching to user OAuth.
+
+## Credentials Under Test
+
+Initial key:
+
+- service account email:
+  - `ocr-service-account@shumei-ocr.iam.gserviceaccount.com`
+- project id:
+  - `shumei-ocr`
+- project number observed in Google API errors:
+  - `860340262476`
+
+Preferred key after live fixes:
+
+- service account email:
+  - `openclaw-calendar-reader@juken-ai-workflow.iam.gserviceaccount.com`
+- project id:
+  - `juken-ai-workflow`
+- project number observed in Google API errors:
+  - `1088384151786`
+
+Verification used explicit service-account mode via:
+
+```bash
+GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=/path/to/service-account.json
+```
+
+This avoids `.env` files. The final adapter/probe also scrub ambient Google
+variables before calling `gws`:
+
+- `GOOGLE_API_KEY`
+- `GOOGLE_APPLICATION_CREDENTIALS`
+- `GOOGLE_CLOUD_PROJECT`
+- `GCLOUD_PROJECT`
+- `GOOGLE_CREDENTIALS_PATH`
+
+Additional local credentials discovered during verification:
+
+- `/Users/masayuki/.config/gcloud/openclaw-calendar-key.json`
+- `/Users/masayuki/.config/gcloud/slides-generator-key.json`
+
+The key finding was that ambient `GOOGLE_API_KEY` skewed helper/workflow calls
+back onto project `860340262476` even when a different
+`GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE` was supplied. After sanitizing ambient
+Google variables, runtime behavior matched the explicit credentials file.
+
+## Live Checks
+
+Initial state with the original `shumei-ocr` key:
+
+- `meeting-prep`
+  - success
+- `standup-report`
+  - partial, blocked on `tasks.googleapis.com`
+- `weekly-digest`
+  - partial, blocked on `gmail.googleapis.com`
+- `drive files list`
+  - blocked on `drive.googleapis.com`
+- `gmail +triage`
+  - blocked on `gmail.googleapis.com`
+- `gcloud services list/enable`
+  - blocked because the service account could not manage Service Usage
+
+Live fixes applied on `juken-ai-workflow` with `flux@cursorvers.com`:
+
+- enabled `tasks.googleapis.com`
+- granted `roles/serviceusage.serviceUsageConsumer` to:
+  - `openclaw-calendar-reader@juken-ai-workflow.iam.gserviceaccount.com`
+  - `slides-generator@juken-ai-workflow.iam.gserviceaccount.com`
+- updated the adapter and live probe to scrub ambient Google auth/project env
+
+Current state with `openclaw-calendar-reader@juken-ai-workflow`:
+
+- `gws calendar calendarList list --params '{"maxResults":1}' --format json`
+  - result: success
+- `gws workflow +meeting-prep --format json`
+  - result: success
+  - response: `{"message":"No upcoming meetings found."}`
+- `gws workflow +standup-report --format json`
+  - result: success
+  - response: meetings and tasks both returned cleanly
+- `gws drive files list --params '{"pageSize":1}' --format json`
+  - result: success
+- `gws workflow +weekly-digest --format json`
+  - result: partial
+  - unread mail path fails with `FAILED_PRECONDITION`
+- `gws gmail +triage --max 1 --format json`
+  - result: blocked
+  - reason: `FAILED_PRECONDITION`
+
+## Conclusion
+
+Service-account mode is now usable for a stable read-only baseline on
+`juken-ai-workflow`, but it is still not sufficient for Gmail mailbox flows.
+
+User OAuth is now also verified on the same project for a bounded write profile:
+
+- Desktop app client:
+  `1088384151786-id2gg3gap5cdsh17ejh2bdaua18gt3d3.apps.googleusercontent.com`
+- encrypted user credentials saved successfully by `gws auth login`
+- dry-run validated:
+  - `gws gmail +send`
+  - `gws drive +upload`
+  - `gws calendar events insert`
+- live validated:
+  - `gws gmail +triage --max 1`
+  - `gws workflow +weekly-digest`
+  - `gws gmail +send`
+  - `gws sheets spreadsheets create`
+  - `gws sheets spreadsheets values append`
+  - `gws docs documents create`
+  - `gws docs documents batchUpdate`
+  - `gws calendar events insert`
+  - `gws drive +upload`
+- cleanup validated:
+  - Drive delete removed temporary Doc, Sheet, and uploaded file
+  - Calendar delete cancelled the temporary event
+  - Gmail trash moved the smoke message out of Inbox
+
+It is currently sufficient for:
+
+- calendar-backed read-only flows that the service account can see
+- Drive list/read flows visible to the service account
+- task-backed standup summaries
+- wrapper smoke checks and shared read-only helper execution
+- operator-approved write helpers under user OAuth
+
+It is not currently sufficient for:
+
+- self-healing setup from the service account itself
+- unattended write automation without a user OAuth credential
+
+## Operational Meaning For FUGUE And Kernel
+
+Safe now:
+
+- use `meeting-prep` as a shared read-only helper
+- keep the new wrapper in service-account mode for calendar/Drive/task-visible
+  resources
+- standardize explicit credentialed runs on
+  `openclaw-calendar-reader@juken-ai-workflow`
+
+Blocked until further setup:
+
+- service-account-only Gmail mailbox access
+- unattended write automation without a user OAuth credential
+- Gmail-persona workflows that assume a background mailbox actor
+
+## Required Next Step
+
+Choose one:
+
+1. stay on service account mode
+   - keep `juken-ai-workflow` as the baseline project
+   - grant the service account access to the required Workspace resources
+   - add domain-wide delegation if user mailbox access is required
+2. switch to user OAuth mode
+   - `gws auth setup`
+     - reached Step 5 successfully on `juken-ai-workflow`
+     - still requires manual OAuth client creation in Cloud Console
+   - `gws auth login --readonly -s calendar,gmail,drive,docs,sheets`
+   - attempted fallback:
+     - `gcloud auth application-default login` with Workspace read-only scopes
+     - Google blocked the `gcloud` public OAuth client during consent
+     - therefore this tenant still needs a project-owned Desktop app OAuth client
+       (and, if Workspace API controls require it, allowlisting/trust in Admin)
+
+The second option is the better fit if the target workflows are personal or
+operator-centric rather than server-to-server.

--- a/docs/googleworkspace-skills-profile.md
+++ b/docs/googleworkspace-skills-profile.md
@@ -1,0 +1,313 @@
+# Google Workspace Skills Profile
+
+This profile defines a curated `googleworkspace/cli` skill set for both `FUGUE`
+and `Kernel`.
+
+## Goals
+
+- Keep Google Workspace operations usable from both Codex and Claude paths.
+- Prefer `SKILL.md + gws CLI` over `gws mcp` for routine operator workflows.
+- Keep Workspace activity outside the control plane: evidence and side effects
+  may happen in Workspace, but orchestration truth remains in FUGUE or Kernel.
+
+## Default Operating Model
+
+Use Google Workspace through:
+
+1. installed `gws-*` skills
+2. the `gws` CLI
+3. bounded command output (`--format table` or narrow `json`)
+
+Do **not** make `gws mcp` the default path for FUGUE or Kernel. MCP remains an
+optional compatibility route for clients that can only consume MCP tools.
+
+Why:
+
+- `SKILL.md` is loaded on demand and stays small.
+- CLI output can be intentionally bounded by command shape and format flags.
+- MCP tool catalogs and large tool responses tend to widen the active context
+  surface faster than focused CLI calls.
+- `gws` already ships task-shaped helper skills and workflows, which reduces the
+  need for a schema-heavy MCP path in daily use.
+
+## Baseline Source Of Truth
+
+Manifest:
+
+- `config/skills/googleworkspace-cli-baseline.tsv`
+
+Sync script:
+
+- `scripts/skills/sync-googleworkspace-skills.sh`
+
+Upstream:
+
+- `https://github.com/googleworkspace/cli`
+
+The sync script pins upstream to commit
+`95bb24e9c2d5dd165fb0b3c81ad82a42ad31fc3f` by default.
+
+## Selected Skills
+
+Required profile:
+
+- `gws-shared`
+- `gws-gmail`
+- `gws-gmail-triage`
+- `gws-calendar`
+- `gws-drive`
+- `gws-docs`
+- `gws-sheets`
+- `gws-workflow`
+- `gws-workflow-meeting-prep`
+- `gws-workflow-standup-report`
+- `gws-workflow-weekly-digest`
+
+Optional profile (`--with-optional`):
+
+- write helpers such as `gws-gmail-send`, `gws-drive-upload`, `gws-docs-write`
+- focused helpers such as `gws-sheets-read`, `gws-sheets-append`
+- workflow extensions such as `gws-workflow-email-to-task`,
+  `gws-workflow-file-announce`
+- role/task guidance such as `persona-exec-assistant`,
+  `recipe-generate-report-from-sheet`
+
+## Install Examples
+
+Install the CLI:
+
+```bash
+npm install -g @googleworkspace/cli
+```
+
+Sync required skills into both orchestrator homes:
+
+```bash
+./scripts/skills/sync-googleworkspace-skills.sh --target both
+```
+
+Include optional skills:
+
+```bash
+./scripts/skills/sync-googleworkspace-skills.sh --target both --with-optional
+```
+
+Dry-run preview:
+
+```bash
+./scripts/skills/sync-googleworkspace-skills.sh --target both --with-optional --dry-run
+```
+
+## Authentication
+
+Preferred interactive setup:
+
+```bash
+gws auth setup
+gws auth login
+```
+
+Observed on `2026-03-07`:
+
+- `gws auth setup` successfully advanced through project/API setup on
+  `juken-ai-workflow`
+- final completion still required a manual Cloud Console step to create a
+  `Desktop app` OAuth client and save it as
+  `~/.config/gws/client_secret.json`
+- until that file exists, `gws auth login` returns `No OAuth client configured`
+- `gcloud auth application-default login` with Workspace read-only scopes was
+  also tested, but Google blocked the public `gcloud` OAuth client for this
+  consent flow, so ADC is not a complete replacement here
+
+If `gcloud` is unavailable or project creation must stay manual, keep auth
+outside FUGUE/Kernel automation and authenticate the operator terminal first.
+
+Service-account mode is also supported when `.env` files are not allowed:
+
+```bash
+./scripts/lib/googleworkspace-cli-adapter.sh \
+  --credentials-file /secure/path/service-account.json \
+  --action meeting-prep
+```
+
+Verified baseline service-account path:
+
+- project: `juken-ai-workflow`
+- service account:
+  `openclaw-calendar-reader@juken-ai-workflow.iam.gserviceaccount.com`
+- verified actions:
+  - `meeting-prep`
+  - `standup-report`
+  - `drive files list`
+- wrapper behavior:
+  - scrubs ambient `GOOGLE_API_KEY`, `GOOGLE_APPLICATION_CREDENTIALS`,
+    `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, and `GOOGLE_CREDENTIALS_PATH`
+    whenever `--credentials-file` is used
+- known service-account limitation:
+  - Gmail mailbox helpers such as `gmail-triage` still require user OAuth or
+    domain-wide delegation
+
+Verified user OAuth write path:
+
+- Desktop app client installed at `~/.config/gws/client_secret.json`
+- encrypted user credentials stored at `~/.config/gws/credentials.enc`
+- verified write-capable scopes:
+  - `https://www.googleapis.com/auth/drive`
+  - `https://www.googleapis.com/auth/spreadsheets`
+  - `https://www.googleapis.com/auth/gmail.modify`
+  - `https://www.googleapis.com/auth/calendar`
+  - `https://www.googleapis.com/auth/documents`
+- dry-run validated actions:
+  - `gws gmail +send`
+  - `gws drive +upload`
+  - `gws calendar events insert`
+- live validated adapter actions:
+  - `gmail-triage`
+  - `weekly-digest`
+  - `gmail-send --dry-run`
+  - `docs-create`
+  - `docs-insert-text`
+  - `sheets-create`
+  - `sheets-append`
+  - `calendar-insert`
+  - `drive-upload`
+- cleanup verified:
+  - temporary Doc, Sheet, uploaded Drive file removed
+  - temporary Calendar event cancelled
+  - temporary Gmail smoke message moved to Trash
+
+Current repo-side live verification:
+
+- `docs/googleworkspace-service-account-verification-2026-03-07.md`
+- `scripts/check-googleworkspace-live.sh`
+
+Current repo-side Kernel integration helpers:
+
+- `scripts/lib/orchestrator-nl-hints.sh`
+  - now emits `workspace_action_hint`, `workspace_domain_hint`,
+    `workspace_reason`, and `workspace_hint_applied`
+- `scripts/harness/resolve-orchestration-context.sh`
+  - now exports Workspace route hints to `GITHUB_OUTPUT`
+  - includes `workspace_suggested_phases`,
+    `workspace_readonly_actions`, and
+    `workspace_approval_required_actions`
+- `scripts/lib/googleworkspace-cli-adapter.sh`
+  - supports `--run-dir` evidence output
+  - supports `--ok-to-execute` and `--human-approved` write gating
+- `scripts/local/run-local-orchestration.sh`
+  - writes `googleworkspace-context.json` into each run directory
+- `scripts/harness/googleworkspace-preflight-enrich.sh`
+  - produces a bounded readonly Workspace artifact for CI preflight
+  - degrades to `skipped` when no Workspace credentials are available
+
+## CI Secret Contract
+
+Readonly GitHub Actions preflight uses a protected `Environment` secret rather
+than a repo-level secret.
+
+Recommended environment:
+
+- `workspace-readonly`
+  - configure required reviewers or approval rules
+  - expose `GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON` only in this environment
+
+Secret:
+
+- `GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON`
+  - service-account JSON payload
+  - intended only for readonly preflight actions
+  - consumed by `scripts/harness/googleworkspace-preflight-enrich.sh`
+  - not passed through the caller workflow as a reusable-workflow secret
+
+Protection model:
+
+- first guard: readonly service-account scope only
+- second guard: protected `Environment` approval before the preflight job can
+  read the secret
+
+If the environment secret is absent, the CI workflow does not fail. It emits a
+`skipped` Workspace artifact instead and continues with the normal Codex path.
+
+Current CI path:
+
+- caller forwards `workspace_*` hints into `fugue-codex-implement`
+- reusable workflow routes Workspace preflight into a dedicated protected job
+- the protected job reads secrets only from `workspace-readonly`
+- implementation job downloads the preflight artifact and does not receive the
+  Workspace credential secret directly
+- readonly preflight artifact lands at:
+  - `.fugue/pre-implement/issue-<n>-googleworkspace.md`
+- raw readonly evidence lands at:
+  - `.fugue/pre-implement/googleworkspace-run/googleworkspace/`
+
+## Safety Rules
+
+- Read `gws-shared` before using any Workspace write helper.
+- Use `--dry-run` on write/delete-capable commands when available.
+- Prefer read-only workflows such as `gws workflow +meeting-prep`,
+  `gws gmail +triage --max 10`, and `gws workflow +weekly-digest` for routine
+  operator assistance.
+- In service-account mode, treat Gmail helpers as opt-in only. The verified
+  baseline for FUGUE/Kernel is Calendar + Drive + Tasks read-only.
+- Use the write adapter only with explicit human approval. The verified
+  write-capable baseline is Gmail send, Drive upload, and Calendar insert.
+- Treat generated Docs, Sheets, or Drive writes as peripheral side effects, not
+  control-plane truth.
+- When `--run-dir` is provided, persist raw output plus a `*-meta.json` receipt
+  under `<run-dir>/googleworkspace/`.
+
+## FUGUE And Kernel Fit
+
+`FUGUE` fit:
+
+- next-meeting preparation
+- standup/reporting support
+- Drive/Docs/Sheets artifact support around issue work
+- Gmail-aware flows only after user OAuth or domain-wide delegation
+- operator-approved write actions via the write adapter
+
+`Kernel` fit:
+
+- bounded peripheral skill family under the execution or adapter plane
+- no change to sovereign routing or execution approval
+- evidence-producing workflow, not governance logic
+- shared read-only adapter: `googleworkspace-cli-readonly`
+- shared write adapter: `googleworkspace-cli-write`
+- operating design:
+  - `docs/kernel-googleworkspace-integration-design.md`
+  - `config/integrations/googleworkspace-kernel-policy.json`
+
+Example adapter usage:
+
+```bash
+./scripts/lib/googleworkspace-cli-adapter.sh --action meeting-prep --resolve-only
+./scripts/lib/googleworkspace-cli-adapter.sh --action gmail-triage --max 10
+./scripts/lib/googleworkspace-cli-adapter.sh --action gmail-send --to flux@cursorvers.com --subject "Test" --body "Hello" --dry-run
+./scripts/lib/googleworkspace-cli-adapter.sh --action drive-upload --file ./README.md --dry-run
+./scripts/lib/googleworkspace-cli-adapter.sh --action calendar-insert --calendar primary --event-json '{"summary":"Test","start":{"dateTime":"2026-03-08T10:00:00+09:00"},"end":{"dateTime":"2026-03-08T10:30:00+09:00"}}' --dry-run
+./scripts/lib/googleworkspace-cli-adapter.sh --action docs-create --title "Test Doc" --format json
+./scripts/lib/googleworkspace-cli-adapter.sh --action docs-insert-text --document-id DOC_ID --text "Hello" --format json
+./scripts/lib/googleworkspace-cli-adapter.sh --action sheets-create --title "Test Sheet" --format json
+./scripts/lib/googleworkspace-cli-adapter.sh --action sheets-append --spreadsheet-id SHEET_ID --range 'シート1!A1' --values-json '{"values":[["a","b"]]}' --format json
+```
+
+## Adjacent CLI-First Candidates
+
+Current repo evidence suggests these MCP surfaces are better managed with
+`skills + CLI` style wrappers than as default MCP-first integrations:
+
+- `supabase-rest-mcp`
+  - already deterministic CLI/REST bridge logic via
+    `scripts/lib/mcp-rest-bridge.sh`
+- `stripe-rest-mcp`
+  - same deterministic REST bridge pattern as Supabase
+
+Keep MCP-first for now:
+
+- `pencil-session-mcp`
+- `excalidraw-session-mcp`
+- `slack-session-mcp`
+- `vercel-session-mcp`
+
+These still carry session/runtime coupling that is not improved by forcing them
+into a fake CLI-only shape.

--- a/docs/kernel-googleworkspace-integration-design.md
+++ b/docs/kernel-googleworkspace-integration-design.md
@@ -1,0 +1,261 @@
+# Kernel Google Workspace Integration Design
+
+## Goal
+
+Integrate `googleworkspace/cli` into `Kernel` as a bounded peripheral adapter
+family for operator workflows.
+
+This design keeps Google Workspace outside the control plane while making it
+available for:
+
+- context gathering
+- operator briefing
+- artifact publishing
+- stakeholder coordination
+
+## Core Rules
+
+1. Google Workspace is a peripheral service boundary, not orchestration truth.
+2. `SKILL.md + gws CLI` is the default route. `gws mcp` is optional only.
+3. Read-only actions are the default. Write actions require explicit approval.
+4. Output returned to `Kernel` must be summarized and bounded.
+5. Authentication must stay outside workspace `.env` files.
+
+## Placement In Kernel
+
+`Kernel` already separates the sovereign core from the execution and adapter
+plane. Google Workspace belongs only in the adapter plane.
+
+- `Kernel Sovereign Core`
+  - decides whether Workspace is relevant
+  - decides whether side effects are allowed
+- `Execution + Adapter Plane`
+  - runs `googleworkspace-cli-readonly`
+  - runs `googleworkspace-cli-write`
+- `Verification + Rollback`
+  - validates adapter contract and smoke paths
+  - does not treat Workspace as rollback authority
+
+## Adapter Family
+
+Current adapters:
+
+- `googleworkspace-cli-readonly`
+  - `scope`: `skill`
+  - `kind`: `knowledge`
+  - `authority`: `service-adapter`
+  - `validation_mode`: `smoke`
+- `googleworkspace-cli-write`
+  - `scope`: `skill`
+  - `kind`: `service`
+  - `authority`: `service-adapter`
+  - `validation_mode`: `smoke`
+
+Current command surface:
+
+- read-only:
+  - `meeting-prep`
+  - `standup-report`
+  - `weekly-digest`
+  - `gmail-triage`
+- write-capable:
+  - `gmail-send`
+  - `drive-upload`
+  - `calendar-insert`
+  - `docs-create`
+  - `docs-insert-text`
+  - `sheets-create`
+  - `sheets-append`
+
+## Authentication Modes
+
+### Service Account Read Only
+
+Use for unattended or scheduled `Kernel` routines.
+
+Allowed baseline:
+
+- `meeting-prep`
+- `standup-report`
+- `drive files list`
+
+Limit:
+
+- no Gmail mailbox access without domain-wide delegation
+
+### User OAuth Read Only
+
+Use for operator-bound context gathering.
+
+Allowed baseline:
+
+- `meeting-prep`
+- `standup-report`
+- `weekly-digest`
+- `gmail-triage`
+
+### User OAuth Write
+
+Use only after both of these are true:
+
+- `Kernel` has reached `ok_to_execute=true`
+- a human has explicitly approved the side effect
+
+Allowed baseline:
+
+- `gmail-send`
+- `drive-upload`
+- `calendar-insert`
+- `docs-create`
+- `docs-insert-text`
+- `sheets-create`
+- `sheets-append`
+
+## Kernel Phase Mapping
+
+| Kernel phase | Trigger | Adapter | Typical actions | Auth mode | Approval gate | Kernel result |
+|---|---|---|---|---|---|---|
+| Intake classify | issue mentions meeting, inbox, doc, drive, report | readonly | none by default; mark Workspace relevance only | none | none | route hint only |
+| Preflight enrich | plan needs human context | readonly | `meeting-prep`, `gmail-triage`, `weekly-digest`, `standup-report` | service account or user read-only | none | summarized evidence block |
+| Scheduled operator loop | morning, pre-meeting, weekly cron | readonly | `standup-report`, `meeting-prep`, `weekly-digest` | service account for narrow flows, user read-only for Gmail | scheduler policy | digest artifact |
+| Execute dry-run | side effect is proposed | write | `gmail-send`, `drive-upload`, `calendar-insert` with `--dry-run` where supported | user write | no execution yet | side-effect preview |
+| Approved execute | publish or notify | write | any validated write action | user write | `ok_to_execute=true` and human approval | side-effect receipt |
+| Post-execute sync | task completed and deliverables exist | write | `docs-create`, `docs-insert-text`, `sheets-append`, `drive-upload`, `gmail-send` | user write | already approved | generated artifact ids |
+| Recovery rehydrate | stale issue or interrupted run | readonly | `meeting-prep`, `weekly-digest`, `gmail-triage` | user read-only | none | refreshed context summary |
+
+## Evidence Envelope
+
+`Kernel` should never ingest full Workspace payloads into the main prompt by
+default. The adapter result should be reduced into an evidence envelope:
+
+```json
+{
+  "source": "googleworkspace-cli",
+  "adapter_id": "googleworkspace-cli-readonly",
+  "action": "meeting-prep",
+  "side_effect": false,
+  "summary": "Next meeting is Project Sync at 10:00 JST with 3 attendees and 2 linked docs.",
+  "references": [
+    { "kind": "calendar-event", "id": "event-id" },
+    { "kind": "drive-file", "id": "file-id-1" },
+    { "kind": "drive-file", "id": "file-id-2" }
+  ],
+  "raw_output_path": ".fugue/run/<run-id>/googleworkspace/meeting-prep.json"
+}
+```
+
+Rules:
+
+- `summary` is the only field intended for prompt re-entry
+- `references` carry stable ids for follow-up actions
+- `raw_output_path` points to local evidence, not active prompt context
+- write actions must add a receipt field such as `message_id`, `file_id`, or
+  `event_id`
+
+## Approval Model
+
+### Read Only
+
+- may run during preflight
+- may run during scheduled digests
+- may run during recovery
+- must remain bounded in size
+
+### Write
+
+- must not run during intake
+- should be preceded by `--dry-run` when the underlying `gws` action supports it
+- must require `ok_to_execute=true`
+- must require explicit operator approval
+- must produce a receipt recorded by `Kernel`
+
+## Context Budget Rules
+
+To avoid context pressure:
+
+- prefer `--format table` for direct operator viewing
+- prefer narrow `json` for machine summarization
+- summarize before reinjecting into the sovereign prompt
+- avoid raw schema or tool catalogs in default loops
+- avoid `gws mcp` unless a client cannot consume CLI flows
+
+## Validation Policy
+
+Default validation:
+
+- `scripts/check-peripheral-adapters.sh`
+- `scripts/check-googleworkspace-live.sh`
+
+Current implemented baseline:
+
+- `scripts/lib/orchestrator-nl-hints.sh`
+  - emits Workspace route hints from issue text
+- `scripts/harness/resolve-orchestration-context.sh`
+  - exports Workspace hints and policy-derived phase hints in CI
+- `scripts/local/run-local-orchestration.sh`
+  - stores `googleworkspace-context.json` in each local run directory
+- `scripts/lib/googleworkspace-cli-adapter.sh`
+  - writes raw outputs and `*-meta.json` receipts under `<run-dir>/googleworkspace/`
+  - enforces `ok_to_execute` and explicit human approval on write actions
+- `scripts/harness/googleworkspace-preflight-enrich.sh`
+  - converts readonly Workspace hints into a bounded CI artifact
+  - returns `ok`, `partial`, or `skipped`
+  - degrades to `skipped` when CI credentials are unavailable
+- `.github/workflows/fugue-tutti-caller.yml`
+  - forwards `workspace_*` hints into the reusable Codex implementation workflow
+- `.github/workflows/fugue-codex-implement.yml`
+  - runs readonly Workspace preflight in a dedicated protected-environment job
+  - uploads Workspace artifact and raw evidence alongside existing protocol logs
+  - keeps Workspace credentials out of the main implementation job
+
+Kernel admission rules:
+
+- `googleworkspace-cli-readonly`
+  - cheap smoke is required in the default loop
+- `googleworkspace-cli-write`
+  - smoke is limited to command resolution or `--dry-run`
+  - actual write canaries stay operator-invoked
+
+## Initial Operating Scenarios
+
+### 1. Meeting-Driven Issue
+
+1. Intake detects calendar-related work.
+2. Preflight runs `meeting-prep`.
+3. Kernel writes a short evidence block into the research artifact.
+4. If follow-up material is needed, operator may approve Docs or Gmail writes.
+
+### 2. Morning Operator Brief
+
+1. Scheduler invokes `standup-report`.
+2. If user OAuth is available, also run `gmail-triage` or `weekly-digest`.
+3. Kernel emits one digest artifact and does not mutate state elsewhere.
+
+### 3. Stakeholder Delivery
+
+1. Task reaches `ok_to_execute=true`.
+2. Kernel resolves a dry-run preview for `docs-create`, `drive-upload`, or
+   `gmail-send`.
+3. Operator approves.
+4. Kernel executes and stores artifact ids and receipts in run evidence.
+
+## Non-Goals
+
+- making Google Workspace the source of task state
+- replacing GitHub issue state with Calendar or Gmail state
+- allowing unattended write actions in the default loop
+- forcing session-backed MCP adapters into this same shape
+
+## Next Implementation Steps
+
+1. Add a `Kernel` evidence writer that stores summarized Workspace envelopes
+   under a dedicated run directory.
+2. Add intent-to-action routing in the intake classifier for meeting, inbox,
+   document, and reporting signals.
+3. Add optional read helpers for `drive search`, `docs read`, and `sheets read`
+   to reduce fallback raw API usage.
+4. Add an approval receipt log for Workspace write actions.
+5. Keep CI Workspace auth limited to optional readonly service-account secrets;
+   do not run unattended write actions in reusable workflows.
+6. Require a protected GitHub `Environment` such as `workspace-readonly` before
+   CI can access readonly Workspace credentials.

--- a/scripts/check-googleworkspace-live.sh
+++ b/scripts/check-googleworkspace-live.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+credentials_file=""
+format="json"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/check-googleworkspace-live.sh [options]
+
+Options:
+  --credentials-file <path>   Service account or exported credentials file.
+                              Fallback order when omitted:
+                              FUGUE_GWS_CREDENTIALS_FILE
+                              KERNEL_GWS_CREDENTIALS_FILE
+                              GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE
+  --format <json|table>       Output format (default: json)
+  -h, --help                  Show help.
+EOF
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --credentials-file)
+      credentials_file="${2:-}"
+      shift 2
+      ;;
+    --format)
+      format="${2:-json}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+case "${format}" in
+  json|table) ;;
+  *)
+    fail "invalid --format=${format}"
+    ;;
+esac
+
+if [[ -z "${credentials_file}" ]]; then
+  credentials_file="${FUGUE_GWS_CREDENTIALS_FILE:-${KERNEL_GWS_CREDENTIALS_FILE:-${GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE:-}}}"
+fi
+
+[[ -n "${credentials_file}" ]] || fail "credentials file is required"
+[[ -f "${credentials_file}" ]] || fail "credentials file not found: ${credentials_file}"
+
+require_cmd gws
+require_cmd jq
+require_cmd mktemp
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+results_file="${tmp_dir}/results.jsonl"
+
+classify_result() {
+  local rc="$1"
+  local output_file="$2"
+
+  if [[ "${rc}" == "0" ]]; then
+    if rg -q '^Warning:' "${output_file}"; then
+      printf 'partial\n'
+    else
+      printf 'ok\n'
+    fi
+    return 0
+  fi
+
+  if rg -q 'accessNotConfigured|SERVICE_DISABLED|API not enabled' "${output_file}"; then
+    printf 'blocked\n'
+    return 0
+  fi
+
+  if rg -q 'serviceusage\\.services\\.use|serviceUsageConsumer' "${output_file}"; then
+    printf 'blocked\n'
+    return 0
+  fi
+
+  if rg -q 'FAILED_PRECONDITION|failedPrecondition|Precondition check failed' "${output_file}"; then
+    printf 'blocked\n'
+    return 0
+  fi
+
+  if rg -q 'PERMISSION_DENIED|permission denied' "${output_file}"; then
+    printf 'blocked\n'
+    return 0
+  fi
+
+  printf 'error\n'
+}
+
+extract_reason() {
+  local output_file="$1"
+
+  if rg -q 'gmail.googleapis.com' "${output_file}"; then
+    printf 'gmail_api_disabled\n'
+    return 0
+  fi
+  if rg -q 'drive.googleapis.com' "${output_file}"; then
+    printf 'drive_api_disabled\n'
+    return 0
+  fi
+  if rg -q 'tasks.googleapis.com' "${output_file}"; then
+    printf 'tasks_api_disabled\n'
+    return 0
+  fi
+  if rg -q 'calendar' "${output_file}"; then
+    printf 'calendar_related\n'
+    return 0
+  fi
+  if rg -q 'PERMISSION_DENIED|permission denied' "${output_file}"; then
+    printf 'permission_denied\n'
+    return 0
+  fi
+  if rg -q 'serviceusage\\.services\\.use|serviceUsageConsumer' "${output_file}"; then
+    printf 'serviceusage_consumer_missing\n'
+    return 0
+  fi
+  if rg -q 'FAILED_PRECONDITION|failedPrecondition|Precondition check failed' "${output_file}"; then
+    printf 'failed_precondition\n'
+    return 0
+  fi
+  if rg -q 'No upcoming meetings found' "${output_file}"; then
+    printf 'no_upcoming_meetings\n'
+    return 0
+  fi
+  printf 'unknown\n'
+}
+
+run_check() {
+  local id="$1"
+  local description="$2"
+  shift 2
+
+  local output_file="${tmp_dir}/${id}.out"
+  local rc=0
+
+  set +e
+  env -u GOOGLE_API_KEY \
+    -u GOOGLE_APPLICATION_CREDENTIALS \
+    -u GOOGLE_CLOUD_PROJECT \
+    -u GCLOUD_PROJECT \
+    -u GOOGLE_CREDENTIALS_PATH \
+    GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE="${credentials_file}" \
+    "$@" >"${output_file}" 2>&1
+  rc=$?
+  set -e
+
+  local status
+  status="$(classify_result "${rc}" "${output_file}")"
+  local reason
+  reason="$(extract_reason "${output_file}")"
+
+  jq -cn \
+    --arg id "${id}" \
+    --arg description "${description}" \
+    --arg status "${status}" \
+    --arg reason "${reason}" \
+    --arg command "$(printf '%q ' "$@")" \
+    '{
+      id:$id,
+      description:$description,
+      status:$status,
+      reason:$reason,
+      command:$command
+    }' >> "${results_file}"
+}
+
+run_check "calendar_raw" "Direct calendar list" \
+  gws calendar calendarList list --params '{"maxResults":1}' --format json
+run_check "meeting_prep" "Next meeting workflow" \
+  gws workflow +meeting-prep --format json
+run_check "standup_report" "Meetings plus tasks workflow" \
+  gws workflow +standup-report --format json
+run_check "weekly_digest" "Meetings plus unread mail workflow" \
+  gws workflow +weekly-digest --format json
+run_check "drive_list" "Drive file listing" \
+  gws drive files list --params '{"pageSize":1}' --format json
+run_check "gmail_triage" "Unread inbox triage" \
+  gws gmail +triage --max 1 --format json
+
+if [[ "${format}" == "table" ]]; then
+  jq -r '[.id, .status, .reason, .description] | @tsv' "${results_file}" \
+    | awk 'BEGIN { print "id\tstatus\treason\tdescription" } { print }'
+  exit 0
+fi
+
+jq -s \
+  --arg credentials_file "${credentials_file}" \
+  '{
+    credentials_file:$credentials_file,
+    checks:.
+  }' "${results_file}"

--- a/scripts/harness/codex-execute-validate.sh
+++ b/scripts/harness/codex-execute-validate.sh
@@ -79,6 +79,9 @@ lessons_report=".fugue/pre-implement/lessons.md"
 research_report="${RESEARCH_REPORT_PATH:-.fugue/pre-implement/issue-${ISSUE_NUMBER}-research.md}"
 plan_report="${PLAN_REPORT_PATH:-.fugue/pre-implement/issue-${ISSUE_NUMBER}-plan.md}"
 critic_report="${CRITIC_REPORT_PATH:-.fugue/pre-implement/issue-${ISSUE_NUMBER}-critic.md}"
+workspace_report="${WORKSPACE_REPORT_PATH:-}"
+workspace_summary="$(printf '%s' "${WORKSPACE_SUMMARY:-}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^[[:space:]]+|[[:space:]]+$//g')"
+workspace_preflight_status="$(echo "${WORKSPACE_PREFLIGHT_STATUS:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
 title_text="$(printf '%s\n' "${ISSUE_TITLE}" | tr '[:upper:]' '[:lower:]')"
 goal_text="$(printf '%s\n' "${ISSUE_BODY}" | awk '
   BEGIN { capture=0 }
@@ -92,6 +95,20 @@ if [[ "${LARGE_REFACTOR_LABEL:-false}" == "true" ]]; then
   is_large_refactor="true"
 elif echo "${task_signal_text}" | grep -Eqi '(大規模|全面|全体|リファクタ|refactor|migration|rewrite|アーキテクチャ刷新)'; then
   is_large_refactor="true"
+fi
+workspace_instruction=""
+if [[ -n "${workspace_report}" || -n "${workspace_summary}" || -n "${workspace_preflight_status}" ]]; then
+  workspace_instruction="$(cat <<EOF
+
+## Google Workspace peripheral evidence
+- Treat Google Workspace only as supplementary peripheral evidence.
+- Do not treat Workspace artifacts as control-plane truth.
+- Workspace preflight status: ${workspace_preflight_status:-none}
+- Workspace report path: ${workspace_report:-none}
+- Workspace summary: ${workspace_summary:-none}
+- Use Workspace evidence only to enrich context, coordination, and stakeholder-facing artifacts.
+EOF
+)"
 fi
 
 # Build instruction from issue
@@ -166,6 +183,7 @@ ${ISSUE_BODY}
   - Preventive rule
   - Trigger signal
 - Before finalizing, include concrete verification evidence (tests, logs, or behavioral diff).
+${workspace_instruction}
 
 ## Rules
 - Implement the changes described above

--- a/scripts/harness/googleworkspace-preflight-enrich.sh
+++ b/scripts/harness/googleworkspace-preflight-enrich.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ISSUE_NUMBER="${ISSUE_NUMBER:-}"
+ISSUE_TITLE="${ISSUE_TITLE:-}"
+ISSUE_BODY="${ISSUE_BODY:-}"
+WORKSPACE_ACTIONS="${WORKSPACE_ACTIONS:-}"
+WORKSPACE_DOMAINS="${WORKSPACE_DOMAINS:-}"
+WORKSPACE_REASON="${WORKSPACE_REASON:-}"
+WORKSPACE_SUGGESTED_PHASES="${WORKSPACE_SUGGESTED_PHASES:-}"
+OUT_DIR="${OUT_DIR:-.fugue/pre-implement}"
+RUN_DIR="${RUN_DIR:-${OUT_DIR}/googleworkspace-run}"
+REPORT_PATH="${REPORT_PATH:-${OUT_DIR}/issue-${ISSUE_NUMBER}-googleworkspace.md}"
+ADAPTER="${ADAPTER:-scripts/lib/googleworkspace-cli-adapter.sh}"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
+append_csv_unique() {
+  local current="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    printf '%s' "${current}"
+    return 0
+  fi
+  case ",${current}," in
+    *,"${value}",*)
+      printf '%s' "${current}"
+      ;;
+    *)
+      if [[ -z "${current}" ]]; then
+        printf '%s' "${value}"
+      else
+        printf '%s,%s' "${current}" "${value}"
+      fi
+      ;;
+  esac
+}
+
+sanitize_summary() {
+  printf '%s' "${1:-}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^[[:space:]]+|[[:space:]]+$//g'
+}
+
+extract_summary() {
+  local action="$1"
+  local raw_file="$2"
+  if [[ ! -s "${raw_file}" ]]; then
+    printf ''
+    return 0
+  fi
+  if ! jq empty "${raw_file}" >/dev/null 2>&1; then
+    head -c 300 "${raw_file}" | tr '\n' ' '
+    return 0
+  fi
+  case "${action}" in
+    meeting-prep)
+      jq -r '(.summary // ("meetingCount=" + ((.meetingCount // 0)|tostring)))' "${raw_file}" 2>/dev/null || true
+      ;;
+    standup-report)
+      jq -r '(.summary // ("meetings=" + ((.meetingCount // (.meetings|length) // 0)|tostring)))' "${raw_file}" 2>/dev/null || true
+      ;;
+    weekly-digest)
+      jq -r '(.summary // ("meetingCount=" + ((.meetingCount // 0)|tostring) + ", unreadEmails=" + ((.unreadEmails // 0)|tostring)))' "${raw_file}" 2>/dev/null || true
+      ;;
+    gmail-triage)
+      jq -r '("resultSizeEstimate=" + ((.resultSizeEstimate // 0)|tostring))' "${raw_file}" 2>/dev/null || true
+      ;;
+    *)
+      jq -r '(.summary // .message // .status // "ok")' "${raw_file}" 2>/dev/null || true
+      ;;
+  esac
+}
+
+require_cmd jq
+[[ -n "${ISSUE_NUMBER}" ]] || fail "ISSUE_NUMBER is required"
+[[ -x "${ADAPTER}" ]] || fail "adapter missing or not executable: ${ADAPTER}"
+
+mkdir -p "${OUT_DIR}" "${RUN_DIR}"
+
+credentials_file="${GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE:-}"
+tmp_credentials=""
+if [[ -z "${credentials_file}" && -n "${GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON:-}" ]]; then
+  tmp_credentials="$(mktemp)"
+  printf '%s' "${GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON}" > "${tmp_credentials}"
+  credentials_file="${tmp_credentials}"
+fi
+credentials_available="false"
+if [[ -n "${credentials_file}" ]]; then
+  credentials_available="true"
+elif [[ -f "${HOME}/.config/gws/credentials.enc" && -f "${HOME}/.config/gws/client_secret.json" ]]; then
+  credentials_available="true"
+fi
+
+cleanup() {
+  if [[ -n "${tmp_credentials}" && -f "${tmp_credentials}" ]]; then
+    rm -f "${tmp_credentials}"
+  fi
+}
+trap cleanup EXIT
+
+actions_csv=""
+IFS=',' read -r -a requested_actions <<< "${WORKSPACE_ACTIONS}"
+for action in "${requested_actions[@]}"; do
+  action="$(printf '%s' "${action}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+  case "${action}" in
+    meeting-prep|standup-report|weekly-digest|gmail-triage)
+      actions_csv="$(append_csv_unique "${actions_csv}" "${action}")"
+      ;;
+  esac
+done
+
+report_status="ok"
+summary_csv=""
+rows=()
+
+if [[ -z "${actions_csv}" ]]; then
+  report_status="skipped"
+  rows+=("| none | skipped | No readonly Google Workspace action was suggested. |")
+  summary_csv="No readonly Google Workspace action was suggested."
+elif [[ "${credentials_available}" != "true" ]]; then
+  report_status="skipped"
+  rows+=("| auth | skipped | No Google Workspace credentials were available for readonly preflight. |")
+  summary_csv="No Google Workspace credentials were available for readonly preflight."
+else
+  IFS=',' read -r -a actions <<< "${actions_csv}"
+  for action in "${actions[@]}"; do
+    stdout_file="$(mktemp)"
+    stderr_file="$(mktemp)"
+    set +e
+    if [[ -n "${credentials_file}" ]]; then
+      bash "${ADAPTER}" \
+        --action "${action}" \
+        --format json \
+        --run-dir "${RUN_DIR}" \
+        --credentials-file "${credentials_file}" \
+        > "${stdout_file}" 2> "${stderr_file}"
+    else
+      bash "${ADAPTER}" \
+        --action "${action}" \
+        --format json \
+        --run-dir "${RUN_DIR}" \
+        > "${stdout_file}" 2> "${stderr_file}"
+    fi
+    rc=$?
+    set -e
+
+    meta_file="${RUN_DIR}/googleworkspace/${action}-meta.json"
+    raw_file="${RUN_DIR}/googleworkspace/${action}.json"
+    status="error"
+    message="command failed"
+    if [[ -f "${meta_file}" ]]; then
+      status="$(jq -r '.status // "error"' "${meta_file}")"
+      message="$(jq -r '.message // ""' "${meta_file}")"
+    fi
+    summary="$(sanitize_summary "$(extract_summary "${action}" "${raw_file}")")"
+    if [[ -z "${summary}" ]]; then
+      summary="$(sanitize_summary "$(head -c 300 "${stderr_file}")")"
+    fi
+    if [[ -z "${summary}" ]]; then
+      summary="${message}"
+    fi
+    rows+=("| ${action} | ${status} | ${summary} |")
+
+    if [[ "${status}" == "ok" ]]; then
+      summary_csv="$(append_csv_unique "${summary_csv}" "${action}: ${summary}")"
+    elif [[ "${status}" == "error" && "${report_status}" == "ok" ]]; then
+      report_status="partial"
+    fi
+    if (( rc != 0 )) && [[ "${report_status}" == "ok" ]]; then
+      report_status="partial"
+    fi
+
+    rm -f "${stdout_file}" "${stderr_file}"
+  done
+fi
+
+if [[ -z "${summary_csv}" ]]; then
+  summary_csv="No successful Google Workspace preflight result."
+fi
+
+{
+  echo "# Issue #${ISSUE_NUMBER} Google Workspace Artifact"
+  echo
+  echo "- status: ${report_status}"
+  echo "- issue: ${ISSUE_TITLE}"
+  echo "- suggested phases: ${WORKSPACE_SUGGESTED_PHASES:-none}"
+  echo "- actions: ${actions_csv:-none}"
+  echo "- domains: ${WORKSPACE_DOMAINS:-none}"
+  echo "- reason: ${WORKSPACE_REASON:-none}"
+  echo "- run dir: ${RUN_DIR}"
+  echo
+  echo "## Summary"
+  echo
+  echo "${summary_csv}"
+  echo
+  echo "## Action Results"
+  echo
+  echo "| action | status | summary |"
+  echo "|---|---|---|"
+  printf '%s\n' "${rows[@]}"
+  echo
+  echo "## Notes"
+  echo
+  echo "- Google Workspace remains peripheral evidence, not control-plane truth."
+  echo "- Errors on Gmail actions under service-account mode are expected when mailbox access is unavailable."
+} > "${REPORT_PATH}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "workspace_preflight_status=${report_status}"
+    echo "workspace_report_path=${REPORT_PATH}"
+    echo "workspace_run_dir=${RUN_DIR}"
+    echo "workspace_summary<<EOF"
+    echo "${summary_csv}"
+    echo "EOF"
+  } >> "${GITHUB_OUTPUT}"
+fi

--- a/scripts/harness/resolve-orchestration-context.sh
+++ b/scripts/harness/resolve-orchestration-context.sh
@@ -69,6 +69,15 @@ normalize_multi_agent_mode() {
   esac
 }
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEFAULT_MAIN_ORCHESTRATOR_PROVIDER="${DEFAULT_MAIN_ORCHESTRATOR_PROVIDER:-codex}"
+DEFAULT_ASSIST_ORCHESTRATOR_PROVIDER="${DEFAULT_ASSIST_ORCHESTRATOR_PROVIDER:-claude}"
+CLAUDE_MAIN_ASSIST_POLICY="${CLAUDE_MAIN_ASSIST_POLICY:-codex}"
+CLAUDE_DEGRADED_ASSIST_POLICY="${CLAUDE_DEGRADED_ASSIST_POLICY:-claude}"
+CLAUDE_ROLE_POLICY="${CLAUDE_ROLE_POLICY:-flex}"
+CLAUDE_TRANSLATOR_MODEL="${CLAUDE_TRANSLATOR_MODEL:-claude-sonnet-4-6}"
+GOOGLEWORKSPACE_KERNEL_POLICY="${ROOT_DIR}/config/integrations/googleworkspace-kernel-policy.json"
+
 ISSUE_NUMBER=""
 if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
   ISSUE_NUMBER="${ISSUE_NUMBER_FROM_DISPATCH}"
@@ -209,10 +218,49 @@ if [[ -z "${body_assist_provider}" ]]; then
 fi
 
 eval "$(
-  scripts/lib/orchestrator-nl-hints.sh \
+  "${ROOT_DIR}/scripts/lib/orchestrator-nl-hints.sh" \
     --title "${title}" \
     --body "${body}"
 )"
+
+workspace_suggested_phases=""
+workspace_readonly_actions=""
+workspace_approval_required_actions=""
+if [[ -f "${GOOGLEWORKSPACE_KERNEL_POLICY}" ]]; then
+  workspace_policy_json="$(jq -cn \
+    --arg action_hint "${workspace_action_hint}" \
+    --arg domain_hint "${workspace_domain_hint}" \
+    --arg reason "${workspace_reason}" \
+    --arg hint_applied "${workspace_hint_applied}" \
+    --slurpfile policy "${GOOGLEWORKSPACE_KERNEL_POLICY}" \
+    '($action_hint | split(",") | map(select(length > 0))) as $actions
+     | ($domain_hint | split(",") | map(select(length > 0))) as $domains
+     | {
+         workspace_hint_applied: ($hint_applied == "true"),
+         workspace_action_hint: $action_hint,
+         workspace_domain_hint: $domain_hint,
+         workspace_reason: $reason,
+         suggested_actions: $actions,
+         suggested_domains: $domains,
+         suggested_phases: (
+           $actions
+           | map($policy[0].action_policy[.]?.default_phase)
+           | map(select(. != null))
+           | unique
+         ),
+         readonly_actions: (
+           $actions
+           | map(select(($policy[0].action_policy[.]?.side_effect // false) | not))
+         ),
+         approval_required_actions: (
+           $actions
+           | map(select(($policy[0].action_policy[.]?.side_effect // false) == true))
+         )
+       }')"
+  workspace_suggested_phases="$(echo "${workspace_policy_json}" | jq -r '.suggested_phases | join(",")')"
+  workspace_readonly_actions="$(echo "${workspace_policy_json}" | jq -r '.readonly_actions | join(",")')"
+  workspace_approval_required_actions="$(echo "${workspace_policy_json}" | jq -r '.approval_required_actions | join(",")')"
+fi
 
 requested_main_provider="${label_main_provider}"
 main_provider_source="label"
@@ -225,7 +273,7 @@ if [[ -z "${requested_main_provider}" && -n "${nl_main_hint}" ]]; then
   main_provider_source="body-natural-language"
 fi
 if [[ -z "${requested_main_provider}" ]]; then
-  requested_main_provider="${DEFAULT_MAIN_ORCHESTRATOR_PROVIDER:-codex}"
+  requested_main_provider="${DEFAULT_MAIN_ORCHESTRATOR_PROVIDER}"
   main_provider_source="default"
 fi
 requested_main_provider="$(echo "${requested_main_provider}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
@@ -284,12 +332,12 @@ if [[ -n "${label_assist_provider}" || -n "${body_assist_provider}" || -n "${nl_
   assist_explicit="true"
 fi
 if [[ -z "${requested_assist_provider}" ]]; then
-  requested_assist_provider="${DEFAULT_ASSIST_ORCHESTRATOR_PROVIDER:-claude}"
+  requested_assist_provider="${DEFAULT_ASSIST_ORCHESTRATOR_PROVIDER}"
   assist_provider_source="default"
 fi
 requested_assist_provider="$(echo "${requested_assist_provider}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
 if [[ "${requested_assist_provider}" != "claude" && "${requested_assist_provider}" != "codex" && "${requested_assist_provider}" != "none" ]]; then
-  requested_assist_provider="${DEFAULT_ASSIST_ORCHESTRATOR_PROVIDER:-claude}"
+  requested_assist_provider="${DEFAULT_ASSIST_ORCHESTRATOR_PROVIDER}"
   assist_provider_source="default"
 fi
 
@@ -352,9 +400,9 @@ translation_payload=""
 normalized_text="$(printf '%s\n\n%s\n' "${title}" "${body}" | head -c "${max_chars_raw}")"
 CODEX_MAIN_MODEL="$(echo "${CODEX_MAIN_MODEL:-gpt-5.4}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
 CODEX_MULTI_AGENT_MODEL="$(echo "${CODEX_MULTI_AGENT_MODEL:-gpt-5.3-codex-spark}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-if [[ -x "scripts/lib/model-policy.sh" ]]; then
+if [[ -x "${ROOT_DIR}/scripts/lib/model-policy.sh" ]]; then
   eval "$(
-    scripts/lib/model-policy.sh \
+    "${ROOT_DIR}/scripts/lib/model-policy.sh" \
       --codex-main-model "${CODEX_MAIN_MODEL}" \
       --codex-multi-agent-model "${CODEX_MULTI_AGENT_MODEL}" \
       --claude-model "claude-sonnet-4-6" \
@@ -369,10 +417,6 @@ if [[ -x "scripts/lib/model-policy.sh" ]]; then
 elif ! [[ "${CODEX_MULTI_AGENT_MODEL}" =~ ^gpt-5(\.[0-9]+)?-codex-spark$ ]]; then
   CODEX_MULTI_AGENT_MODEL="gpt-5.3-codex-spark"
 fi
-if [[ "${CLAUDE_TRANSLATOR_MODEL}" != "claude-sonnet-4-6" ]]; then
-  CLAUDE_TRANSLATOR_MODEL="claude-sonnet-4-6"
-fi
-
 if [[ "${translator_mode}" != "off" && -n "${OPENAI_API_KEY:-}" ]]; then
   judge_sys_prompt="You are Codex Orchestrator gate. Decide if Claude translation should be inserted before orchestration. Return ONLY compact JSON: {\"score\":0-100,\"should_translate\":true|false,\"reason\":\"short\",\"signals\":[\"...\"]}."
   judge_user_prompt="Analyze this issue text for ambiguity/conflict/risk/implicit constraints. Prioritize translation when requirements are unclear, mixed-language, or high-risk refactor/migration. Text:\n${normalized_text}"
@@ -561,7 +605,7 @@ elif [[ "${translation_gate_decision}" == "true" ]]; then
 fi
 
 eval "$(
-  scripts/lib/orchestrator-policy.sh \
+  "${ROOT_DIR}/scripts/lib/orchestrator-policy.sh" \
     --main "${requested_main_provider_initial}" \
     --assist "${requested_assist_provider}" \
     --default-main "${DEFAULT_MAIN_ORCHESTRATOR_PROVIDER}" \
@@ -656,9 +700,9 @@ claude_teams_reason="policy-script-missing"
 claude_teams_collaboration_signal="false"
 claude_teams_member_cap="3"
 claude_teams_max_invocations="1"
-if [[ -x "scripts/lib/claude-teams-policy.sh" ]]; then
+if [[ -x "${ROOT_DIR}/scripts/lib/claude-teams-policy.sh" ]]; then
   eval "$(
-    scripts/lib/claude-teams-policy.sh \
+    "${ROOT_DIR}/scripts/lib/claude-teams-policy.sh" \
       --task-size-tier "${task_size_tier}" \
       --risk-tier "${risk_tier}" \
       --claude-state "${claude_state}" \
@@ -734,7 +778,7 @@ if [[ "${assist_explicit}" != "true" && "${force_claude}" != "true" && "${reques
   fi
 fi
 eval "$(
-  scripts/lib/orchestrator-policy.sh \
+  "${ROOT_DIR}/scripts/lib/orchestrator-policy.sh" \
     --main "${requested_main_provider_initial}" \
     --assist "${requested_assist_provider}" \
     --default-main "${DEFAULT_MAIN_ORCHESTRATOR_PROVIDER}" \
@@ -828,6 +872,13 @@ fi
   echo "nl_main_reason=${nl_main_reason}"
   echo "nl_assist_reason=${nl_assist_reason}"
   echo "nl_inference_skipped_reason=${nl_inference_skipped_reason}"
+  echo "workspace_hint_applied=${workspace_hint_applied}"
+  echo "workspace_action_hint=${workspace_action_hint}"
+  echo "workspace_domain_hint=${workspace_domain_hint}"
+  echo "workspace_reason=${workspace_reason}"
+  echo "workspace_suggested_phases=${workspace_suggested_phases}"
+  echo "workspace_readonly_actions=${workspace_readonly_actions}"
+  echo "workspace_approval_required_actions=${workspace_approval_required_actions}"
   echo "claude_fallback_applied=${main_claude_fallback_applied}"
   echo "claude_fallback_reason=${main_claude_fallback_reason}"
   echo "main_claude_fallback_applied=${main_claude_fallback_applied}"

--- a/scripts/lib/googleworkspace-cli-adapter.sh
+++ b/scripts/lib/googleworkspace-cli-adapter.sh
@@ -1,0 +1,523 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+action=""
+format="table"
+calendar="primary"
+max_results="10"
+credentials_file=""
+resolve_only="false"
+dry_run="false"
+email_to=""
+subject=""
+body=""
+file_path=""
+target_name=""
+parent_id=""
+event_json=""
+title=""
+document_id=""
+spreadsheet_id=""
+sheet_range=""
+values_json=""
+text=""
+run_dir=""
+ok_to_execute="false"
+human_approved="false"
+
+usage() {
+  cat <<'EOF'
+Usage: googleworkspace-cli-adapter.sh --action <id> [options]
+
+Actions:
+  smoke
+  gmail-triage
+  gmail-send
+  drive-upload
+  calendar-insert
+  docs-create
+  docs-insert-text
+  sheets-create
+  sheets-append
+  meeting-prep
+  standup-report
+  weekly-digest
+
+Options:
+  --format <json|table|yaml|csv>   Output format for gws workflow commands.
+  --calendar <id>                  Calendar ID for meeting-prep (default: primary).
+  --max <n>                        Max unread items for gmail-triage (default: 10).
+  --to <email>                     Recipient email for gmail-send.
+  --subject <text>                 Subject for gmail-send.
+  --body <text>                    Body for gmail-send.
+  --file <path>                    Local file path for drive-upload.
+  --name <text>                    Optional target filename for drive-upload.
+  --parent <id>                    Optional parent folder ID for drive-upload.
+  --event-json <json>              Calendar event JSON body for calendar-insert.
+  --title <text>                   Title for docs-create or sheets-create.
+  --document-id <id>               Document ID for docs-insert-text.
+  --spreadsheet-id <id>            Spreadsheet ID for sheets-append.
+  --range <a1>                     A1 range for sheets-append.
+  --values-json <json>             Sheets values JSON body for sheets-append.
+  --text <text>                    Text payload for docs-insert-text.
+  --run-dir <path>                 Write raw outputs and receipt metadata under <run-dir>/googleworkspace.
+  --ok-to-execute <true|false>     Gate write actions on Kernel approval state.
+  --human-approved <true|false>    Gate write actions on explicit human approval.
+  --credentials-file <path>        Use a specific service account or exported credential file.
+                                   Fallback order when omitted:
+                                   FUGUE_GWS_CREDENTIALS_FILE
+                                   KERNEL_GWS_CREDENTIALS_FILE
+                                   GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE
+  --resolve-only                   Print the resolved gws command and exit.
+  --dry-run                        For write actions, pass through to gws. For read-only actions, alias for --resolve-only.
+  -h, --help                       Show this help.
+EOF
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+validate_positive_int() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]] || fail "expected positive integer, got: $1"
+}
+
+require_non_empty() {
+  local value="$1"
+  local label="$2"
+  [[ -n "${value}" ]] || fail "${label} is required"
+}
+
+normalize_bool() {
+  local value
+  value="$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+  if [[ "${value}" == "true" ]]; then
+    printf 'true'
+  else
+    printf 'false'
+  fi
+}
+
+is_write_action() {
+  case "${1:-}" in
+    gmail-send|drive-upload|calendar-insert|docs-create|docs-insert-text|sheets-create|sheets-append)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+format_extension() {
+  case "${1:-table}" in
+    json)
+      printf 'json'
+      ;;
+    yaml)
+      printf 'yaml'
+      ;;
+    csv)
+      printf 'csv'
+      ;;
+    *)
+      printf 'txt'
+      ;;
+  esac
+}
+
+print_command() {
+  local cmd=("$@")
+  if [[ -n "${credentials_file}" ]]; then
+    printf 'env -u GOOGLE_API_KEY -u GOOGLE_APPLICATION_CREDENTIALS -u GOOGLE_CLOUD_PROJECT -u GCLOUD_PROJECT -u GOOGLE_CREDENTIALS_PATH GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=%q ' "${credentials_file}"
+  fi
+  printf '%q' "${cmd[0]}"
+  local i
+  for (( i = 1; i < ${#cmd[@]}; i++ )); do
+    printf ' %q' "${cmd[i]}"
+  done
+  printf '\n'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --action)
+      action="${2:-}"
+      shift 2
+      ;;
+    --format)
+      format="${2:-table}"
+      shift 2
+      ;;
+    --calendar)
+      calendar="${2:-primary}"
+      shift 2
+      ;;
+    --max)
+      max_results="${2:-10}"
+      shift 2
+      ;;
+    --to)
+      email_to="${2:-}"
+      shift 2
+      ;;
+    --subject)
+      subject="${2:-}"
+      shift 2
+      ;;
+    --body)
+      body="${2:-}"
+      shift 2
+      ;;
+    --file)
+      file_path="${2:-}"
+      shift 2
+      ;;
+    --name)
+      target_name="${2:-}"
+      shift 2
+      ;;
+    --parent)
+      parent_id="${2:-}"
+      shift 2
+      ;;
+    --event-json)
+      event_json="${2:-}"
+      shift 2
+      ;;
+    --title)
+      title="${2:-}"
+      shift 2
+      ;;
+    --document-id)
+      document_id="${2:-}"
+      shift 2
+      ;;
+    --spreadsheet-id)
+      spreadsheet_id="${2:-}"
+      shift 2
+      ;;
+    --range)
+      sheet_range="${2:-}"
+      shift 2
+      ;;
+    --values-json)
+      values_json="${2:-}"
+      shift 2
+      ;;
+    --text)
+      text="${2:-}"
+      shift 2
+      ;;
+    --run-dir)
+      run_dir="${2:-}"
+      shift 2
+      ;;
+    --ok-to-execute)
+      ok_to_execute="${2:-false}"
+      shift 2
+      ;;
+    --human-approved)
+      human_approved="${2:-false}"
+      shift 2
+      ;;
+    --credentials-file)
+      credentials_file="${2:-}"
+      shift 2
+      ;;
+    --resolve-only)
+      resolve_only="true"
+      shift
+      ;;
+    --dry-run)
+      dry_run="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+[[ -n "${action}" ]] || fail "--action is required"
+
+case "${format}" in
+  json|table|yaml|csv) ;;
+  *)
+    fail "invalid --format=${format}"
+    ;;
+esac
+
+validate_positive_int "${max_results}"
+ok_to_execute="$(normalize_bool "${ok_to_execute}")"
+human_approved="$(normalize_bool "${human_approved}")"
+
+if [[ -z "${credentials_file}" ]]; then
+  credentials_file="${FUGUE_GWS_CREDENTIALS_FILE:-${KERNEL_GWS_CREDENTIALS_FILE:-${GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE:-}}}"
+fi
+
+if [[ -n "${credentials_file}" && ! -f "${credentials_file}" ]]; then
+  fail "credentials file not found: ${credentials_file}"
+fi
+
+if [[ -n "${run_dir}" && "${run_dir}" != /* ]]; then
+  run_dir="$(cd "${PWD}" && pwd)/${run_dir}"
+fi
+
+cmd=()
+case "${action}" in
+  smoke)
+    cmd=(gws --help)
+    ;;
+  gmail-triage)
+    cmd=(gws gmail +triage --max "${max_results}" --format "${format}")
+    ;;
+  gmail-send)
+    require_non_empty "${email_to}" "--to"
+    require_non_empty "${subject}" "--subject"
+    require_non_empty "${body}" "--body"
+    cmd=(gws gmail +send --to "${email_to}" --subject "${subject}" --body "${body}" --format "${format}")
+    if [[ "${dry_run}" == "true" ]]; then
+      cmd+=(--dry-run)
+    fi
+    ;;
+  drive-upload)
+    require_non_empty "${file_path}" "--file"
+    [[ -f "${file_path}" ]] || fail "file not found: ${file_path}"
+    cmd=(gws drive +upload "${file_path}" --format "${format}")
+    if [[ -n "${target_name}" ]]; then
+      cmd+=(--name "${target_name}")
+    fi
+    if [[ -n "${parent_id}" ]]; then
+      cmd+=(--parent "${parent_id}")
+    fi
+    if [[ "${dry_run}" == "true" ]]; then
+      cmd+=(--dry-run)
+    fi
+    ;;
+  calendar-insert)
+    require_non_empty "${event_json}" "--event-json"
+    cmd=(gws calendar events insert --params "{\"calendarId\":\"${calendar}\"}" --json "${event_json}" --format "${format}")
+    if [[ "${dry_run}" == "true" ]]; then
+      cmd+=(--dry-run)
+    fi
+    ;;
+  docs-create)
+    require_non_empty "${title}" "--title"
+    cmd=(gws docs documents create --json "{\"title\":\"${title}\"}" --format "${format}")
+    ;;
+  docs-insert-text)
+    require_non_empty "${document_id}" "--document-id"
+    require_non_empty "${text}" "--text"
+    cmd=(gws docs documents batchUpdate --params "{\"documentId\":\"${document_id}\"}" --json "{\"requests\":[{\"insertText\":{\"location\":{\"index\":1},\"text\":\"${text}\"}}]}" --format "${format}")
+    ;;
+  sheets-create)
+    require_non_empty "${title}" "--title"
+    cmd=(gws sheets spreadsheets create --json "{\"properties\":{\"title\":\"${title}\"}}" --format "${format}")
+    ;;
+  sheets-append)
+    require_non_empty "${spreadsheet_id}" "--spreadsheet-id"
+    require_non_empty "${sheet_range}" "--range"
+    require_non_empty "${values_json}" "--values-json"
+    cmd=(gws sheets spreadsheets values append --params "{\"spreadsheetId\":\"${spreadsheet_id}\",\"range\":\"${sheet_range}\",\"valueInputOption\":\"RAW\"}" --json "${values_json}" --format "${format}")
+    ;;
+  meeting-prep)
+    cmd=(gws workflow +meeting-prep --calendar "${calendar}" --format "${format}")
+    ;;
+  standup-report)
+    cmd=(gws workflow +standup-report --format "${format}")
+    ;;
+  weekly-digest)
+    cmd=(gws workflow +weekly-digest --format "${format}")
+    ;;
+  *)
+    fail "unsupported --action=${action}"
+    ;;
+esac
+
+write_action="false"
+if is_write_action "${action}"; then
+  write_action="true"
+fi
+
+resolved_command="$(print_command "${cmd[@]}")"
+gw_dir=""
+raw_output_path=""
+stderr_output_path=""
+meta_output_path=""
+if [[ -n "${run_dir}" ]]; then
+  gw_dir="${run_dir%/}/googleworkspace"
+  mkdir -p "${gw_dir}"
+  output_ext="$(format_extension "${format}")"
+  raw_output_path="${gw_dir}/${action}.${output_ext}"
+  stderr_output_path="${gw_dir}/${action}.stderr.log"
+  meta_output_path="${gw_dir}/${action}-meta.json"
+fi
+
+write_meta() {
+  local status="$1"
+  local exit_code="$2"
+  local message="$3"
+  local receipt_json="${4:-}"
+  if [[ -z "${receipt_json}" ]]; then
+    receipt_json='{}'
+  fi
+  [[ -n "${meta_output_path}" ]] || return 0
+  jq -n \
+    --arg action "${action}" \
+    --arg status "${status}" \
+    --arg message "${message}" \
+    --arg format "${format}" \
+    --arg command "${resolved_command}" \
+    --arg credentials_file "${credentials_file}" \
+    --arg run_dir "${run_dir}" \
+    --arg raw_output_path "${raw_output_path}" \
+    --arg stderr_output_path "${stderr_output_path}" \
+    --arg ok_to_execute "${ok_to_execute}" \
+    --arg human_approved "${human_approved}" \
+    --arg write_action "${write_action}" \
+    --argjson exit_code "${exit_code}" \
+    --argjson receipt "${receipt_json}" \
+    '{
+      action:$action,
+      status:$status,
+      message:$message,
+      format:$format,
+      command:$command,
+      credentials_file:(if $credentials_file == "" then null else $credentials_file end),
+      run_dir:(if $run_dir == "" then null else $run_dir end),
+      raw_output_path:(if $raw_output_path == "" then null else $raw_output_path end),
+      stderr_output_path:(if $stderr_output_path == "" then null else $stderr_output_path end),
+      ok_to_execute:($ok_to_execute == "true"),
+      human_approved:($human_approved == "true"),
+      side_effect:($write_action == "true"),
+      exit_code:$exit_code,
+      receipt:$receipt
+    }' > "${meta_output_path}"
+}
+
+extract_receipt() {
+  local output_file="$1"
+  if [[ "${format}" != "json" || ! -s "${output_file}" ]]; then
+    printf '{}'
+    return 0
+  fi
+  if ! jq empty "${output_file}" >/dev/null 2>&1; then
+    printf '{}'
+    return 0
+  fi
+  jq -c '
+    if type == "object" then
+      {
+        id: (.id // null),
+        documentId: (.documentId // null),
+        spreadsheetId: (.spreadsheetId // null),
+        updatedRange: (.updatedRange // .updates.updatedRange // null)
+      } | with_entries(select(.value != null and .value != ""))
+    else
+      {}
+    end
+  ' "${output_file}"
+}
+
+if [[ "${resolve_only}" == "true" ]]; then
+  write_meta "resolved" 0 "resolved command" "{}"
+  print_command "${cmd[@]}"
+  exit 0
+fi
+
+if [[ "${dry_run}" == "true" ]]; then
+  case "${action}" in
+    smoke|gmail-triage|meeting-prep|standup-report|weekly-digest)
+      write_meta "resolved" 0 "dry-run resolved command" "{}"
+      print_command "${cmd[@]}"
+      exit 0
+      ;;
+  esac
+fi
+
+if [[ "${write_action}" == "true" && "${dry_run}" != "true" ]]; then
+  if [[ "${ok_to_execute}" != "true" || "${human_approved}" != "true" ]]; then
+    write_meta "skipped" 4 "write action blocked by approval gate" "{}"
+    echo "ERROR: write action requires --ok-to-execute true and --human-approved true" >&2
+    exit 4
+  fi
+fi
+
+require_cmd gws
+
+if [[ "${action}" == "smoke" ]]; then
+  if [[ -n "${credentials_file}" ]]; then
+    env -u GOOGLE_API_KEY \
+      -u GOOGLE_APPLICATION_CREDENTIALS \
+      -u GOOGLE_CLOUD_PROJECT \
+      -u GCLOUD_PROJECT \
+      -u GOOGLE_CREDENTIALS_PATH \
+      GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE="${credentials_file}" \
+      "${cmd[@]}" >/dev/null
+  else
+    "${cmd[@]}" >/dev/null
+  fi
+  write_meta "ok" 0 "adapter ready" "{}"
+  echo "googleworkspace-cli adapter ready"
+  exit 0
+fi
+
+if [[ -z "${meta_output_path}" ]]; then
+  if [[ -n "${credentials_file}" ]]; then
+    exec env -u GOOGLE_API_KEY \
+      -u GOOGLE_APPLICATION_CREDENTIALS \
+      -u GOOGLE_CLOUD_PROJECT \
+      -u GCLOUD_PROJECT \
+      -u GOOGLE_CREDENTIALS_PATH \
+      GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE="${credentials_file}" \
+      "${cmd[@]}"
+  fi
+  exec "${cmd[@]}"
+fi
+
+if [[ -n "${credentials_file}" ]]; then
+  set +e
+  env -u GOOGLE_API_KEY \
+    -u GOOGLE_APPLICATION_CREDENTIALS \
+    -u GOOGLE_CLOUD_PROJECT \
+    -u GCLOUD_PROJECT \
+    -u GOOGLE_CREDENTIALS_PATH \
+    GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE="${credentials_file}" \
+    "${cmd[@]}" > "${raw_output_path}" 2> "${stderr_output_path}"
+  rc=$?
+  set -e
+else
+  set +e
+  "${cmd[@]}" > "${raw_output_path}" 2> "${stderr_output_path}"
+  rc=$?
+  set -e
+fi
+
+receipt_json="$(extract_receipt "${raw_output_path}")"
+status="ok"
+message="command completed"
+if (( rc != 0 )); then
+  status="error"
+  message="command failed"
+fi
+write_meta "${status}" "${rc}" "${message}" "${receipt_json}"
+
+if [[ -s "${raw_output_path}" ]]; then
+  cat "${raw_output_path}"
+fi
+if (( rc != 0 )); then
+  if [[ -s "${stderr_output_path}" ]]; then
+    cat "${stderr_output_path}" >&2
+  fi
+  exit "${rc}"
+fi

--- a/scripts/lib/orchestrator-nl-hints.sh
+++ b/scripts/lib/orchestrator-nl-hints.sh
@@ -64,10 +64,35 @@ nl_assist_hint=""
 nl_main_reason=""
 nl_assist_reason=""
 nl_inference_skipped_reason=""
+workspace_action_hint=""
+workspace_domain_hint=""
+workspace_reason=""
+workspace_hint_applied="false"
 
 contains() {
   local pattern="$1"
   printf '%s\n' "${flat}" | grep -Eqi "${pattern}"
+}
+
+append_csv_unique() {
+  local current="$1"
+  local value="$2"
+  if [[ -z "${value}" ]]; then
+    printf '%s' "${current}"
+    return 0
+  fi
+  case ",${current}," in
+    *,"${value}",*)
+      printf '%s' "${current}"
+      ;;
+    *)
+      if [[ -z "${current}" ]]; then
+        printf '%s' "${value}"
+      else
+        printf '%s,%s' "${current}" "${value}"
+      fi
+      ;;
+  esac
 }
 
 question_like="false"
@@ -173,6 +198,48 @@ else
   fi
 fi
 
+if contains '(meeting[[:space:]_-]*prep|meeting|calendar|agenda|attendee|会議|打ち合わせ|予定|アジェンダ|参加者)'; then
+  workspace_action_hint="$(append_csv_unique "${workspace_action_hint}" "meeting-prep")"
+  workspace_domain_hint="$(append_csv_unique "${workspace_domain_hint}" "calendar")"
+  workspace_domain_hint="$(append_csv_unique "${workspace_domain_hint}" "drive")"
+  workspace_domain_hint="$(append_csv_unique "${workspace_domain_hint}" "docs")"
+  workspace_reason="$(append_csv_unique "${workspace_reason}" "meeting-context")"
+fi
+
+if contains '(standup|daily[[:space:]_-]*report|daily[[:space:]_-]*brief|朝会|日報|スタンドアップ)'; then
+  workspace_action_hint="$(append_csv_unique "${workspace_action_hint}" "standup-report")"
+  workspace_domain_hint="$(append_csv_unique "${workspace_domain_hint}" "calendar")"
+  workspace_reason="$(append_csv_unique "${workspace_reason}" "standup-context")"
+fi
+
+if contains '(weekly[[:space:]_-]*digest|週次|週報|digest|ダイジェスト)'; then
+  workspace_action_hint="$(append_csv_unique "${workspace_action_hint}" "weekly-digest")"
+  workspace_domain_hint="$(append_csv_unique "${workspace_domain_hint}" "calendar")"
+  workspace_domain_hint="$(append_csv_unique "${workspace_domain_hint}" "gmail")"
+  workspace_reason="$(append_csv_unique "${workspace_reason}" "digest-context")"
+fi
+
+if contains '(gmail|email|e-mail|mail|inbox|受信箱|未読|メール|triage|トリアージ)'; then
+  workspace_action_hint="$(append_csv_unique "${workspace_action_hint}" "gmail-triage")"
+  workspace_domain_hint="$(append_csv_unique "${workspace_domain_hint}" "gmail")"
+  workspace_reason="$(append_csv_unique "${workspace_reason}" "mail-context")"
+fi
+
+if contains '(drive|folder|file|files|document|docs|doc|資料|添付|共有ファイル|共有資料)'; then
+  workspace_domain_hint="$(append_csv_unique "${workspace_domain_hint}" "drive")"
+  workspace_domain_hint="$(append_csv_unique "${workspace_domain_hint}" "docs")"
+  workspace_reason="$(append_csv_unique "${workspace_reason}" "document-context")"
+fi
+
+if contains '(sheet|sheets|spreadsheet|スプレッドシート|表計算|csv|table|レポート表)'; then
+  workspace_domain_hint="$(append_csv_unique "${workspace_domain_hint}" "sheets")"
+  workspace_reason="$(append_csv_unique "${workspace_reason}" "sheet-context")"
+fi
+
+if [[ -n "${workspace_action_hint}" || -n "${workspace_domain_hint}" ]]; then
+  workspace_hint_applied="true"
+fi
+
 if [[ "${nl_main_hint}" != "claude" && "${nl_main_hint}" != "codex" ]]; then
   nl_main_hint=""
   nl_main_reason=""
@@ -195,13 +262,21 @@ if [[ "${format}" == "json" ]]; then
     --arg nl_assist_reason "${nl_assist_reason}" \
     --arg nl_inference_skipped_reason "${nl_inference_skipped_reason}" \
     --arg nl_hint_applied "${nl_hint_applied}" \
+    --arg workspace_action_hint "${workspace_action_hint}" \
+    --arg workspace_domain_hint "${workspace_domain_hint}" \
+    --arg workspace_reason "${workspace_reason}" \
+    --arg workspace_hint_applied "${workspace_hint_applied}" \
     '{
       nl_main_hint: $nl_main_hint,
       nl_assist_hint: $nl_assist_hint,
       nl_main_reason: $nl_main_reason,
       nl_assist_reason: $nl_assist_reason,
       nl_inference_skipped_reason: $nl_inference_skipped_reason,
-      nl_hint_applied: ($nl_hint_applied == "true")
+      nl_hint_applied: ($nl_hint_applied == "true"),
+      workspace_action_hint: $workspace_action_hint,
+      workspace_domain_hint: $workspace_domain_hint,
+      workspace_reason: $workspace_reason,
+      workspace_hint_applied: ($workspace_hint_applied == "true")
     }'
 else
   printf 'nl_main_hint=%q\n' "${nl_main_hint}"
@@ -210,4 +285,8 @@ else
   printf 'nl_assist_reason=%q\n' "${nl_assist_reason}"
   printf 'nl_inference_skipped_reason=%q\n' "${nl_inference_skipped_reason}"
   printf 'nl_hint_applied=%q\n' "${nl_hint_applied}"
+  printf 'workspace_action_hint=%q\n' "${workspace_action_hint}"
+  printf 'workspace_domain_hint=%q\n' "${workspace_domain_hint}"
+  printf 'workspace_reason=%q\n' "${workspace_reason}"
+  printf 'workspace_hint_applied=%q\n' "${workspace_hint_applied}"
 fi

--- a/scripts/local/run-local-orchestration.sh
+++ b/scripts/local/run-local-orchestration.sh
@@ -279,6 +279,8 @@ MODEL_POLICY="${ROOT_DIR}/scripts/lib/model-policy.sh"
 WORKFLOW_RISK_POLICY="${ROOT_DIR}/scripts/lib/workflow-risk-policy.sh"
 CLAUDE_TEAMS_POLICY="${ROOT_DIR}/scripts/lib/claude-teams-policy.sh"
 LINKED_RUNNER="${ROOT_DIR}/scripts/local/run-linked-systems.sh"
+ORCHESTRATOR_NL_HINTS="${ROOT_DIR}/scripts/lib/orchestrator-nl-hints.sh"
+GOOGLEWORKSPACE_KERNEL_POLICY="${ROOT_DIR}/config/integrations/googleworkspace-kernel-policy.json"
 if [[ ! -x "${SUBSCRIPTION_RUNNER}" || ! -x "${HARNESS_RUNNER}" || ! -x "${MATRIX_BUILDER}" ]]; then
   echo "Error: required harness runners are missing/executable flags are not set." >&2
   exit 2
@@ -293,6 +295,14 @@ if [[ ! -x "${WORKFLOW_RISK_POLICY}" ]]; then
 fi
 if [[ ! -x "${CLAUDE_TEAMS_POLICY}" ]]; then
   echo "Error: required Claude Teams policy script is missing or not executable: ${CLAUDE_TEAMS_POLICY}" >&2
+  exit 2
+fi
+if [[ ! -x "${ORCHESTRATOR_NL_HINTS}" ]]; then
+  echo "Error: required NL hint script is missing or not executable: ${ORCHESTRATOR_NL_HINTS}" >&2
+  exit 2
+fi
+if [[ ! -f "${GOOGLEWORKSPACE_KERNEL_POLICY}" ]]; then
+  echo "Error: Google Workspace Kernel policy missing: ${GOOGLEWORKSPACE_KERNEL_POLICY}" >&2
   exit 2
 fi
 if [[ "${WITH_LINKED_SYSTEMS}" == "true" && ! -x "${LINKED_RUNNER}" ]]; then
@@ -389,6 +399,44 @@ RUN_DIR="${OUT_DIR}/issue-${ISSUE_NUMBER}-${run_id}"
 LANE_DIR="${RUN_DIR}/lanes"
 TMP_DIR="${RUN_DIR}/tmp"
 mkdir -p "${LANE_DIR}" "${TMP_DIR}"
+
+workspace_hint_json="$("${ORCHESTRATOR_NL_HINTS}" \
+  --title "${ISSUE_TITLE}" \
+  --body "${ISSUE_BODY}" \
+  --format json)"
+workspace_context_file="${RUN_DIR}/googleworkspace-context.json"
+workspace_hint_applied="$(echo "${workspace_hint_json}" | jq -r '.workspace_hint_applied // false')"
+workspace_action_hint="$(echo "${workspace_hint_json}" | jq -r '.workspace_action_hint // ""')"
+workspace_domain_hint="$(echo "${workspace_hint_json}" | jq -r '.workspace_domain_hint // ""')"
+workspace_reason="$(echo "${workspace_hint_json}" | jq -r '.workspace_reason // ""')"
+jq -cn \
+  --argjson hints "${workspace_hint_json}" \
+  --slurpfile policy "${GOOGLEWORKSPACE_KERNEL_POLICY}" \
+  '($hints.workspace_action_hint | split(",") | map(select(length > 0))) as $actions
+   | ($hints.workspace_domain_hint | split(",") | map(select(length > 0))) as $domains
+   | {
+       workspace_hint_applied: ($hints.workspace_hint_applied // false),
+       workspace_action_hint: $hints.workspace_action_hint,
+       workspace_domain_hint: $hints.workspace_domain_hint,
+       workspace_reason: $hints.workspace_reason,
+       suggested_actions: $actions,
+       suggested_domains: $domains,
+       suggested_phases: (
+         $actions
+         | map($policy[0].action_policy[.]?.default_phase)
+         | map(select(. != null))
+         | unique
+       ),
+       readonly_actions: (
+         $actions
+         | map(select(($policy[0].action_policy[.]?.side_effect // false) | not))
+       ),
+       approval_required_actions: (
+         $actions
+         | map(select(($policy[0].action_policy[.]?.side_effect // false) == true))
+       ),
+       policy_file: "config/integrations/googleworkspace-kernel-policy.json"
+     }' > "${workspace_context_file}"
 
 strict_main="${FUGUE_STRICT_MAIN_CODEX_MODEL:-false}"
 strict_opus="${FUGUE_STRICT_OPUS_ASSIST_DIRECT:-false}"
@@ -894,6 +942,11 @@ jq -n \
   --argjson claude_session_count "${claude_session_count}" \
   --arg claude_sessions_file "${claude_sessions_file}" \
   --arg claude_resume_hint "${claude_resume_hint}" \
+  --arg workspace_hint_applied "${workspace_hint_applied}" \
+  --arg workspace_action_hint "${workspace_action_hint}" \
+  --arg workspace_domain_hint "${workspace_domain_hint}" \
+  --arg workspace_reason "${workspace_reason}" \
+  --arg workspace_context_file "${workspace_context_file}" \
   '{
     issue_number:($issue_number|tonumber),
     issue_url:$issue_url,
@@ -937,7 +990,12 @@ jq -n \
     glm_baseline_success:$glm_baseline_success,
     claude_session_count:$claude_session_count,
     claude_sessions_file:$claude_sessions_file,
-    claude_resume_hint:$claude_resume_hint
+    claude_resume_hint:$claude_resume_hint,
+    workspace_hint_applied:($workspace_hint_applied=="true"),
+    workspace_action_hint:$workspace_action_hint,
+    workspace_domain_hint:$workspace_domain_hint,
+    workspace_reason:$workspace_reason,
+    workspace_context_file:$workspace_context_file
   }' > "${integrated_json}"
 
 summary_md="${RUN_DIR}/summary.md"
@@ -970,6 +1028,10 @@ cat > "${summary_md}" <<EOF
 - claude session handoff: ${claude_session_handoff} (sessions ${claude_session_count})
 - claude sessions file: ${claude_sessions_file}
 - claude resume hint: ${claude_resume_hint}
+- workspace hint applied: ${workspace_hint_applied}
+- workspace action hint: ${workspace_action_hint}
+- workspace domain hint: ${workspace_domain_hint}
+- workspace context file: ${workspace_context_file}
 - ok_to_execute: ${ok_to_execute}
 - run dir: ${RUN_DIR}
 EOF

--- a/scripts/skills/sync-googleworkspace-skills.sh
+++ b/scripts/skills/sync-googleworkspace-skills.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+MANIFEST="${REPO_ROOT}/config/skills/googleworkspace-cli-baseline.tsv"
+GWS_CLI_REPO="${GWS_CLI_REPO:-googleworkspace/cli}"
+GWS_CLI_REF_DEFAULT="95bb24e9c2d5dd165fb0b3c81ad82a42ad31fc3f"
+GWS_CLI_REF="${GWS_CLI_REF:-${GWS_CLI_REF_DEFAULT}}"
+
+TARGET="both"            # codex | claude | both
+INCLUDE_OPTIONAL="false" # true | false
+FORCE="false"            # true | false
+DRY_RUN="false"          # true | false
+
+CODEX_SKILLS_DIR="${CODEX_SKILLS_DIR:-${HOME}/.codex/skills}"
+CLAUDE_SKILLS_DIR="${CLAUDE_SKILLS_DIR:-${HOME}/.claude/skills}"
+MANAGED_MARKER=".fugue-managed-googleworkspace"
+TMP_DIR=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/skills/sync-googleworkspace-skills.sh [options]
+
+Options:
+  --target <codex|claude|both>    Install destination. Default: both
+  --with-optional                 Include optional skills from manifest.
+  --ref <git-ref>                 Pin googleworkspace/cli source ref. Default is pinned SHA.
+  --manifest <path>               Manifest file path override.
+  --force                         Replace existing non-managed target directories.
+  --dry-run                       Print actions without writing files.
+  -h, --help                      Show this help.
+
+Environment:
+  GWS_CLI_REPO                    GitHub repository (default: googleworkspace/cli)
+  GWS_CLI_REF                     Source ref override (tag/branch/sha)
+  CODEX_SKILLS_DIR                Codex skills directory (default: ~/.codex/skills)
+  CLAUDE_SKILLS_DIR               Claude skills directory (default: ~/.claude/skills)
+EOF
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --target)
+        [[ $# -ge 2 ]] || fail "--target requires a value"
+        TARGET="$2"
+        shift 2
+        ;;
+      --with-optional)
+        INCLUDE_OPTIONAL="true"
+        shift
+        ;;
+      --ref)
+        [[ $# -ge 2 ]] || fail "--ref requires a value"
+        GWS_CLI_REF="$2"
+        shift 2
+        ;;
+      --manifest)
+        [[ $# -ge 2 ]] || fail "--manifest requires a value"
+        MANIFEST="$2"
+        shift 2
+        ;;
+      --force)
+        FORCE="true"
+        shift
+        ;;
+      --dry-run)
+        DRY_RUN="true"
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        fail "unknown option: $1"
+        ;;
+    esac
+  done
+
+  case "${TARGET}" in
+    codex|claude|both) ;;
+    *)
+      fail "--target must be codex, claude, or both"
+      ;;
+  esac
+}
+
+download_snapshot() {
+  local tmp_dir="$1"
+  local tarball="${tmp_dir}/googleworkspace-cli.tar.gz"
+  local url="https://codeload.github.com/${GWS_CLI_REPO}/tar.gz/${GWS_CLI_REF}"
+
+  echo "Downloading ${GWS_CLI_REPO}@${GWS_CLI_REF}"
+  curl -fsSL "${url}" -o "${tarball}"
+  tar -xzf "${tarball}" -C "${tmp_dir}"
+}
+
+resolve_snapshot_root() {
+  local tmp_dir="$1"
+  local repo_basename="${GWS_CLI_REPO##*/}"
+  local root
+
+  root="$(find "${tmp_dir}" -mindepth 1 -maxdepth 1 -type d -name "${repo_basename}-*" | head -n1 || true)"
+  [[ -n "${root}" ]] || fail "could not find extracted googleworkspace/cli directory"
+  echo "${root}"
+}
+
+validate_skill_payload() {
+  local skill_dir="$1"
+  local skill_name="$2"
+  local skill_md="${skill_dir}/SKILL.md"
+
+  [[ -f "${skill_md}" ]] || fail "skill ${skill_name} has no SKILL.md"
+
+  head -n1 "${skill_md}" | grep -q '^---$' || fail "skill ${skill_name} frontmatter is missing"
+  grep -q '^name:' "${skill_md}" || fail "skill ${skill_name} has no name in frontmatter"
+  grep -q '^description:' "${skill_md}" || fail "skill ${skill_name} has no description in frontmatter"
+
+  if rg -n --no-messages --fixed-strings -- '--yolo' "${skill_md}" >/dev/null; then
+    fail "skill ${skill_name} includes --yolo guidance; blocked by security policy"
+  fi
+  if rg -n --no-messages --fixed-strings -- '--full-auto' "${skill_md}" >/dev/null; then
+    fail "skill ${skill_name} includes --full-auto guidance; blocked by security policy"
+  fi
+}
+
+copy_skill() {
+  local source_dir="$1"
+  local target_base="$2"
+  local skill_name="$3"
+  local target_dir="${target_base}/${skill_name}"
+
+  mkdir -p "${target_base}"
+
+  if [[ -d "${target_dir}" ]]; then
+    if [[ -f "${target_dir}/${MANAGED_MARKER}" || "${FORCE}" == "true" ]]; then
+      if [[ "${DRY_RUN}" == "true" ]]; then
+        echo "DRY-RUN replace ${target_dir}"
+      else
+        rm -rf "${target_dir}"
+      fi
+    else
+      echo "SKIP ${target_dir} (exists and not managed, use --force to replace)"
+      return 0
+    fi
+  fi
+
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "DRY-RUN install ${skill_name} -> ${target_dir}"
+    return 0
+  fi
+
+  mkdir -p "${target_dir}"
+  cp -R "${source_dir}/." "${target_dir}/"
+  cat > "${target_dir}/${MANAGED_MARKER}" <<EOF
+source_repo=${GWS_CLI_REPO}
+source_ref=${GWS_CLI_REF}
+installed_at_utc=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+EOF
+}
+
+read_manifest() {
+  [[ -f "${MANIFEST}" ]] || fail "manifest not found: ${MANIFEST}"
+  awk -F'\t' '
+    BEGIN { OFS="\t" }
+    /^#/ { next }
+    NF < 2 { next }
+    { print $1, $2 }
+  ' "${MANIFEST}"
+}
+
+main() {
+  parse_args "$@"
+  require_cmd curl
+  require_cmd tar
+  require_cmd awk
+  require_cmd rg
+
+  local snapshot_root
+  TMP_DIR="$(mktemp -d)"
+  chmod 700 "${TMP_DIR}"
+  trap 'if [[ -n "${TMP_DIR:-}" && -d "${TMP_DIR}" ]]; then rm -rf "${TMP_DIR}"; fi' EXIT
+
+  download_snapshot "${TMP_DIR}"
+  snapshot_root="$(resolve_snapshot_root "${TMP_DIR}")"
+
+  local installed=0 selected=0
+  while IFS=$'\t' read -r skill_name profile; do
+    [[ -n "${skill_name}" ]] || continue
+
+    if [[ "${profile}" == "optional" && "${INCLUDE_OPTIONAL}" != "true" ]]; then
+      continue
+    fi
+
+    selected=$((selected + 1))
+    local source_skill_dir="${snapshot_root}/skills/${skill_name}"
+    [[ -d "${source_skill_dir}" ]] || fail "skill not found in snapshot: ${skill_name}"
+    validate_skill_payload "${source_skill_dir}" "${skill_name}"
+
+    if [[ "${TARGET}" == "codex" || "${TARGET}" == "both" ]]; then
+      copy_skill "${source_skill_dir}" "${CODEX_SKILLS_DIR}" "${skill_name}"
+    fi
+    if [[ "${TARGET}" == "claude" || "${TARGET}" == "both" ]]; then
+      copy_skill "${source_skill_dir}" "${CLAUDE_SKILLS_DIR}" "${skill_name}"
+    fi
+    installed=$((installed + 1))
+  done < <(read_manifest)
+
+  echo "Completed: selected=${selected}, processed=${installed}, target=${TARGET}, optional=${INCLUDE_OPTIONAL}, dry_run=${DRY_RUN}"
+  echo "Source: ${GWS_CLI_REPO}@${GWS_CLI_REF}"
+}
+
+main "$@"

--- a/tests/test-googleworkspace-cli-adapter.sh
+++ b/tests/test-googleworkspace-cli-adapter.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+ADAPTER="${SCRIPT_DIR}/scripts/lib/googleworkspace-cli-adapter.sh"
+
+passed=0
+failed=0
+total=0
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+fake_gws="${tmp_dir}/gws"
+cat > "${fake_gws}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" ]]; then
+  echo "gws help"
+  exit 0
+fi
+
+case "${1:-}" in
+  gmail)
+    if [[ "${2:-}" == "+send" ]]; then
+      echo '{"id":"msg-123","labelIds":["SENT"]}'
+      exit 0
+    fi
+    if [[ "${2:-}" == "+triage" ]]; then
+      echo '{"resultSizeEstimate":3}'
+      exit 0
+    fi
+    ;;
+  workflow)
+    if [[ "${2:-}" == "+meeting-prep" ]]; then
+      echo '{"summary":"meeting prep ok","meetingCount":1}'
+      exit 0
+    fi
+    ;;
+esac
+
+echo '{"status":"unexpected","argv":'"$(printf '%s\n' "$@" | jq -R . | jq -s .)"'}'
+EOF
+chmod +x "${fake_gws}"
+
+assert_ok() {
+  local test_name="$1"
+  shift
+  total=$((total + 1))
+  if "$@"; then
+    echo "PASS [${test_name}]"
+    passed=$((passed + 1))
+  else
+    echo "FAIL [${test_name}]"
+    failed=$((failed + 1))
+  fi
+}
+
+test_write_gate_blocked() {
+  local run_dir="${tmp_dir}/blocked"
+  mkdir -p "${run_dir}"
+  if env PATH="${tmp_dir}:${PATH}" "${ADAPTER}" \
+    --action gmail-send \
+    --to flux@example.com \
+    --subject "Test" \
+    --body "Hello" \
+    --format json \
+    --run-dir "${run_dir}" >/dev/null 2>"${run_dir}/stderr.log"; then
+    return 1
+  fi
+  jq -e '.status == "skipped" and .side_effect == true and .ok_to_execute == false and .human_approved == false' \
+    "${run_dir}/googleworkspace/gmail-send-meta.json" >/dev/null
+}
+
+test_write_receipt_logged() {
+  local run_dir="${tmp_dir}/write-ok"
+  mkdir -p "${run_dir}"
+  local output
+  output="$(env PATH="${tmp_dir}:${PATH}" "${ADAPTER}" \
+    --action gmail-send \
+    --to flux@example.com \
+    --subject "Test" \
+    --body "Hello" \
+    --format json \
+    --run-dir "${run_dir}" \
+    --ok-to-execute true \
+    --human-approved true)"
+  echo "${output}" | jq -e '.id == "msg-123"' >/dev/null
+  jq -e '.status == "ok" and .receipt.id == "msg-123" and .side_effect == true' \
+    "${run_dir}/googleworkspace/gmail-send-meta.json" >/dev/null
+}
+
+test_readonly_evidence_written() {
+  local run_dir="${tmp_dir}/readonly"
+  mkdir -p "${run_dir}"
+  local output
+  output="$(env PATH="${tmp_dir}:${PATH}" "${ADAPTER}" \
+    --action meeting-prep \
+    --format json \
+    --run-dir "${run_dir}")"
+  echo "${output}" | jq -e '.meetingCount == 1' >/dev/null
+  jq -e '.status == "ok" and .side_effect == false' \
+    "${run_dir}/googleworkspace/meeting-prep-meta.json" >/dev/null
+  test -s "${run_dir}/googleworkspace/meeting-prep.json"
+}
+
+echo "=== googleworkspace-cli-adapter.sh unit tests ==="
+echo ""
+
+assert_ok "write-gate-blocked" test_write_gate_blocked
+assert_ok "write-receipt-logged" test_write_receipt_logged
+assert_ok "readonly-evidence-written" test_readonly_evidence_written
+
+echo ""
+echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="
+
+if [[ "${failed}" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test-googleworkspace-preflight-enrich.sh
+++ b/tests/test-googleworkspace-preflight-enrich.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${SCRIPT_DIR}/scripts/harness/googleworkspace-preflight-enrich.sh"
+
+passed=0
+failed=0
+total=0
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+fake_adapter="${tmp_dir}/googleworkspace-cli-adapter.sh"
+cat > "${fake_adapter}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+action=""
+run_dir=""
+credentials_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "${1}" in
+    --action)
+      action="${2:-}"
+      shift 2
+      ;;
+    --run-dir)
+      run_dir="${2:-}"
+      shift 2
+      ;;
+    --credentials-file)
+      credentials_file="${2:-}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+mkdir -p "${run_dir}/googleworkspace"
+if [[ -n "${TMP_ADAPTER_CALLS_LOG:-}" ]]; then
+  printf '%s\n' "${action}" >> "${TMP_ADAPTER_CALLS_LOG}"
+fi
+if [[ -n "${credentials_file}" && -n "${TMP_ADAPTER_CREDENTIALS_LOG:-}" ]]; then
+  cat "${credentials_file}" > "${TMP_ADAPTER_CREDENTIALS_LOG}"
+fi
+
+meta_file="${run_dir}/googleworkspace/${action}-meta.json"
+raw_file="${run_dir}/googleworkspace/${action}.json"
+
+case "${action}" in
+  meeting-prep)
+    printf '%s' '{"summary":"next meeting at 10:00","meetingCount":1}' > "${raw_file}"
+    printf '%s' '{"status":"ok","message":"ok"}' > "${meta_file}"
+    cat "${raw_file}"
+    ;;
+  gmail-triage)
+    printf '%s' '{"status":"error","message":"mailbox unavailable"}' > "${meta_file}"
+    echo "mailbox unavailable" >&2
+    exit 1
+    ;;
+  *)
+    printf '%s' '{"status":"error","message":"unsupported action"}' > "${meta_file}"
+    echo "unsupported action" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${fake_adapter}"
+
+assert_ok() {
+  local test_name="$1"
+  shift
+  total=$((total + 1))
+  if "$@"; then
+    echo "PASS [${test_name}]"
+    passed=$((passed + 1))
+  else
+    echo "FAIL [${test_name}]"
+    failed=$((failed + 1))
+  fi
+}
+
+test_skips_without_credentials() {
+  local work_dir="${tmp_dir}/skip"
+  local home_dir="${work_dir}/home"
+  local calls_log="${work_dir}/calls.log"
+  local output_file="${work_dir}/github-output.txt"
+  local report_path="${work_dir}/report.md"
+
+  mkdir -p "${work_dir}" "${home_dir}"
+
+  env \
+    HOME="${home_dir}" \
+    TMP_ADAPTER_CALLS_LOG="${calls_log}" \
+    ISSUE_NUMBER="41" \
+    ISSUE_TITLE="Skip test" \
+    WORKSPACE_ACTIONS="meeting-prep" \
+    WORKSPACE_REASON="meeting context requested" \
+    WORKSPACE_SUGGESTED_PHASES="preflight-enrich" \
+    REPORT_PATH="${report_path}" \
+    OUT_DIR="${work_dir}" \
+    RUN_DIR="${work_dir}/run" \
+    GITHUB_OUTPUT="${output_file}" \
+    ADAPTER="${fake_adapter}" \
+    bash "${SCRIPT}" >/dev/null
+
+  grep -q '^workspace_preflight_status=skipped$' "${output_file}" &&
+    grep -q 'No Google Workspace credentials were available for readonly preflight\.' "${report_path}" &&
+    [[ ! -s "${calls_log}" ]]
+}
+
+test_partial_report_and_outputs() {
+  local work_dir="${tmp_dir}/partial"
+  local home_dir="${work_dir}/home"
+  local calls_log="${work_dir}/calls.log"
+  local credentials_log="${work_dir}/credentials.json"
+  local output_file="${work_dir}/github-output.txt"
+  local report_path="${work_dir}/report.md"
+
+  mkdir -p "${work_dir}" "${home_dir}"
+
+  env \
+    HOME="${home_dir}" \
+    TMP_ADAPTER_CALLS_LOG="${calls_log}" \
+    TMP_ADAPTER_CREDENTIALS_LOG="${credentials_log}" \
+    GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON='{"type":"service_account","project_id":"demo"}' \
+    ISSUE_NUMBER="42" \
+    ISSUE_TITLE="Meeting and inbox context" \
+    ISSUE_BODY="Need meeting prep and inbox triage." \
+    WORKSPACE_ACTIONS="meeting-prep,gmail-triage,docs-create" \
+    WORKSPACE_DOMAINS="calendar,drive,docs,gmail" \
+    WORKSPACE_REASON="Issue mentions meetings and unread mail." \
+    WORKSPACE_SUGGESTED_PHASES="preflight-enrich" \
+    REPORT_PATH="${report_path}" \
+    OUT_DIR="${work_dir}" \
+    RUN_DIR="${work_dir}/run" \
+    GITHUB_OUTPUT="${output_file}" \
+    ADAPTER="${fake_adapter}" \
+    bash "${SCRIPT}" >/dev/null
+
+  grep -q '^workspace_preflight_status=partial$' "${output_file}" &&
+    grep -q '^workspace_report_path='"${report_path}"'$' "${output_file}" &&
+    grep -q 'meeting-prep: next meeting at 10:00' "${output_file}" &&
+    grep -q -- '- status: partial' "${report_path}" &&
+    grep -q '| meeting-prep | ok | next meeting at 10:00 |' "${report_path}" &&
+    grep -q '| gmail-triage | error | mailbox unavailable |' "${report_path}" &&
+    ! grep -q 'docs-create' "${report_path}" &&
+    grep -q '^meeting-prep$' "${calls_log}" &&
+    grep -q '^gmail-triage$' "${calls_log}" &&
+    ! grep -q 'docs-create' "${calls_log}" &&
+    grep -q '"type":"service_account"' "${credentials_log}"
+}
+
+echo "=== googleworkspace-preflight-enrich.sh unit tests ==="
+echo ""
+
+assert_ok "skips-without-credentials" test_skips_without_credentials
+assert_ok "partial-report-and-outputs" test_partial_report_and_outputs
+
+echo ""
+echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="
+
+if [[ "${failed}" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test-orchestrator-nl-hints.sh
+++ b/tests/test-orchestrator-nl-hints.sh
@@ -51,6 +51,43 @@ assert_nl() {
   fi
 }
 
+assert_workspace() {
+  local test_name="$1"
+  local expected_actions="$2"
+  local expected_domains="$3"
+  local expected_applied="$4"
+  shift 4
+
+  total=$((total + 1))
+  local output
+  output="$("${NL}" "$@" --format env)" || {
+    echo "FAIL [${test_name}]: script exited with error"
+    failed=$((failed + 1))
+    return
+  }
+
+  eval "${output}"
+
+  local errors=""
+  if [[ "${workspace_action_hint}" != "${expected_actions}" ]]; then
+    errors+=" actions=${workspace_action_hint}(expected ${expected_actions})"
+  fi
+  if [[ "${workspace_domain_hint}" != "${expected_domains}" ]]; then
+    errors+=" domains=${workspace_domain_hint}(expected ${expected_domains})"
+  fi
+  if [[ "${workspace_hint_applied}" != "${expected_applied}" ]]; then
+    errors+=" applied=${workspace_hint_applied}(expected ${expected_applied})"
+  fi
+
+  if [[ -n "${errors}" ]]; then
+    echo "FAIL [${test_name}]:${errors}"
+    failed=$((failed + 1))
+  else
+    echo "PASS [${test_name}]"
+    passed=$((passed + 1))
+  fi
+}
+
 echo "=== orchestrator-nl-hints.sh unit tests ==="
 echo ""
 
@@ -165,6 +202,23 @@ assert_nl "title-body-combined" \
 assert_nl "uppercase-providers" \
   "claude" "codex" "true" \
   --text "CLAUDEをMAINにしてCODEXをSUBにする"
+
+# --- Group 12: Workspace route hints ---
+assert_workspace "workspace-meeting" \
+  "meeting-prep" "calendar,drive,docs" "true" \
+  --text "会議前に agenda と linked docs を確認したい"
+
+assert_workspace "workspace-mail" \
+  "gmail-triage" "gmail" "true" \
+  --text "受信箱の未読メールを triage したい"
+
+assert_workspace "workspace-digest" \
+  "weekly-digest" "calendar,gmail" "true" \
+  --text "週次 digest を作って"
+
+assert_workspace "workspace-doc-sheet-domain-only" \
+  "" "drive,docs,sheets" "true" \
+  --text "共有資料と spreadsheet を参照してレポート表を作る"
 
 echo ""
 echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="

--- a/tests/test-resolve-orchestration-context.sh
+++ b/tests/test-resolve-orchestration-context.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+SCRIPT="${SCRIPT_DIR}/scripts/harness/resolve-orchestration-context.sh"
+
+passed=0
+failed=0
+total=0
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+fake_gh="${tmp_dir}/gh"
+cat > "${fake_gh}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "api" ]]; then
+  endpoint="${2:-}"
+  case "${endpoint}" in
+    repos/cursorvers/fugue-orchestrator/issues/123)
+      cat <<'JSON'
+{"title":"会議前に agenda と linked docs を確認したい","body":"未読メールも triage したい\n\n## Execution Mode\nreview","url":"https://github.com/cursorvers/fugue-orchestrator/issues/123","labels":[{"name":"fugue-task"},{"name":"tutti"}]}
+JSON
+      exit 0
+      ;;
+    repos/cursorvers/fugue-orchestrator/issues/124)
+      cat <<'JSON'
+{"title":"通常のレビュー","body":"テストを実行して結果をまとめる","url":"https://github.com/cursorvers/fugue-orchestrator/issues/124","labels":[{"name":"fugue-task"},{"name":"tutti"}]}
+JSON
+      exit 0
+      ;;
+    *)
+      echo "{}"
+      exit 0
+      ;;
+  esac
+fi
+
+echo "unsupported fake gh invocation" >&2
+exit 1
+EOF
+chmod +x "${fake_gh}"
+
+assert_output() {
+  local test_name="$1"
+  local issue_number="$2"
+  local field="$3"
+  local expected="$4"
+
+  total=$((total + 1))
+  local out_file="${tmp_dir}/${test_name}.out"
+
+  if ! env \
+    PATH="${tmp_dir}:${PATH}" \
+    GITHUB_EVENT_NAME="issues" \
+    GITHUB_REPOSITORY="cursorvers/fugue-orchestrator" \
+    ISSUE_NUMBER_FROM_ISSUE="${issue_number}" \
+    ISSUE_NUMBER_FROM_DISPATCH="" \
+    GITHUB_OUTPUT="${out_file}" \
+    CI_EXECUTION_ENGINE="api" \
+    CLAUDE_TRANSLATOR_MODE="off" \
+    DEFAULT_MAIN_ORCHESTRATOR_PROVIDER="codex" \
+    DEFAULT_ASSIST_ORCHESTRATOR_PROVIDER="claude" \
+    CLAUDE_MAIN_ASSIST_POLICY="codex" \
+    CLAUDE_DEGRADED_ASSIST_POLICY="claude" \
+    CLAUDE_ROLE_POLICY="flex" \
+    bash "${SCRIPT}" >/dev/null 2>"${tmp_dir}/${test_name}.stderr"; then
+    echo "FAIL [${test_name}]: script exited with error"
+    failed=$((failed + 1))
+    return
+  fi
+
+  local actual
+  actual="$(grep -E "^${field}=" "${out_file}" | head -n1 | cut -d= -f2- || true)"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "FAIL [${test_name}]: ${field}=${actual}(expected ${expected})"
+    failed=$((failed + 1))
+  else
+    echo "PASS [${test_name}]"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== resolve-orchestration-context.sh unit tests ==="
+echo ""
+
+assert_output "workspace-hint-applied" "123" "workspace_hint_applied" "true"
+assert_output "workspace-action-hint" "123" "workspace_action_hint" "meeting-prep,gmail-triage"
+assert_output "workspace-domain-hint" "123" "workspace_domain_hint" "calendar,drive,docs,gmail"
+assert_output "workspace-phase-hint" "123" "workspace_suggested_phases" "preflight-enrich"
+assert_output "workspace-readonly-actions" "123" "workspace_readonly_actions" "meeting-prep,gmail-triage"
+assert_output "workspace-none" "124" "workspace_hint_applied" "false"
+
+echo ""
+echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="
+
+if [[ "${failed}" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add Google Workspace CLI skill/profile, adapters, and Kernel policy artifacts
- route Workspace hints from orchestration context into readonly CI preflight
- isolate readonly Workspace credentials behind the protected `workspace-readonly` environment

## Verification
- bash tests/test-googleworkspace-preflight-enrich.sh
- bash tests/test-googleworkspace-cli-adapter.sh
- bash tests/test-orchestrator-nl-hints.sh
- bash tests/test-resolve-orchestration-context.sh
