### PR TITLE
feat: add readonly Workspace smoke workflow

### DIFF
--- a/.github/workflows/googleworkspace-readonly-smoke.yml
+++ b/.github/workflows/googleworkspace-readonly-smoke.yml
@@ -1,0 +1,125 @@
+name: Google Workspace Readonly Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number used to derive Google Workspace hints"
+        required: true
+        type: string
+      workspace_readonly_environment:
+        description: "Protected GitHub Environment used for readonly Google Workspace smoke"
+        required: false
+        type: string
+        default: "workspace-readonly"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  resolve-context:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      issue_number: ${{ steps.ctx.outputs.issue_number }}
+      issue_title: ${{ steps.ctx.outputs.issue_title }}
+      issue_body: ${{ steps.ctx.outputs.issue_body }}
+      workspace_hint_applied: ${{ steps.ctx.outputs.workspace_hint_applied }}
+      workspace_action_hint: ${{ steps.ctx.outputs.workspace_action_hint }}
+      workspace_domain_hint: ${{ steps.ctx.outputs.workspace_domain_hint }}
+      workspace_reason: ${{ steps.ctx.outputs.workspace_reason }}
+      workspace_suggested_phases: ${{ steps.ctx.outputs.workspace_suggested_phases }}
+      workspace_readonly_actions: ${{ steps.ctx.outputs.workspace_readonly_actions }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve issue context
+        id: ctx
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER_FROM_DISPATCH: ${{ inputs.issue_number }}
+          ISSUE_NUMBER_FROM_ISSUE: ""
+          HANDOFF_TARGET_INPUT: kernel
+          CI_EXECUTION_ENGINE: api
+          CLAUDE_TRANSLATOR_MODE: off
+          DEFAULT_MAIN_ORCHESTRATOR_PROVIDER: codex
+          DEFAULT_ASSIST_ORCHESTRATOR_PROVIDER: none
+        run: bash scripts/harness/resolve-orchestration-context.sh
+
+  workspace-preflight:
+    if: ${{ needs.resolve-context.outputs.workspace_hint_applied == 'true' }}
+    needs: [resolve-context]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment:
+      name: ${{ inputs.workspace_readonly_environment }}
+    outputs:
+      workspace_preflight_status: ${{ steps.preflight.outputs.workspace_preflight_status }}
+      workspace_report_path: ${{ steps.preflight.outputs.workspace_report_path }}
+      workspace_summary: ${{ steps.preflight.outputs.workspace_summary }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Google Workspace CLI
+        run: npm install -g @googleworkspace/cli
+
+      - name: Run readonly Workspace smoke
+        id: preflight
+        env:
+          ISSUE_NUMBER: ${{ needs.resolve-context.outputs.issue_number }}
+          ISSUE_TITLE: ${{ needs.resolve-context.outputs.issue_title }}
+          ISSUE_BODY: ${{ needs.resolve-context.outputs.issue_body }}
+          WORKSPACE_ACTIONS: ${{ needs.resolve-context.outputs.workspace_readonly_actions || needs.resolve-context.outputs.workspace_action_hint }}
+          WORKSPACE_DOMAINS: ${{ needs.resolve-context.outputs.workspace_domain_hint }}
+          WORKSPACE_REASON: ${{ needs.resolve-context.outputs.workspace_reason }}
+          WORKSPACE_SUGGESTED_PHASES: ${{ needs.resolve-context.outputs.workspace_suggested_phases }}
+          OUT_DIR: .fugue/pre-implement
+          RUN_DIR: .fugue/pre-implement/googleworkspace-run
+          REPORT_PATH: .fugue/pre-implement/issue-${{ needs.resolve-context.outputs.issue_number }}-googleworkspace.md
+          ADAPTER: scripts/lib/googleworkspace-cli-adapter.sh
+          GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON: ${{ secrets.GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON }}
+        run: bash scripts/harness/googleworkspace-preflight-enrich.sh
+
+      - name: Upload Workspace smoke artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: googleworkspace-readonly-smoke-${{ needs.resolve-context.outputs.issue_number }}
+          path: |
+            .fugue/pre-implement/issue-${{ needs.resolve-context.outputs.issue_number }}-googleworkspace.md
+            .fugue/pre-implement/googleworkspace-run
+          if-no-files-found: ignore
+
+  finalize:
+    if: always()
+    needs: [resolve-context, workspace-preflight]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Comment smoke result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ needs.resolve-context.outputs.issue_number }}
+          WORKSPACE_HINT_APPLIED: ${{ needs.resolve-context.outputs.workspace_hint_applied }}
+          WORKSPACE_ACTION_HINT: ${{ needs.resolve-context.outputs.workspace_action_hint }}
+          WORKSPACE_PREFLIGHT_STATUS: ${{ needs.workspace-preflight.outputs.workspace_preflight_status }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${WORKSPACE_HINT_APPLIED}" != "true" ]]; then
+            gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+              --body "Readonly Workspace smoke: no applicable Google Workspace action hint was derived from this issue. No protected preflight job was run."
+            exit 0
+          fi
+
+          status="${WORKSPACE_PREFLIGHT_STATUS:-unknown}"
+          gh issue comment "${ISSUE_NUMBER}" --repo "${GITHUB_REPOSITORY}" \
+            --body "Readonly Workspace smoke completed. actions=\`${WORKSPACE_ACTION_HINT}\`, status=\`${status}\`. Check the workflow artifacts for the bounded Google Workspace report."

--- a/docs/googleworkspace-skills-profile.md
+++ b/docs/googleworkspace-skills-profile.md
@@ -235,6 +235,10 @@ Current CI path:
 - the protected job reads secrets only from `workspace-readonly`
 - implementation job downloads the preflight artifact and does not receive the
   Workspace credential secret directly
+- manual smoke entrypoint:
+  - `.github/workflows/googleworkspace-readonly-smoke.yml`
+  - use this when protected readonly Workspace verification is needed without
+    going through Tutti execution approval
 - readonly preflight artifact lands at:
   - `.fugue/pre-implement/issue-<n>-googleworkspace.md`
 - raw readonly evidence lands at:


### PR DESCRIPTION
## Summary
- add a manual protected readonly Google Workspace smoke workflow
- resolve workspace hints from an issue and run only the protected readonly preflight path
- document the manual smoke entrypoint for Workspace verification

## Verification
- python3 - <<'PY' ... yaml.safe_load('.github/workflows/googleworkspace-readonly-smoke.yml')
- bash -n scripts/harness/googleworkspace-preflight-enrich.sh scripts/harness/resolve-orchestration-context.sh scripts/lib/googleworkspace-cli-adapter.sh
- bash tests/test-googleworkspace-preflight-enrich.sh