### PR TITLE
feat: reinject scheduled GWS feed into Kernel context

### DIFF
--- a/.github/workflows/fugue-codex-implement.yml
+++ b/.github/workflows/fugue-codex-implement.yml
@@ -87,6 +87,21 @@ on:
         required: false
         type: string
         default: ""
+      workspace_feed_status:
+        description: "Latest scheduled Google Workspace feed ingest status"
+        required: false
+        type: string
+        default: ""
+      workspace_feed_profiles:
+        description: "Comma-separated scheduled Google Workspace feed profiles used for context"
+        required: false
+        type: string
+        default: ""
+      workspace_feed_summary:
+        description: "Bounded summary derived from scheduled Google Workspace feeds"
+        required: false
+        type: string
+        default: ""
       workspace_readonly_environment:
         description: "Protected GitHub Environment used for readonly Google Workspace CI preflight"
         required: false
@@ -614,6 +629,9 @@ jobs:
           WORKSPACE_REPORT_PATH: ${{ needs.workspace-preflight.outputs.workspace_report_path }}
           WORKSPACE_SUMMARY: ${{ needs.workspace-preflight.outputs.workspace_summary }}
           WORKSPACE_PREFLIGHT_STATUS: ${{ needs.workspace-preflight.outputs.workspace_preflight_status }}
+          WORKSPACE_FEED_STATUS: ${{ inputs.workspace_feed_status }}
+          WORKSPACE_FEED_PROFILES: ${{ inputs.workspace_feed_profiles }}
+          WORKSPACE_FEED_SUMMARY: ${{ inputs.workspace_feed_summary }}
         run: bash scripts/harness/codex-execute-validate.sh
 
       - name: Commit changes

--- a/.github/workflows/fugue-status.yml
+++ b/.github/workflows/fugue-status.yml
@@ -410,6 +410,8 @@ jobs:
           $(wf_line "fugue-tutti-caller.yml" "mainframe")
           $(wf_line "fugue-task-router.yml" "router")
           $(wf_line "fugue-watchdog.yml" "watchdog")
+          $(wf_line "googleworkspace-feed-sync.yml" "gws-shared-feed")
+          $(wf_line "googleworkspace-personal-feed-sync.yml" "gws-personal-feed")
 
           **Top open issues**
           ${top}

--- a/.github/workflows/fugue-tutti-caller.yml
+++ b/.github/workflows/fugue-tutti-caller.yml
@@ -121,6 +121,9 @@ jobs:
       workspace_suggested_phases: ${{ steps.ctx.outputs.workspace_suggested_phases }}
       workspace_readonly_actions: ${{ steps.ctx.outputs.workspace_readonly_actions }}
       workspace_approval_required_actions: ${{ steps.ctx.outputs.workspace_approval_required_actions }}
+      workspace_feed_status: ${{ steps.ctx.outputs.workspace_feed_status }}
+      workspace_feed_profiles: ${{ steps.ctx.outputs.workspace_feed_profiles }}
+      workspace_feed_summary: ${{ steps.ctx.outputs.workspace_feed_summary }}
       vote_instruction: ${{ steps.ctx.outputs.vote_instruction }}
     steps:
       - name: Checkout repository
@@ -156,6 +159,9 @@ jobs:
           CLAUDE_TRANSLATOR_THRESHOLD_DEGRADED_CLAUDE_LIGHT: ${{ vars.FUGUE_CLAUDE_TRANSLATOR_THRESHOLD_DEGRADED_CLAUDE_LIGHT || '95' }}
           CLAUDE_TRANSLATOR_MAX_CHARS: ${{ vars.FUGUE_CLAUDE_TRANSLATOR_MAX_CHARS || '6000' }}
           CLAUDE_TRANSLATOR_MODEL: ${{ vars.FUGUE_CLAUDE_TRANSLATOR_MODEL || 'claude-sonnet-4-6' }}
+          GOOGLEWORKSPACE_FEED_SYNC_ENABLE: ${{ vars.FUGUE_GOOGLEWORKSPACE_FEED_SYNC_ENABLE || 'true' }}
+          GOOGLEWORKSPACE_FEED_FETCH_REMOTE: true
+          GOOGLEWORKSPACE_FEED_BRANCH: main
           CODEX_MAIN_MODEL: ${{ vars.FUGUE_CODEX_MAIN_MODEL || 'gpt-5.4' }}
           CODEX_MULTI_AGENT_MODEL: ${{ vars.FUGUE_CODEX_MULTI_AGENT_MODEL || 'gpt-5.3-codex-spark' }}
           DEFAULT_MULTI_AGENT_MODE: ${{ vars.FUGUE_MULTI_AGENT_MODE || '' }}
@@ -531,6 +537,9 @@ jobs:
       workspace_suggested_phases: "${{ needs.ctx.outputs.workspace_suggested_phases }}"
       workspace_readonly_actions: "${{ needs.ctx.outputs.workspace_readonly_actions }}"
       workspace_approval_required_actions: "${{ needs.ctx.outputs.workspace_approval_required_actions }}"
+      workspace_feed_status: "${{ needs.ctx.outputs.workspace_feed_status }}"
+      workspace_feed_profiles: "${{ needs.ctx.outputs.workspace_feed_profiles }}"
+      workspace_feed_summary: "${{ needs.ctx.outputs.workspace_feed_summary }}"
       workspace_readonly_environment: "${{ vars.FUGUE_WORKSPACE_READONLY_ENV || 'workspace-readonly' }}"
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/docs/googleworkspace-feed-sync-design.md
+++ b/docs/googleworkspace-feed-sync-design.md
@@ -106,9 +106,19 @@ Reflection happens in two stages:
 2. `googleworkspace-feed-ingest.sh`
    - selects only fresh manifests
    - collapses them into one bounded context JSON
