### PR TITLE
feat: support user OAuth readonly Workspace preflight

### DIFF
--- a/.github/workflows/fugue-codex-implement.yml
+++ b/.github/workflows/fugue-codex-implement.yml
@@ -346,6 +346,7 @@ jobs:
           REPORT_PATH: .fugue/pre-implement/issue-${{ needs.prepare.outputs.issue_number }}-googleworkspace.md
           ADAPTER: scripts/lib/googleworkspace-cli-adapter.sh
           GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON: ${{ secrets.GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON }}
+          GOOGLE_WORKSPACE_USER_CREDENTIALS_JSON: ${{ secrets.GOOGLE_WORKSPACE_USER_CREDENTIALS_JSON }}
         run: bash scripts/harness/googleworkspace-preflight-enrich.sh
 
       - name: Upload Google Workspace preflight artifact

--- a/.github/workflows/googleworkspace-readonly-smoke.yml
+++ b/.github/workflows/googleworkspace-readonly-smoke.yml
@@ -86,6 +86,7 @@ jobs:
           REPORT_PATH: .fugue/pre-implement/issue-${{ needs.resolve-context.outputs.issue_number }}-googleworkspace.md
           ADAPTER: scripts/lib/googleworkspace-cli-adapter.sh
           GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON: ${{ secrets.GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON }}
+          GOOGLE_WORKSPACE_USER_CREDENTIALS_JSON: ${{ secrets.GOOGLE_WORKSPACE_USER_CREDENTIALS_JSON }}
         run: bash scripts/harness/googleworkspace-preflight-enrich.sh
 
       - name: Upload Workspace smoke artifact

--- a/docs/googleworkspace-skills-profile.md
+++ b/docs/googleworkspace-skills-profile.md
@@ -210,6 +210,7 @@ Recommended environment:
 - `workspace-readonly`
   - configure required reviewers or approval rules
   - expose `GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON` only in this environment
+  - optionally expose `GOOGLE_WORKSPACE_USER_CREDENTIALS_JSON` for mailbox helpers
 
 Secret:
 
@@ -218,12 +219,23 @@ Secret:
   - intended only for readonly preflight actions
   - consumed by `scripts/harness/googleworkspace-preflight-enrich.sh`
   - not passed through the caller workflow as a reusable-workflow secret
+- `GOOGLE_WORKSPACE_USER_CREDENTIALS_JSON`
+  - optional `authorized_user` JSON payload for mailbox helpers such as
+    `gmail-triage` and `weekly-digest`
+  - generate it with:
+    ```bash
+    gws auth export --unmasked > credentials.json
+    ```
+  - note: masked `gws auth export` output is not valid for CI use
+  - consumed only inside the protected readonly preflight job
 
 Protection model:
 
 - first guard: readonly service-account scope only
 - second guard: protected `Environment` approval before the preflight job can
   read the secret
+- mailbox helpers prefer `GOOGLE_WORKSPACE_USER_CREDENTIALS_JSON` when present
+  and otherwise degrade gracefully under service-account mode
 
 If the environment secret is absent, the CI workflow does not fail. It emits a
 `skipped` Workspace artifact instead and continues with the normal Codex path.

--- a/docs/kernel-googleworkspace-integration-design.md
+++ b/docs/kernel-googleworkspace-integration-design.md
@@ -228,7 +228,8 @@ Kernel admission rules:
 ### 2. Morning Operator Brief
 
 1. Scheduler invokes `standup-report`.
-2. If user OAuth is available, also run `gmail-triage` or `weekly-digest`.
+2. If protected readonly user OAuth export is available, also run
+   `gmail-triage` or `weekly-digest`.
 3. Kernel emits one digest artifact and does not mutate state elsewhere.
 
 ### 3. Stakeholder Delivery
@@ -255,7 +256,9 @@ Kernel admission rules:
 3. Add optional read helpers for `drive search`, `docs read`, and `sheets read`
    to reduce fallback raw API usage.
 4. Add an approval receipt log for Workspace write actions.
