### PR TITLE
fix: scrub ambient gws credential env for local oauth

### DIFF
--- a/scripts/lib/googleworkspace-cli-adapter.sh
+++ b/scripts/lib/googleworkspace-cli-adapter.sh
@@ -144,6 +144,33 @@ print_command() {
   printf '\n'
 }
 
+run_gws_command() {
+  local stdout_path="${1:-}"
+  local stderr_path="${2:-}"
+  shift 2
+  local cmd=("$@")
+  local env_cmd=(
+    env
+    -u GOOGLE_API_KEY
+    -u GOOGLE_APPLICATION_CREDENTIALS
+    -u GOOGLE_CLOUD_PROJECT
+    -u GCLOUD_PROJECT
+    -u GOOGLE_CREDENTIALS_PATH
+    -u GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE
+    -u FUGUE_GWS_CREDENTIALS_FILE
+    -u KERNEL_GWS_CREDENTIALS_FILE
+  )
+  if [[ -n "${credentials_file}" ]]; then
+    env_cmd+=("GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE=${credentials_file}")
+  fi
+
+  if [[ -n "${stdout_path}" ]]; then
+    "${env_cmd[@]}" "${cmd[@]}" > "${stdout_path}" 2> "${stderr_path}"
+  else
+    "${env_cmd[@]}" "${cmd[@]}"
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --action)
@@ -456,52 +483,21 @@ fi
 require_cmd gws
 
 if [[ "${action}" == "smoke" ]]; then
-  if [[ -n "${credentials_file}" ]]; then
-    env -u GOOGLE_API_KEY \
-      -u GOOGLE_APPLICATION_CREDENTIALS \
-      -u GOOGLE_CLOUD_PROJECT \
-      -u GCLOUD_PROJECT \
-      -u GOOGLE_CREDENTIALS_PATH \
-      GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE="${credentials_file}" \
-      "${cmd[@]}" >/dev/null
-  else
-    "${cmd[@]}" >/dev/null
-  fi
+  run_gws_command "/dev/null" "/dev/null" "${cmd[@]}"
   write_meta "ok" 0 "adapter ready" "{}"
   echo "googleworkspace-cli adapter ready"
   exit 0
 fi
 
 if [[ -z "${meta_output_path}" ]]; then
-  if [[ -n "${credentials_file}" ]]; then
-    exec env -u GOOGLE_API_KEY \
-      -u GOOGLE_APPLICATION_CREDENTIALS \
-      -u GOOGLE_CLOUD_PROJECT \
-      -u GCLOUD_PROJECT \
-      -u GOOGLE_CREDENTIALS_PATH \
-      GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE="${credentials_file}" \
-      "${cmd[@]}"
-  fi
-  exec "${cmd[@]}"
+  run_gws_command "" "" "${cmd[@]}"
+  exit 0
 fi
 
-if [[ -n "${credentials_file}" ]]; then
-  set +e
-  env -u GOOGLE_API_KEY \
-    -u GOOGLE_APPLICATION_CREDENTIALS \
-    -u GOOGLE_CLOUD_PROJECT \
-    -u GCLOUD_PROJECT \
-    -u GOOGLE_CREDENTIALS_PATH \
-    GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE="${credentials_file}" \
-    "${cmd[@]}" > "${raw_output_path}" 2> "${stderr_output_path}"
-  rc=$?
-  set -e
-else
-  set +e
-  "${cmd[@]}" > "${raw_output_path}" 2> "${stderr_output_path}"
-  rc=$?
-  set -e
-fi
+set +e
+run_gws_command "${raw_output_path}" "${stderr_output_path}" "${cmd[@]}"
+rc=$?
+set -e
 
 receipt_json="$(extract_receipt "${raw_output_path}")"
 status="ok"

--- a/tests/test-googleworkspace-cli-adapter.sh
+++ b/tests/test-googleworkspace-cli-adapter.sh
@@ -16,6 +16,11 @@ cat > "${fake_gws}" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "${GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE+x}" == "x" && -z "${GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE}" ]]; then
+  echo '{"error":"empty-credentials-env"}' >&2
+  exit 11
+fi
+
 if [[ "${1:-}" == "--help" ]]; then
   echo "gws help"
   exit 0
@@ -105,12 +110,26 @@ test_readonly_evidence_written() {
   test -s "${run_dir}/googleworkspace/meeting-prep.json"
 }
 
+test_readonly_clears_empty_ambient_credentials_env() {
+  local run_dir="${tmp_dir}/ambient-empty"
+  mkdir -p "${run_dir}"
+  local output
+  output="$(env PATH="${tmp_dir}:${PATH}" GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE="" "${ADAPTER}" \
+    --action gmail-triage \
+    --format json \
+    --run-dir "${run_dir}")"
+  echo "${output}" | jq -e '.resultSizeEstimate == 3' >/dev/null
+  jq -e '.status == "ok" and .exit_code == 0' \
+    "${run_dir}/googleworkspace/gmail-triage-meta.json" >/dev/null
+}
+
 echo "=== googleworkspace-cli-adapter.sh unit tests ==="
 echo ""
 
 assert_ok "write-gate-blocked" test_write_gate_blocked
 assert_ok "write-receipt-logged" test_write_receipt_logged
 assert_ok "readonly-evidence-written" test_readonly_evidence_written
+assert_ok "readonly-clears-empty-ambient-credentials-env" test_readonly_clears_empty_ambient_credentials_env
 
 echo ""
 echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="


### PR DESCRIPTION
## Summary
- scrub ambient Google Workspace credential env vars before invoking gws so empty inherited values do not break local OAuth fallback
- keep explicit --credentials-file behavior unchanged while unsetting conflicting FUGUE/KERNEL env hints
- add adapter coverage for the empty ambient credential env case

## Verification
- bash tests/test-googleworkspace-cli-adapter.sh
- bash tests/test-googleworkspace-scheduled-extract.sh
- bash -n scripts/lib/googleworkspace-cli-adapter.sh tests/test-googleworkspace-cli-adapter.sh