### PR TITLE
fix: align codex main default to gpt-5.4

### DIFF
--- a/.github/workflows/fugue-status.yml
+++ b/.github/workflows/fugue-status.yml
@@ -195,7 +195,7 @@ jobs:
           ci_execution_engine="$(gh variable get FUGUE_CI_EXECUTION_ENGINE --repo "${GITHUB_REPOSITORY}" --json value -q '.value' 2>/dev/null || echo "subscription")"
           subscription_offline_policy="$(gh variable get FUGUE_SUBSCRIPTION_OFFLINE_POLICY --repo "${GITHUB_REPOSITORY}" --json value -q '.value' 2>/dev/null || echo "continuity")"
           subscription_runner_label="$(gh variable get FUGUE_SUBSCRIPTION_RUNNER_LABEL --repo "${GITHUB_REPOSITORY}" --json value -q '.value' 2>/dev/null || echo "fugue-subscription")"
-          codex_main_model="$(gh variable get FUGUE_CODEX_MAIN_MODEL --repo "${GITHUB_REPOSITORY}" --json value -q '.value' 2>/dev/null || echo "gpt-5-codex")"
+          codex_main_model="$(gh variable get FUGUE_CODEX_MAIN_MODEL --repo "${GITHUB_REPOSITORY}" --json value -q '.value' 2>/dev/null || echo "gpt-5.4")"
           codex_multi_agent_model="$(gh variable get FUGUE_CODEX_MULTI_AGENT_MODEL --repo "${GITHUB_REPOSITORY}" --json value -q '.value' 2>/dev/null || echo "gpt-5.3-codex-spark")"
           multi_agent_mode="$(gh variable get FUGUE_MULTI_AGENT_MODE --repo "${GITHUB_REPOSITORY}" --json value -q '.value' 2>/dev/null || echo "standard")"
           glm_subagent_mode="$(gh variable get FUGUE_GLM_SUBAGENT_MODE --repo "${GITHUB_REPOSITORY}" --json value -q '.value' 2>/dev/null || echo "paired")"
@@ -258,7 +258,7 @@ jobs:
             subscription_runner_label="fugue-subscription"
           fi
           if [[ -z "${codex_main_model}" ]]; then
-            codex_main_model="gpt-5-codex"
+            codex_main_model="gpt-5.4"
           fi
           if [[ -z "${codex_multi_agent_model}" ]]; then
             codex_multi_agent_model="gpt-5.3-codex-spark"

--- a/.github/workflows/fugue-task-router.yml
+++ b/.github/workflows/fugue-task-router.yml
@@ -617,7 +617,7 @@ jobs:
           XAI_MODEL: ${{ vars.FUGUE_XAI_MODEL || 'grok-4' }}
           GEMINI_PRIMARY_MODEL: ${{ vars.FUGUE_GEMINI_MODEL || 'gemini-3.1-pro' }}
           GEMINI_FALLBACK_MODEL: ${{ vars.FUGUE_GEMINI_FALLBACK_MODEL || 'gemini-3-flash' }}
-          CODEX_MAIN_MODEL: ${{ vars.FUGUE_CODEX_MAIN_MODEL || 'gpt-5-codex' }}
+          CODEX_MAIN_MODEL: ${{ vars.FUGUE_CODEX_MAIN_MODEL || 'gpt-5.4' }}
           CODEX_MULTI_AGENT_MODEL: ${{ vars.FUGUE_CODEX_MULTI_AGENT_MODEL || 'gpt-5.3-codex-spark' }}
           ISSUE_TITLE: ${{ steps.ctx.outputs.issue_title }}
           ISSUE_BODY: ${{ steps.ctx.outputs.issue_body }}
@@ -630,7 +630,7 @@ jobs:
           TIER="${{ steps.final.outputs.tier }}"
           TITLE="${ISSUE_TITLE}"
           BODY="${ISSUE_BODY}"
-          CODEX_MAIN_MODEL="gpt-5-codex"
+          CODEX_MAIN_MODEL="gpt-5.4"
           if ! [[ "${CODEX_MULTI_AGENT_MODEL}" =~ ^gpt-5(\.[0-9]+)?-codex-spark$ ]]; then
             CODEX_MULTI_AGENT_MODEL="gpt-5.3-codex-spark"
           fi
@@ -654,7 +654,7 @@ jobs:
           RESP_PROVIDER=""
           # Try OpenAI first if provider is codex
           if [[ "${PROVIDER}" == "codex" && -n "${OPENAI_API_KEY}" ]]; then