-3. `googleworkspace-personal-feed-sync.yml`
+3. `googleworkspace-fetch-feed-artifacts.sh`
+   - downloads the latest successful shared and personal feed artifacts when CI
+     needs fresh scheduled evidence
+4. `resolve-orchestration-context.sh`
+   - emits `workspace_feed_status`, `workspace_feed_profiles`, and
+     `workspace_feed_summary` for reusable workflows
+5. `codex-execute-validate.sh`
+   - injects only the combined feed summary into the prompt as peripheral evidence
+6. `googleworkspace-personal-feed-sync.yml`
    - runs personal readonly profiles on always-on GitHub Actions
-4. `googleworkspace-feed-sync-local.sh`
+7. `run-local-orchestration.sh`
+   - stores `googleworkspace-feed-context.json` beside each local run summary
+8. `googleworkspace-feed-sync-local.sh`
    - remains an operator fallback, not the primary scheduler
 
 The sovereign prompt should ingest only the combined summary, not the raw

--- a/docs/googleworkspace-skills-profile.md
+++ b/docs/googleworkspace-skills-profile.md
@@ -266,6 +266,7 @@ Current CI path:
 - raw readonly evidence lands at:
   - `.fugue/pre-implement/googleworkspace-run/googleworkspace/`
 - scheduled feed sync prototype:
+  - `scripts/harness/googleworkspace-fetch-feed-artifacts.sh`
   - `config/integrations/googleworkspace-feed-policy.json`
   - `scripts/harness/resolve-googleworkspace-feed-matrix.sh`
   - `scripts/harness/googleworkspace-scheduled-extract.sh`
@@ -273,6 +274,13 @@ Current CI path:
   - `.github/workflows/googleworkspace-feed-sync.yml`
   - `.github/workflows/googleworkspace-personal-feed-sync.yml`
   - `scripts/local/googleworkspace-feed-sync-local.sh`
+  - `scripts/harness/resolve-orchestration-context.sh` can fetch the latest
+    feed artifacts and emit `workspace_feed_*` outputs
+  - `scripts/harness/codex-execute-validate.sh` injects only feed summaries,
+    never raw payloads, into Codex execution prompts
+  - `scripts/local/run-local-orchestration.sh` writes
+    `googleworkspace-feed-context.json` into each run directory
+  - `fugue-status` reports the latest feed workflow runs in status comments
 
 ## Safety Rules
 

--- a/docs/kernel-googleworkspace-integration-design.md
+++ b/docs/kernel-googleworkspace-integration-design.md
@@ -205,10 +205,18 @@ Current implemented baseline:
   - turns scheduled readonly profiles into cached Workspace feed manifests
 - `scripts/harness/googleworkspace-feed-ingest.sh`
   - rehydrates only fresh feed manifests into a bounded context envelope
+- `scripts/harness/googleworkspace-fetch-feed-artifacts.sh`
+  - fetches the latest successful shared and personal feed artifacts from GitHub Actions
 - `scripts/harness/resolve-googleworkspace-feed-matrix.sh`
   - resolves shared vs personal feed profiles into workflow matrices
+- `scripts/harness/resolve-orchestration-context.sh`
+  - can rehydrate scheduled feed evidence into `workspace_feed_*` outputs for CI
 - `scripts/local/googleworkspace-feed-sync-local.sh`
   - remains an operator fallback when local-only replay is needed
+- `scripts/local/run-local-orchestration.sh`
+  - stores `googleworkspace-feed-context.json` in each local run directory
+- `scripts/harness/codex-execute-validate.sh`
+  - injects only scheduled feed summaries into Codex instructions as bounded peripheral evidence
 - `.github/workflows/fugue-tutti-caller.yml`
   - forwards `workspace_*` hints into the reusable Codex implementation workflow
 - `.github/workflows/fugue-codex-implement.yml`
@@ -219,6 +227,8 @@ Current implemented baseline:
   - runs low-frequency shared readonly feed sync profiles on schedule or manual dispatch
 - `.github/workflows/googleworkspace-personal-feed-sync.yml`
   - runs always-on personal readonly mailbox feeds in a dedicated environment
+- `.github/workflows/fugue-status.yml`
+  - reports the latest shared and personal Google Workspace feed runs in status comments
 
 Kernel admission rules:
 
@@ -259,22 +269,11 @@ Kernel admission rules:
 - allowing unattended write actions in the default loop
 - forcing session-backed MCP adapters into this same shape
 
-## Next Implementation Steps
+## Remaining Follow-Ups
 
-1. Add a `Kernel` evidence writer that stores summarized Workspace envelopes
-   under a dedicated run directory.
-2. Add intent-to-action routing in the intake classifier for meeting, inbox,
-   document, and reporting signals.
-3. Add optional read helpers for `drive search`, `docs read`, and `sheets read`
+1. Add optional read helpers for `drive search`, `docs read`, and `sheets read`
    to reduce fallback raw API usage.
-4. Add an approval receipt log for Workspace write actions.
-5. Keep CI Workspace auth limited to protected readonly secrets only:
-   service-account JSON for shared context and optional user OAuth export JSON
-   for mailbox helpers. Do not run unattended write actions in reusable
-   workflows.
-6. Require a protected GitHub `Environment` such as `workspace-readonly` before
-   CI can access readonly Workspace credentials.
-7. Add scheduled feed extraction only for low-frequency readonly profiles and
-   gate stale feeds with TTL before reinjecting into Kernel/FUGUE prompts.
-8. Keep personal mailbox feed extraction in a dedicated readonly GitHub
-   environment rather than relying on a local machine to stay online.
+2. Add an approval receipt log for Workspace write actions.
+3. Tune phase-specific reinjection rules so only the minimum fresh feed summary
+   returns to each prompt.
+4. Expand live smoke coverage when new scheduled feed profiles are introduced.