-5. Keep CI Workspace auth limited to optional readonly service-account secrets;
-   do not run unattended write actions in reusable workflows.
+5. Keep CI Workspace auth limited to protected readonly secrets only:
+   service-account JSON for shared context and optional user OAuth export JSON
+   for mailbox helpers. Do not run unattended write actions in reusable
+   workflows.
 6. Require a protected GitHub `Environment` such as `workspace-readonly` before
    CI can access readonly Workspace credentials.

--- a/scripts/harness/googleworkspace-preflight-enrich.sh
+++ b/scripts/harness/googleworkspace-preflight-enrich.sh
@@ -47,6 +47,43 @@ sanitize_summary() {
   printf '%s' "${1:-}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^[[:space:]]+|[[:space:]]+$//g'
 }
 
+is_mailbox_action() {
+  case "${1:-}" in
+    gmail-triage|weekly-digest)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+select_credentials_file() {
+  local action="$1"
+
+  if is_mailbox_action "${action}"; then
+    if [[ -n "${user_credentials_file}" ]]; then
+      printf '%s' "${user_credentials_file}"
+      return 0
+    fi
+    if [[ -n "${service_credentials_file}" ]]; then
+      printf '%s' "${service_credentials_file}"
+      return 0
+    fi
+  else
+    if [[ -n "${service_credentials_file}" ]]; then
+      printf '%s' "${service_credentials_file}"
+      return 0
+    fi
+    if [[ -n "${user_credentials_file}" ]]; then
+      printf '%s' "${user_credentials_file}"
+      return 0
+    fi
+  fi
+
+  printf ''
+}
+
 extract_summary() {
   local action="$1"
   local raw_file="$2"
@@ -83,23 +120,37 @@ require_cmd jq
 
 mkdir -p "${OUT_DIR}" "${RUN_DIR}"
 
-credentials_file="${GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE:-}"
-tmp_credentials=""
-if [[ -z "${credentials_file}" && -n "${GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON:-}" ]]; then
-  tmp_credentials="$(mktemp)"
-  printf '%s' "${GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON}" > "${tmp_credentials}"
-  credentials_file="${tmp_credentials}"
+service_credentials_file="${GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE:-}"
+service_tmp_credentials=""
+if [[ -z "${service_credentials_file}" && -n "${GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON:-}" ]]; then
+  service_tmp_credentials="$(mktemp)"
+  printf '%s' "${GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON}" > "${service_tmp_credentials}"
+  service_credentials_file="${service_tmp_credentials}"
 fi
+
+user_credentials_file="${GOOGLE_WORKSPACE_USER_CREDENTIALS_FILE:-}"
+user_tmp_credentials=""
+if [[ -z "${user_credentials_file}" && -n "${GOOGLE_WORKSPACE_USER_CREDENTIALS_JSON:-}" ]]; then
+  user_tmp_credentials="$(mktemp)"
+  printf '%s' "${GOOGLE_WORKSPACE_USER_CREDENTIALS_JSON}" > "${user_tmp_credentials}"
+  user_credentials_file="${user_tmp_credentials}"
+fi
+
 credentials_available="false"
-if [[ -n "${credentials_file}" ]]; then
+local_oauth_available="false"
+if [[ -n "${service_credentials_file}" || -n "${user_credentials_file}" ]]; then
   credentials_available="true"
 elif [[ -f "${HOME}/.config/gws/credentials.enc" && -f "${HOME}/.config/gws/client_secret.json" ]]; then
   credentials_available="true"
+  local_oauth_available="true"
 fi
 
 cleanup() {
-  if [[ -n "${tmp_credentials}" && -f "${tmp_credentials}" ]]; then
-    rm -f "${tmp_credentials}"
+  if [[ -n "${service_tmp_credentials}" && -f "${service_tmp_credentials}" ]]; then
+    rm -f "${service_tmp_credentials}"
+  fi
+  if [[ -n "${user_tmp_credentials}" && -f "${user_tmp_credentials}" ]]; then
+    rm -f "${user_tmp_credentials}"
   fi
 }
 trap cleanup EXIT
@@ -130,24 +181,30 @@ elif [[ "${credentials_available}" != "true" ]]; then
 else
   IFS=',' read -r -a actions <<< "${actions_csv}"
   for action in "${actions[@]}"; do
+    selected_credentials_file="$(select_credentials_file "${action}")"
     stdout_file="$(mktemp)"
     stderr_file="$(mktemp)"
     set +e
-    if [[ -n "${credentials_file}" ]]; then
+    if [[ -n "${selected_credentials_file}" ]]; then
       bash "${ADAPTER}" \
         --action "${action}" \
         --format json \
         --run-dir "${RUN_DIR}" \
-        --credentials-file "${credentials_file}" \
+        --credentials-file "${selected_credentials_file}" \
+        > "${stdout_file}" 2> "${stderr_file}"
+    elif [[ "${local_oauth_available}" == "true" ]]; then
+      bash "${ADAPTER}" \
+        --action "${action}" \
+        --format json \
+        --run-dir "${RUN_DIR}" \
         > "${stdout_file}" 2> "${stderr_file}"
     else
-      bash "${ADAPTER}" \
-        --action "${action}" \
-        --format json \
-        --run-dir "${RUN_DIR}" \
-        > "${stdout_file}" 2> "${stderr_file}"
+      mkdir -p "${RUN_DIR}/googleworkspace"
+      printf '%s' '{"status":"skipped","message":"no matching credentials available"}' > "${RUN_DIR}/googleworkspace/${action}-meta.json"
+      echo "no matching credentials available" > "${stderr_file}"
+      rc=1
     fi
-    rc=$?
+    if [[ -z "${rc:-}" ]]; then rc=$?; fi
     set -e
 
     meta_file="${RUN_DIR}/googleworkspace/${action}-meta.json"
@@ -175,6 +232,7 @@ else
     if (( rc != 0 )) && [[ "${report_status}" == "ok" ]]; then
       report_status="partial"
     fi
+    unset rc
 
     rm -f "${stdout_file}" "${stderr_file}"
   done
@@ -208,6 +266,7 @@ fi
   echo "## Notes"
   echo
   echo "- Google Workspace remains peripheral evidence, not control-plane truth."
+  echo "- Gmail and weekly digest actions prefer GOOGLE_WORKSPACE_USER_CREDENTIALS_FILE/JSON when supplied."
   echo "- Errors on Gmail actions under service-account mode are expected when mailbox access is unavailable."
 } > "${REPORT_PATH}"
 