-            OPENAI_MODEL_CANDIDATES=("${CODEX_MULTI_AGENT_MODEL}" "${CODEX_MAIN_MODEL}" "gpt-5-codex")
+            OPENAI_MODEL_CANDIDATES=("${CODEX_MULTI_AGENT_MODEL}" "${CODEX_MAIN_MODEL}" "gpt-5.4")
             for OPENAI_MODEL in "${OPENAI_MODEL_CANDIDATES[@]}"; do
               REQ="$(jq -n --arg model "${OPENAI_MODEL}" --arg s "${SYS_PROMPT}" --arg u "${USER_PROMPT}" '{model:$model,messages:[{role:"system",content:$s},{role:"user",content:$u}],temperature:0.2}')"
               raw="$(curl -sS -w "\n%{http_code}" https://api.openai.com/v1/chat/completions \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ Auditability:
 - `FUGUE_REQUIRE_BASELINE_TRIO=true` enforces baseline trio success (`codex` + `claude` + `glm`) before execution approval (default enabled).
 - Multi-agent depth baseline is controlled by `FUGUE_MULTI_AGENT_MODE=standard|enhanced|max` (default `enhanced`), with complexity-based downshift/upshift when no explicit override is present.
 - Codex lane model split:
-  - `FUGUE_CODEX_MAIN_MODEL` for `codex-main-orchestrator` (default `gpt-5.3-codex`)
+- `FUGUE_CODEX_MAIN_MODEL` for `codex-main-orchestrator` (default `gpt-5.4`)
   - `FUGUE_CODEX_MULTI_AGENT_MODEL` for non-main codex lanes (default `gpt-5.3-codex-spark`)
 - GLM baseline model: `glm-5.0`.
 - `FUGUE_ALLOW_GLM_IN_SUBSCRIPTION=true` (default) keeps GLM baseline voters active even when `FUGUE_CI_EXECUTION_ENGINE=subscription` (hybrid: codex/claude via CLI, GLM via API).
@@ -182,7 +182,7 @@ scripts/sim-orchestrator-switch.sh
 
 Simulation common rule:
 - `FUGUE_SIM_CODEX_SPARK_ONLY=true` (default) forces simulation to run `codex-main` and codex multi-agent lanes on `gpt-5.3-codex-spark` for faster turnaround.
-- Set `FUGUE_SIM_CODEX_SPARK_ONLY=false` only when main-model parity testing against `gpt-5-codex` is explicitly required.
+- Set `FUGUE_SIM_CODEX_SPARK_ONLY=false` only when main-model parity testing against `gpt-5.4` is explicitly required.
 
 Use live rehearsal only when needed and clean up synthetic issues after verification.
 

--- a/docs/requirements-codex-main-claude-assist.md
+++ b/docs/requirements-codex-main-claude-assist.md
@@ -130,7 +130,7 @@ Required/optional repo variables:
 - `FUGUE_REQUIRE_DIRECT_CLAUDE_ASSIST` (`true|false`, default `false`; when true, `/vote` requires direct-success on `claude-opus-assist` under `assist=claude` + state=`ok`)
 - `FUGUE_REQUIRE_CLAUDE_SUB_ON_COMPLEX` (`true|false`, default `true`; require Claude sub gate on complex tasks only when assist=`claude`: `risk_tier=high` or ambiguity translation-gate=true)
 - `FUGUE_MIN_CONSENSUS_LANES` (integer >=6, default `6`; hard floor for resolved lane count in workflow/local orchestration)
-- `FUGUE_CODEX_MAIN_MODEL` (default `gpt-5-codex`; model for `codex-main-orchestrator` lane)
+- `FUGUE_CODEX_MAIN_MODEL` (default `gpt-5.4`; model for `codex-main-orchestrator` lane)
 - `FUGUE_CODEX_MULTI_AGENT_MODEL` (default `gpt-5.3-codex-spark`; model for non-main codex multi-agent lanes)
 - `FUGUE_API_STRICT_MODE` (`true|false`, default `false`; when false, strict guards are disabled in `harness|api` profiles)
 - `FUGUE_EMERGENCY_CONTINUITY_MODE` (`true|false`, default `false`; when true, only in-flight `processing` issues continue)


### PR DESCRIPTION
## Summary
- align the vote and status defaults for the codex main lane to gpt-5.4
- remove stale gpt-5-codex / gpt-5.3-codex default references from runtime-adjacent docs and workflows
- keep gpt-5.3-codex-spark as the multi-agent speed lane

## Testing
- actionlint .github/workflows/fugue-task-router.yml .github/workflows/fugue-status.yml