--- a/scripts/harness/codex-execute-validate.sh
+++ b/scripts/harness/codex-execute-validate.sh
@@ -82,6 +82,9 @@ critic_report="${CRITIC_REPORT_PATH:-.fugue/pre-implement/issue-${ISSUE_NUMBER}-
 workspace_report="${WORKSPACE_REPORT_PATH:-}"
 workspace_summary="$(printf '%s' "${WORKSPACE_SUMMARY:-}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^[[:space:]]+|[[:space:]]+$//g')"
 workspace_preflight_status="$(echo "${WORKSPACE_PREFLIGHT_STATUS:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+workspace_feed_status="$(echo "${WORKSPACE_FEED_STATUS:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+workspace_feed_profiles="$(printf '%s' "${WORKSPACE_FEED_PROFILES:-}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+workspace_feed_summary="$(printf '%s' "${WORKSPACE_FEED_SUMMARY:-}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^[[:space:]]+|[[:space:]]+$//g')"
 title_text="$(printf '%s\n' "${ISSUE_TITLE}" | tr '[:upper:]' '[:lower:]')"
 goal_text="$(printf '%s\n' "${ISSUE_BODY}" | awk '
   BEGIN { capture=0 }
@@ -107,6 +110,17 @@ if [[ -n "${workspace_report}" || -n "${workspace_summary}" || -n "${workspace_p
 - Workspace report path: ${workspace_report:-none}
 - Workspace summary: ${workspace_summary:-none}
 - Use Workspace evidence only to enrich context, coordination, and stakeholder-facing artifacts.
+EOF
+)"
+fi
+if [[ -n "${workspace_feed_status}" || -n "${workspace_feed_summary}" || -n "${workspace_feed_profiles}" ]]; then
+  workspace_instruction="${workspace_instruction}$(cat <<EOF
+
+## Google Workspace scheduled feed evidence
+- Scheduled feed status: ${workspace_feed_status:-none}
+- Scheduled feed profiles: ${workspace_feed_profiles:-none}
+- Scheduled feed summary: ${workspace_feed_summary:-none}
+- Use scheduled feed evidence only when it reduces repeated lookups; ignore it if it conflicts with fresher issue or preflight context.
 EOF
 )"
 fi

--- a/scripts/harness/googleworkspace-feed-ingest.sh
+++ b/scripts/harness/googleworkspace-feed-ingest.sh
@@ -6,6 +6,8 @@ POLICY_FILE="${GOOGLEWORKSPACE_FEED_POLICY_FILE:-config/integrations/googleworks
 OUT_ROOT="${OUT_ROOT:-}"
 NOW_ISO="${NOW_ISO:-}"
 OUT_FILE="${OUT_FILE:-}"
+WORKSPACE_ACTIONS="${WORKSPACE_ACTIONS:-}"
+WORKSPACE_REASON="${WORKSPACE_REASON:-}"
 
 fail() {
   echo "ERROR: $*" >&2
@@ -37,6 +39,22 @@ fi
 
 if [[ -n "${FEED_PROFILES}" ]]; then
   requested_profiles_json="$(csv_to_json_array "${FEED_PROFILES}")"
+elif [[ -n "${WORKSPACE_ACTIONS}" || -n "${WORKSPACE_REASON}" ]]; then
+  requested_profiles_json="$(jq -c \
+    --arg actions_csv "${WORKSPACE_ACTIONS}" \
+    --arg reason_csv "${WORKSPACE_REASON}" '
+    ($actions_csv | split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0))) as $actions
+    | ($reason_csv | split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) | map(select(length > 0))) as $reasons
+    | [
+        .profiles
+        | to_entries[]
+        | select(.value.enabled_by_default == true)
+        | select(
+            ([ (.value.actions // [])[] as $profile_action | select($actions | index($profile_action) != null) ] | length) > 0
+            or ([ (.value.reason // [])[] as $profile_reason | select($reasons | index($profile_reason) != null) ] | length) > 0
+          )
+        | .key
+      ]' "${POLICY_FILE}")"
 else
   requested_profiles_json="$(jq -c '[.profiles | to_entries[] | select(.value.enabled_by_default == true) | .key]' "${POLICY_FILE}")"
 fi
@@ -111,6 +129,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
     echo "feed_ingest_status=${status}"
     echo "feed_context_file=${OUT_FILE}"
+    echo "feed_requested_profiles=$(printf '%s' "${requested_profiles_json}" | jq -r 'join(",")')"
     echo "feed_summary<<EOF"
     echo "${combined_summary}"
     echo "EOF"

--- a/scripts/harness/googleworkspace-fetch-feed-artifacts.sh
+++ b/scripts/harness/googleworkspace-fetch-feed-artifacts.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-}"
+OUT_ROOT="${OUT_ROOT:-}"
+WORKFLOWS_CSV="${WORKFLOWS_CSV:-googleworkspace-feed-sync.yml,googleworkspace-personal-feed-sync.yml}"
+BRANCH="${BRANCH:-main}"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
+require_cmd gh
+require_cmd jq
+[[ -n "${REPO}" ]] || fail "GITHUB_REPOSITORY or REPO is required"
+[[ -n "${OUT_ROOT}" ]] || fail "OUT_ROOT is required"
+
+mkdir -p "${OUT_ROOT}"
+download_root="$(mktemp -d)"
+trap 'rm -rf "${download_root}"' EXIT
+
+IFS=',' read -r -a workflows <<< "${WORKFLOWS_CSV}"
+for workflow in "${workflows[@]}"; do
+  workflow="$(printf '%s' "${workflow}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+  [[ -n "${workflow}" ]] || continue
+
+  run_id="$(gh run list \
+    --repo "${REPO}" \
+    --workflow "${workflow}" \
+    --branch "${BRANCH}" \
+    --limit 10 \
+    --json databaseId,status,conclusion \
+    --jq '[.[] | select(.status == "completed" and .conclusion == "success")][0].databaseId // ""' 2>/dev/null || true)"
+
+  [[ -n "${run_id}" ]] || continue
+
+  workflow_dir="${download_root}/${workflow%.yml}"
+  mkdir -p "${workflow_dir}"
+  gh run download "${run_id}" --repo "${REPO}" --dir "${workflow_dir}" >/dev/null
+
+  while IFS= read -r artifact_dir; do
+    [[ -d "${artifact_dir}" ]] || continue
+    profile_id="$(basename "${artifact_dir}")"
+    profile_id="${profile_id#googleworkspace-feed-}"
+    profile_out="${OUT_ROOT%/}/${profile_id}"
+    mkdir -p "${profile_out}"
+    cp -R "${artifact_dir}/." "${profile_out}/"
+  done < <(find "${workflow_dir}" -maxdepth 1 -mindepth 1 -type d -name 'googleworkspace-feed-*' | sort)
+done
+
+printf 'out_root=%s\n' "${OUT_ROOT}"

--- a/scripts/harness/resolve-orchestration-context.sh
+++ b/scripts/harness/resolve-orchestration-context.sh
@@ -57,6 +57,9 @@ CLAUDE_DEGRADED_ASSIST_POLICY="${CLAUDE_DEGRADED_ASSIST_POLICY:-claude}"
 CLAUDE_ROLE_POLICY="${CLAUDE_ROLE_POLICY:-flex}"
 CLAUDE_TRANSLATOR_MODEL="${CLAUDE_TRANSLATOR_MODEL:-claude-sonnet-4-6}"
 GOOGLEWORKSPACE_KERNEL_POLICY="${ROOT_DIR}/config/integrations/googleworkspace-kernel-policy.json"
+GOOGLEWORKSPACE_FEED_POLICY="${ROOT_DIR}/config/integrations/googleworkspace-feed-policy.json"
+GOOGLEWORKSPACE_FEED_INGEST="${ROOT_DIR}/scripts/harness/googleworkspace-feed-ingest.sh"
+GOOGLEWORKSPACE_FEED_FETCH="${ROOT_DIR}/scripts/harness/googleworkspace-fetch-feed-artifacts.sh"
 
 ISSUE_NUMBER=""
 if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
@@ -206,6 +209,10 @@ eval "$(
 workspace_suggested_phases=""
 workspace_readonly_actions=""
 workspace_approval_required_actions=""
+workspace_feed_status="skipped"
+workspace_feed_summary=""
+workspace_feed_profiles=""
+workspace_feed_context_path=""
 if [[ -f "${GOOGLEWORKSPACE_KERNEL_POLICY}" ]]; then
   workspace_policy_json="$(jq -cn \
     --arg action_hint "${workspace_action_hint}" \
@@ -240,6 +247,61 @@ if [[ -f "${GOOGLEWORKSPACE_KERNEL_POLICY}" ]]; then
   workspace_suggested_phases="$(echo "${workspace_policy_json}" | jq -r '.suggested_phases | join(",")')"
   workspace_readonly_actions="$(echo "${workspace_policy_json}" | jq -r '.readonly_actions | join(",")')"
   workspace_approval_required_actions="$(echo "${workspace_policy_json}" | jq -r '.approval_required_actions | join(",")')"
+fi
+
+workspace_feed_sync_enable="$(echo "${GOOGLEWORKSPACE_FEED_SYNC_ENABLE:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+if [[ "${workspace_feed_sync_enable}" != "true" ]]; then
+  workspace_feed_sync_enable="false"
+fi
+workspace_feed_fetch_remote="$(echo "${GOOGLEWORKSPACE_FEED_FETCH_REMOTE:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+if [[ "${workspace_feed_fetch_remote}" != "true" ]]; then
+  workspace_feed_fetch_remote="false"
+fi
+if [[ "${workspace_hint_applied}" == "true" && "${workspace_feed_sync_enable}" == "true" && -f "${GOOGLEWORKSPACE_FEED_POLICY}" && -f "${GOOGLEWORKSPACE_FEED_INGEST}" ]]; then
+  workspace_feed_out_root="${GOOGLEWORKSPACE_FEED_OUT_ROOT:-${ROOT_DIR}/.fugue/feeds/googleworkspace}"
+  workspace_feed_tmp_dir=""
+  if [[ "${workspace_feed_fetch_remote}" == "true" && -f "${GOOGLEWORKSPACE_FEED_FETCH}" ]]; then
+    workspace_feed_tmp_dir="$(mktemp -d)"
+    if env \
+      GITHUB_REPOSITORY="${GITHUB_REPOSITORY}" \
+      OUT_ROOT="${workspace_feed_tmp_dir}" \
+      WORKFLOWS_CSV="${GOOGLEWORKSPACE_FEED_WORKFLOWS:-googleworkspace-feed-sync.yml,googleworkspace-personal-feed-sync.yml}" \
+      BRANCH="${GOOGLEWORKSPACE_FEED_BRANCH:-main}" \
+      bash "${GOOGLEWORKSPACE_FEED_FETCH}" >/dev/null 2>&1
+    then
+      workspace_feed_out_root="${workspace_feed_tmp_dir}"
+    else
+      rm -rf "${workspace_feed_tmp_dir}"
+      workspace_feed_tmp_dir=""
+    fi
+  fi
+
+  if [[ -d "${workspace_feed_out_root}" ]]; then
+    workspace_feed_context_path="$(mktemp)"
+    workspace_feed_output_file="$(mktemp)"
+    if env \
+      WORKSPACE_ACTIONS="${workspace_action_hint}" \
+      WORKSPACE_REASON="${workspace_reason}" \
+      GOOGLEWORKSPACE_FEED_POLICY_FILE="${GOOGLEWORKSPACE_FEED_POLICY}" \
+      OUT_ROOT="${workspace_feed_out_root}" \
+      OUT_FILE="${workspace_feed_context_path}" \
+      GITHUB_OUTPUT="${workspace_feed_output_file}" \
+      bash "${GOOGLEWORKSPACE_FEED_INGEST}" >/dev/null 2>&1
+    then
+      workspace_feed_status="$(grep -E '^feed_ingest_status=' "${workspace_feed_output_file}" | head -n1 | cut -d= -f2- || true)"
+      workspace_feed_profiles="$(grep -E '^feed_active_profiles=' "${workspace_feed_output_file}" | head -n1 | cut -d= -f2- || true)"
+      workspace_feed_summary="$(awk '
+        $0 == "feed_summary<<EOF" { capture = 1; next }
+        capture && $0 == "EOF" { exit }
+        capture { print }
+      ' "${workspace_feed_output_file}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^[[:space:]]+|[[:space:]]+$//g')"
+    else
+      workspace_feed_status="skipped"
+      workspace_feed_summary=""
+      workspace_feed_profiles=""
+    fi
+    rm -f "${workspace_feed_output_file}"
+  fi
 fi
 
 requested_main_provider="${label_main_provider}"
@@ -856,6 +918,12 @@ fi
   echo "workspace_action_hint=${workspace_action_hint}"
   echo "workspace_domain_hint=${workspace_domain_hint}"
   echo "workspace_reason=${workspace_reason}"
+  echo "workspace_feed_status=${workspace_feed_status}"
+  echo "workspace_feed_profiles=${workspace_feed_profiles}"
+  echo "workspace_feed_context_path=${workspace_feed_context_path}"
+  echo "workspace_feed_summary<<EOF"
+  echo "${workspace_feed_summary}"
+  echo "EOF"
   echo "content_hint_applied=${content_hint_applied}"
   echo "content_action_hint=${content_action_hint}"
   echo "content_skill_hint=${content_skill_hint}"

--- a/scripts/local/run-local-orchestration.sh
+++ b/scripts/local/run-local-orchestration.sh
@@ -281,6 +281,8 @@ CLAUDE_TEAMS_POLICY="${ROOT_DIR}/scripts/lib/claude-teams-policy.sh"
 LINKED_RUNNER="${ROOT_DIR}/scripts/local/run-linked-systems.sh"
 ORCHESTRATOR_NL_HINTS="${ROOT_DIR}/scripts/lib/orchestrator-nl-hints.sh"
 GOOGLEWORKSPACE_KERNEL_POLICY="${ROOT_DIR}/config/integrations/googleworkspace-kernel-policy.json"
+GOOGLEWORKSPACE_FEED_POLICY="${ROOT_DIR}/config/integrations/googleworkspace-feed-policy.json"
+GOOGLEWORKSPACE_FEED_INGEST="${ROOT_DIR}/scripts/harness/googleworkspace-feed-ingest.sh"
 if [[ ! -x "${SUBSCRIPTION_RUNNER}" || ! -x "${HARNESS_RUNNER}" || ! -x "${MATRIX_BUILDER}" ]]; then
   echo "Error: required harness runners are missing/executable flags are not set." >&2
   exit 2
@@ -303,6 +305,14 @@ if [[ ! -x "${ORCHESTRATOR_NL_HINTS}" ]]; then
 fi
 if [[ ! -f "${GOOGLEWORKSPACE_KERNEL_POLICY}" ]]; then
   echo "Error: Google Workspace Kernel policy missing: ${GOOGLEWORKSPACE_KERNEL_POLICY}" >&2
+  exit 2
+fi
+if [[ ! -f "${GOOGLEWORKSPACE_FEED_POLICY}" ]]; then
+  echo "Error: Google Workspace feed policy missing: ${GOOGLEWORKSPACE_FEED_POLICY}" >&2
+  exit 2
+fi
+if [[ ! -x "${GOOGLEWORKSPACE_FEED_INGEST}" ]]; then
+  echo "Error: Google Workspace feed ingest script missing or not executable: ${GOOGLEWORKSPACE_FEED_INGEST}" >&2
   exit 2
 fi
 if [[ "${WITH_LINKED_SYSTEMS}" == "true" && ! -x "${LINKED_RUNNER}" ]]; then
@@ -409,6 +419,10 @@ workspace_hint_applied="$(echo "${workspace_hint_json}" | jq -r '.workspace_hint
 workspace_action_hint="$(echo "${workspace_hint_json}" | jq -r '.workspace_action_hint // ""')"
 workspace_domain_hint="$(echo "${workspace_hint_json}" | jq -r '.workspace_domain_hint // ""')"
 workspace_reason="$(echo "${workspace_hint_json}" | jq -r '.workspace_reason // ""')"
+workspace_feed_context_file="${RUN_DIR}/googleworkspace-feed-context.json"
+workspace_feed_status="skipped"
+workspace_feed_summary=""
+workspace_feed_profiles=""
 jq -cn \
   --argjson hints "${workspace_hint_json}" \
   --slurpfile policy "${GOOGLEWORKSPACE_KERNEL_POLICY}" \
@@ -437,6 +451,31 @@ jq -cn \
        ),
        policy_file: "config/integrations/googleworkspace-kernel-policy.json"
      }' > "${workspace_context_file}"
+
+if [[ "${workspace_hint_applied}" == "true" ]]; then
+  feed_out_root="${GOOGLEWORKSPACE_FEED_OUT_ROOT:-${ROOT_DIR}/.fugue/feeds/googleworkspace}"
+  if [[ -d "${feed_out_root}" ]]; then
+    workspace_feed_output_file="$(mktemp)"
+    if env \
+      WORKSPACE_ACTIONS="${workspace_action_hint}" \
+      WORKSPACE_REASON="${workspace_reason}" \
+      GOOGLEWORKSPACE_FEED_POLICY_FILE="${GOOGLEWORKSPACE_FEED_POLICY}" \
+      OUT_ROOT="${feed_out_root}" \
+      OUT_FILE="${workspace_feed_context_file}" \
+      GITHUB_OUTPUT="${workspace_feed_output_file}" \
+      bash "${GOOGLEWORKSPACE_FEED_INGEST}" >/dev/null 2>&1
+    then
+      workspace_feed_status="$(grep -E '^feed_ingest_status=' "${workspace_feed_output_file}" | head -n1 | cut -d= -f2- || true)"
+      workspace_feed_profiles="$(grep -E '^feed_active_profiles=' "${workspace_feed_output_file}" | head -n1 | cut -d= -f2- || true)"
+      workspace_feed_summary="$(awk '
+        $0 == "feed_summary<<EOF" { capture = 1; next }
+        capture && $0 == "EOF" { exit }
+        capture { print }
+      ' "${workspace_feed_output_file}" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^[[:space:]]+|[[:space:]]+$//g')"
+    fi
+    rm -f "${workspace_feed_output_file}"
+  fi
+fi
 
 strict_main="${FUGUE_STRICT_MAIN_CODEX_MODEL:-false}"
 strict_opus="${FUGUE_STRICT_OPUS_ASSIST_DIRECT:-false}"
@@ -995,7 +1034,11 @@ jq -n \
     workspace_action_hint:$workspace_action_hint,
     workspace_domain_hint:$workspace_domain_hint,
     workspace_reason:$workspace_reason,
-    workspace_context_file:$workspace_context_file
+    workspace_context_file:$workspace_context_file,
+    workspace_feed_status:$workspace_feed_status,
+    workspace_feed_summary:$workspace_feed_summary,
+    workspace_feed_profiles:$workspace_feed_profiles,
+    workspace_feed_context_file:$workspace_feed_context_file
   }' > "${integrated_json}"
 
 summary_md="${RUN_DIR}/summary.md"
@@ -1032,6 +1075,10 @@ cat > "${summary_md}" <<EOF
 - workspace action hint: ${workspace_action_hint}
 - workspace domain hint: ${workspace_domain_hint}
 - workspace context file: ${workspace_context_file}
+- workspace feed status: ${workspace_feed_status}
+- workspace feed profiles: ${workspace_feed_profiles}
+- workspace feed summary: ${workspace_feed_summary}
+- workspace feed context file: ${workspace_feed_context_file}
 - ok_to_execute: ${ok_to_execute}
 - run dir: ${RUN_DIR}
 EOF

--- a/tests/test-googleworkspace-feed-ingest.sh
+++ b/tests/test-googleworkspace-feed-ingest.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INGEST_SCRIPT="${SCRIPT_DIR}/scripts/harness/googleworkspace-feed-ingest.sh"
+
+passed=0
+failed=0
+total=0
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+policy_file="${tmp_dir}/policy.json"
+cat > "${policy_file}" <<'EOF'
+{
+  "version": 1,
+  "out_root": "__OUT_ROOT__",
+  "profiles": {
+    "morning-brief-shared": {
+      "enabled_by_default": true,
+      "actions": ["standup-report"],
+      "reason": ["standup-context"],
+      "ttl_minutes": 360
+    },
+    "morning-brief-personal": {
+      "enabled_by_default": true,
+      "actions": ["gmail-triage"],
+      "reason": ["mail-context"],
+      "ttl_minutes": 360
+    },
+    "weekly-digest-personal": {
+      "enabled_by_default": true,
+      "actions": ["weekly-digest"],
+      "reason": ["digest-context"],
+      "ttl_minutes": 10080
+    },
+    "pre-meeting-scan": {
+      "enabled_by_default": false,
+      "actions": ["meeting-prep"],
+      "reason": ["meeting-context", "document-context"],
+      "ttl_minutes": 45
+    }
+  }
+}
+EOF
+
+out_root="${tmp_dir}/feeds"
+sed -i.bak "s#__OUT_ROOT__#${out_root}#g" "${policy_file}"
+rm -f "${policy_file}.bak"
+
+mkdir -p "${out_root}/morning-brief-personal" "${out_root}/morning-brief-shared" "${out_root}/weekly-digest-personal"
+
+cat > "${out_root}/morning-brief-personal/latest.json" <<'EOF'
+{
+  "profile_id": "morning-brief-personal",
+  "status": "ok",
+  "summary": "gmail-triage: resultSizeEstimate=8",
+  "valid_until": "2026-03-07T12:00:00Z"
+}
+EOF
+
+cat > "${out_root}/morning-brief-shared/latest.json" <<'EOF'
+{
+  "profile_id": "morning-brief-shared",
+  "status": "skipped",
+  "summary": "standup-report: no meetings",
+  "valid_until": "2026-03-07T12:00:00Z"
+}
+EOF
+
+cat > "${out_root}/weekly-digest-personal/latest.json" <<'EOF'
+{
+  "profile_id": "weekly-digest-personal",
+  "status": "ok",
+  "summary": "weekly-digest: meetingCount=6, unreadEmails=14",
+  "valid_until": "2026-03-14T00:00:00Z"
+}
+EOF
+
+assert_ok() {
+  local test_name="$1"
+  shift
+  total=$((total + 1))
+  if "$@"; then
+    echo "PASS [${test_name}]"
+    passed=$((passed + 1))
+  else
+    echo "FAIL [${test_name}]"
+    failed=$((failed + 1))
+  fi
+}
+
+test_selects_enabled_profiles_from_workspace_hints() {
+  local output_file="${tmp_dir}/ingest-hints.out"
+  local context_file="${tmp_dir}/ingest-hints.json"
+
+  env \
+    WORKSPACE_ACTIONS="meeting-prep,gmail-triage" \
+    WORKSPACE_REASON="meeting-context,mail-context,document-context" \
+    NOW_ISO="2026-03-07T08:00:00Z" \
+    GOOGLEWORKSPACE_FEED_POLICY_FILE="${policy_file}" \
+    OUT_ROOT="${out_root}" \
+    OUT_FILE="${context_file}" \
+    GITHUB_OUTPUT="${output_file}" \
+    bash "${INGEST_SCRIPT}" >/dev/null
+
+  grep -q '^feed_ingest_status=ok$' "${output_file}" &&
+    grep -q '^feed_requested_profiles=morning-brief-personal$' "${output_file}" &&
+    grep -q '^feed_active_profiles=morning-brief-personal$' "${output_file}" &&
+    jq -e '.requested_profiles == ["morning-brief-personal"]' "${context_file}" >/dev/null &&
+    jq -e '.active_profiles == ["morning-brief-personal"]' "${context_file}" >/dev/null &&
+    jq -e '.summary == "morning-brief-personal: gmail-triage: resultSizeEstimate=8"' "${context_file}" >/dev/null
+}
+
+test_marks_stale_and_missing_profiles_partial() {
+  local output_file="${tmp_dir}/ingest-explicit.out"
+  local context_file="${tmp_dir}/ingest-explicit.json"
+
+  env \
+    FEED_PROFILES="morning-brief-personal,morning-brief-shared,weekly-digest-personal,missing-profile" \
+    NOW_ISO="2026-03-07T13:30:00Z" \
+    GOOGLEWORKSPACE_FEED_POLICY_FILE="${policy_file}" \
+    OUT_ROOT="${out_root}" \
+    OUT_FILE="${context_file}" \
+    GITHUB_OUTPUT="${output_file}" \
+    bash "${INGEST_SCRIPT}" >/dev/null
+
+  grep -q '^feed_ingest_status=partial$' "${output_file}" &&
+    grep -q '^feed_active_profiles=weekly-digest-personal$' "${output_file}" &&
+    jq -e '.active_profiles == ["weekly-digest-personal"]' "${context_file}" >/dev/null &&
+    jq -e '.stale_profiles == ["morning-brief-personal","morning-brief-shared"]' "${context_file}" >/dev/null &&
+    jq -e '.missing_profiles == ["missing-profile"]' "${context_file}" >/dev/null
+}
+
+test_defaults_to_all_enabled_profiles_without_hints() {
+  local output_file="${tmp_dir}/ingest-defaults.out"
+  local context_file="${tmp_dir}/ingest-defaults.json"
+
+  env \
+    NOW_ISO="2026-03-07T08:00:00Z" \
+    GOOGLEWORKSPACE_FEED_POLICY_FILE="${policy_file}" \
+    OUT_ROOT="${out_root}" \
+    OUT_FILE="${context_file}" \
+    GITHUB_OUTPUT="${output_file}" \
+    bash "${INGEST_SCRIPT}" >/dev/null
+
+  grep -q '^feed_ingest_status=partial$' "${output_file}" &&
+    grep -q '^feed_requested_profiles=morning-brief-shared,morning-brief-personal,weekly-digest-personal$' "${output_file}" &&
+    jq -e '.requested_profiles == ["morning-brief-shared","morning-brief-personal","weekly-digest-personal"]' "${context_file}" >/dev/null &&
+    jq -e '.active_profiles == ["morning-brief-personal","weekly-digest-personal"]' "${context_file}" >/dev/null &&
+    jq -e '.stale_profiles == ["morning-brief-shared"]' "${context_file}" >/dev/null
+}
+
+echo "=== googleworkspace feed ingest tests ==="
+echo ""
+
+assert_ok "selects-enabled-profiles-from-workspace-hints" test_selects_enabled_profiles_from_workspace_hints
+assert_ok "marks-stale-and-missing-profiles-partial" test_marks_stale_and_missing_profiles_partial
+assert_ok "defaults-to-all-enabled-profiles-without-hints" test_defaults_to_all_enabled_profiles_without_hints
+
+echo ""
+echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="
+
+if [[ "${failed}" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test-googleworkspace-fetch-feed-artifacts.sh
+++ b/tests/test-googleworkspace-fetch-feed-artifacts.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FETCH_SCRIPT="${SCRIPT_DIR}/scripts/harness/googleworkspace-fetch-feed-artifacts.sh"
+
+passed=0
+failed=0
+total=0
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+fake_bin="${tmp_dir}/bin"
+mkdir -p "${fake_bin}"
+
+cat > "${fake_bin}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
+  workflow=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --workflow)
+        workflow="${2:-}"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  case "${workflow}" in
+    googleworkspace-feed-sync.yml)
+      printf '101\n'
+      ;;
+    googleworkspace-personal-feed-sync.yml)
+      printf '202\n'
+      ;;
+    *)
+      printf '\n'
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ "${1:-}" == "run" && "${2:-}" == "download" ]]; then
+  run_id="${3:-}"
+  out_dir=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dir)
+        out_dir="${2:-}"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  mkdir -p "${out_dir}"
+  case "${run_id}" in
+    101)
+      mkdir -p "${out_dir}/googleworkspace-feed-morning-brief-shared"
+      cat > "${out_dir}/googleworkspace-feed-morning-brief-shared/latest.json" <<'JSON'
+{"profile_id":"morning-brief-shared","status":"ok","summary":"standup-report: meetings=0","valid_until":"2099-01-01T00:00:00Z"}
+JSON
+      ;;
+    202)
+      mkdir -p "${out_dir}/googleworkspace-feed-morning-brief-personal"
+      mkdir -p "${out_dir}/googleworkspace-feed-weekly-digest-personal"
+      cat > "${out_dir}/googleworkspace-feed-morning-brief-personal/latest.json" <<'JSON'
+{"profile_id":"morning-brief-personal","status":"ok","summary":"gmail-triage: resultSizeEstimate=10","valid_until":"2099-01-01T00:00:00Z"}
+JSON
+      cat > "${out_dir}/googleworkspace-feed-weekly-digest-personal/latest.json" <<'JSON'
+{"profile_id":"weekly-digest-personal","status":"ok","summary":"weekly-digest: meetingCount=4, unreadEmails=9","valid_until":"2099-01-01T00:00:00Z"}
+JSON
+      ;;
+    *)
+      ;;
+  esac
+  exit 0
+fi
+
+echo "unsupported gh invocation: $*" >&2
+exit 1
+EOF
+chmod +x "${fake_bin}/gh"
+
+assert_ok() {
+  local test_name="$1"
+  shift
+  total=$((total + 1))
+  if "$@"; then
+    echo "PASS [${test_name}]"
+    passed=$((passed + 1))
+  else
+    echo "FAIL [${test_name}]"
+    failed=$((failed + 1))
+  fi
+}
+
+test_downloads_and_normalizes_feed_artifacts() {
+  local out_root="${tmp_dir}/out"
+  env \
+    PATH="${fake_bin}:${PATH}" \
+    GITHUB_REPOSITORY="cursorvers/fugue-orchestrator" \
+    OUT_ROOT="${out_root}" \
+    bash "${FETCH_SCRIPT}" >/dev/null
+
+  [[ -f "${out_root}/morning-brief-shared/latest.json" ]] &&
+    [[ -f "${out_root}/morning-brief-personal/latest.json" ]] &&
+    [[ -f "${out_root}/weekly-digest-personal/latest.json" ]] &&
+    jq -e '.profile_id == "morning-brief-shared"' "${out_root}/morning-brief-shared/latest.json" >/dev/null &&
+    jq -e '.profile_id == "morning-brief-personal"' "${out_root}/morning-brief-personal/latest.json" >/dev/null &&
+    jq -e '.profile_id == "weekly-digest-personal"' "${out_root}/weekly-digest-personal/latest.json" >/dev/null
+}
+
+echo "=== googleworkspace feed artifact fetch tests ==="
+echo ""
+
+assert_ok "downloads-and-normalizes-feed-artifacts" test_downloads_and_normalizes_feed_artifacts
+
+echo ""
+echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="
+
+if [[ "${failed}" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test-resolve-orchestration-context.sh
+++ b/tests/test-resolve-orchestration-context.sh
@@ -49,6 +49,27 @@ exit 1
 EOF
 chmod +x "${fake_gh}"
 
+feed_root="${tmp_dir}/feeds"
+mkdir -p "${feed_root}/morning-brief-personal" "${feed_root}/weekly-digest-personal"
+
+cat > "${feed_root}/morning-brief-personal/latest.json" <<'EOF'
+{
+  "profile_id": "morning-brief-personal",
+  "status": "ok",
+  "summary": "gmail-triage: resultSizeEstimate=5",
+  "valid_until": "2099-01-01T00:00:00Z"
+}
+EOF
+
+cat > "${feed_root}/weekly-digest-personal/latest.json" <<'EOF'
+{
+  "profile_id": "weekly-digest-personal",
+  "status": "ok",
+  "summary": "weekly-digest: meetingCount=3, unreadEmails=11",
+  "valid_until": "2099-01-01T00:00:00Z"
+}
+EOF
+
 assert_output() {
   local test_name="$1"
   local issue_number="$2"
@@ -72,6 +93,8 @@ assert_output() {
     CLAUDE_MAIN_ASSIST_POLICY="codex" \
     CLAUDE_DEGRADED_ASSIST_POLICY="claude" \
     CLAUDE_ROLE_POLICY="flex" \
+    GOOGLEWORKSPACE_FEED_SYNC_ENABLE="true" \
+    GOOGLEWORKSPACE_FEED_OUT_ROOT="${feed_root}" \
     bash "${SCRIPT}" >/dev/null 2>"${tmp_dir}/${test_name}.stderr"; then
     echo "FAIL [${test_name}]: script exited with error"
     failed=$((failed + 1))
@@ -97,6 +120,8 @@ assert_output "workspace-action-hint" "123" "workspace_action_hint" "meeting-pre
 assert_output "workspace-domain-hint" "123" "workspace_domain_hint" "calendar,drive,docs,gmail"
 assert_output "workspace-phase-hint" "123" "workspace_suggested_phases" "preflight-enrich"
 assert_output "workspace-readonly-actions" "123" "workspace_readonly_actions" "meeting-prep,gmail-triage"
+assert_output "workspace-feed-status" "123" "workspace_feed_status" "ok"
+assert_output "workspace-feed-profiles" "123" "workspace_feed_profiles" "morning-brief-personal"
 assert_output "workspace-none" "124" "workspace_hint_applied" "false"
 assert_output "content-hint-applied" "125" "content_hint_applied" "true"
 assert_output "content-action-hint" "125" "content_action_hint" "slide-deck"


### PR DESCRIPTION
## Summary
- rehydrate scheduled Google Workspace feed evidence into CI and local orchestration context
- inject bounded feed summaries into Codex execution instructions and surface feed runs in fugue-status
- add coverage for feed ingest, artifact fetch, and resolve-context wiring

## Testing
- bash tests/test-googleworkspace-feed-ingest.sh
- bash tests/test-googleworkspace-fetch-feed-artifacts.sh
- bash tests/test-resolve-orchestration-context.sh
- bash tests/test-googleworkspace-scheduled-extract.sh
- bash tests/test-googleworkspace-feed-sync-local.sh
- bash tests/test-googleworkspace-preflight-enrich.sh
- bash tests/test-googleworkspace-cli-adapter.sh
- bash tests/test-orchestrator-nl-hints.sh
- bash tests/test-resolve-googleworkspace-feed-matrix.sh
- bash -n scripts/harness/googleworkspace-feed-ingest.sh scripts/harness/googleworkspace-fetch-feed-artifacts.sh scripts/harness/resolve-orchestration-context.sh scripts/local/run-local-orchestration.sh scripts/harness/codex-execute-validate.sh tests/test-googleworkspace-feed-ingest.sh tests/test-googleworkspace-fetch-feed-artifacts.sh tests/test-resolve-orchestration-context.sh tests/test-googleworkspace-scheduled-extract.sh tests/test-googleworkspace-feed-sync-local.sh tests/test-googleworkspace-preflight-enrich.sh tests/test-googleworkspace-cli-adapter.sh