--- a/tests/test-googleworkspace-preflight-enrich.sh
+++ b/tests/test-googleworkspace-preflight-enrich.sh
@@ -45,7 +45,7 @@ if [[ -n "${TMP_ADAPTER_CALLS_LOG:-}" ]]; then
   printf '%s\n' "${action}" >> "${TMP_ADAPTER_CALLS_LOG}"
 fi
 if [[ -n "${credentials_file}" && -n "${TMP_ADAPTER_CREDENTIALS_LOG:-}" ]]; then
-  cat "${credentials_file}" > "${TMP_ADAPTER_CREDENTIALS_LOG}"
+  printf '%s\t%s\n' "${action}" "$(tr -d '\n' < "${credentials_file}")" >> "${TMP_ADAPTER_CREDENTIALS_LOG}"
 fi
 
 meta_file="${run_dir}/googleworkspace/${action}-meta.json"
@@ -58,9 +58,15 @@ case "${action}" in
     cat "${raw_file}"
     ;;
   gmail-triage)
-    printf '%s' '{"status":"error","message":"mailbox unavailable"}' > "${meta_file}"
-    echo "mailbox unavailable" >&2
-    exit 1
+    if [[ -n "${credentials_file}" ]] && grep -q '"type":"authorized_user"' "${credentials_file}"; then
+      printf '%s' '{"resultSizeEstimate":3}' > "${raw_file}"
+      printf '%s' '{"status":"ok","message":"ok"}' > "${meta_file}"
+      cat "${raw_file}"
+    else
+      printf '%s' '{"status":"error","message":"mailbox unavailable"}' > "${meta_file}"
+      echo "mailbox unavailable" >&2
+      exit 1
+    fi
     ;;
   *)
     printf '%s' '{"status":"error","message":"unsupported action"}' > "${meta_file}"
@@ -152,7 +158,48 @@ test_partial_report_and_outputs() {
     grep -q '^meeting-prep$' "${calls_log}" &&
     grep -q '^gmail-triage$' "${calls_log}" &&
     ! grep -q 'docs-create' "${calls_log}" &&
-    grep -q '"type":"service_account"' "${credentials_log}"
+    grep -q $'^meeting-prep\t.*"type":"service_account"' "${credentials_log}" &&
+    grep -q $'^gmail-triage\t.*"type":"service_account"' "${credentials_log}"
+}
+
+test_prefers_user_oauth_for_mailbox_actions() {
+  local work_dir="${tmp_dir}/user-oauth"
+  local home_dir="${work_dir}/home"
+  local calls_log="${work_dir}/calls.log"
+  local credentials_log="${work_dir}/credentials.log"
+  local output_file="${work_dir}/github-output.txt"
+  local report_path="${work_dir}/report.md"
+
+  mkdir -p "${work_dir}" "${home_dir}"
+
+  env \
+    HOME="${home_dir}" \
+    TMP_ADAPTER_CALLS_LOG="${calls_log}" \
+    TMP_ADAPTER_CREDENTIALS_LOG="${credentials_log}" \
+    GOOGLE_WORKSPACE_CLI_CREDENTIALS_JSON='{"type":"service_account","project_id":"demo"}' \
+    GOOGLE_WORKSPACE_USER_CREDENTIALS_JSON='{"type":"authorized_user","client_id":"abc","client_secret":"def","refresh_token":"ghi"}' \
+    ISSUE_NUMBER="43" \
+    ISSUE_TITLE="Meeting and inbox context" \
+    ISSUE_BODY="Need meeting prep and inbox triage." \
+    WORKSPACE_ACTIONS="meeting-prep,gmail-triage" \
+    WORKSPACE_DOMAINS="calendar,gmail" \
+    WORKSPACE_REASON="Issue mentions meetings and unread mail." \
+    WORKSPACE_SUGGESTED_PHASES="preflight-enrich" \
+    REPORT_PATH="${report_path}" \
+    OUT_DIR="${work_dir}" \
+    RUN_DIR="${work_dir}/run" \
+    GITHUB_OUTPUT="${output_file}" \
+    ADAPTER="${fake_adapter}" \
+    bash "${SCRIPT}" >/dev/null
+
+  grep -q '^workspace_preflight_status=ok$' "${output_file}" &&
+    grep -q 'meeting-prep: next meeting at 10:00' "${output_file}" &&
+    grep -q 'gmail-triage: resultSizeEstimate=3' "${output_file}" &&
+    grep -q -- '- status: ok' "${report_path}" &&
+    grep -q '| meeting-prep | ok | next meeting at 10:00 |' "${report_path}" &&
+    grep -q '| gmail-triage | ok | resultSizeEstimate=3 |' "${report_path}" &&
+    grep -q $'^meeting-prep\t.*"type":"service_account"' "${credentials_log}" &&
+    grep -q $'^gmail-triage\t.*"type":"authorized_user"' "${credentials_log}"
 }
 
 echo "=== googleworkspace-preflight-enrich.sh unit tests ==="
@@ -160,6 +207,7 @@ echo ""
 
 assert_ok "skips-without-credentials" test_skips_without_credentials
 assert_ok "partial-report-and-outputs" test_partial_report_and_outputs
+assert_ok "prefers-user-oauth-for-mailbox-actions" test_prefers_user_oauth_for_mailbox_actions
 
 echo ""
 echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="


### PR DESCRIPTION
## Summary
- teach readonly Workspace preflight to prefer optional user OAuth credentials for mailbox actions
- wire the optional protected environment secret into the reusable workflow and manual smoke workflow
- document the CI secret contract for unmasked gws auth export JSON

## Verification
- bash tests/test-googleworkspace-preflight-enrich.sh
- bash tests/test-googleworkspace-cli-adapter.sh
- bash -n scripts/harness/googleworkspace-preflight-enrich.sh tests/test-googleworkspace-preflight-enrich.sh scripts/lib/googleworkspace-cli-adapter.sh
- local live preflight: meeting-prep + gmail-triage both ok with service account + gws auth export --unmasked