### PR TITLE
fix: keep vote handoff running past standby

### DIFF
--- a/scripts/harness/route-task-handoff.sh
+++ b/scripts/harness/route-task-handoff.sh
@@ -39,6 +39,12 @@ case "${execution_mode_override}" in
   auto|primary|backup-safe|backup-heavy) ;;
   *) execution_mode_override="auto" ;;
 esac
+resolved_execution_mode_override="${execution_mode_override}"
+if [[ "${resolved_execution_mode_override}" == "auto" && "${IS_VOTE_COMMAND}" == "true" ]]; then
+  # /vote is an explicit human handoff signal, so do not strand it in
+  # record-only standby. Keep GitHub-hosted consensus moving.
+  resolved_execution_mode_override="primary"
+fi
 if [[ "${IS_VOTE_COMMAND}" == "true" ]]; then
   # Keep structured parsing immune to comment-injected headings.
   text="$(printf '%s\n%s\n' "${title}" "${body}")"
@@ -509,8 +515,8 @@ fi
 if [[ -n "${subscription_offline_policy_override}" ]]; then
   dispatch_args+=(-f subscription_offline_policy_override="${subscription_offline_policy_override}")
 fi
-if [[ "${execution_mode_override}" != "auto" ]]; then
-  dispatch_args+=(-f execution_mode_override="${execution_mode_override}")
+if [[ "${resolved_execution_mode_override}" != "auto" ]]; then
+  dispatch_args+=(-f execution_mode_override="${resolved_execution_mode_override}")
 fi
 
 bridge_handoff_script="scripts/harness/fugue-bridge-handoff.sh"
@@ -531,7 +537,7 @@ if [[ "${handoff_target}" == "fugue-bridge" ]]; then
     --implement-request "${wants_implement}"
     --implement-confirmed "${confirm_implement}"
     --vote-command "${IS_VOTE_COMMAND}"
-    --execution-mode-override "${execution_mode_override}"
+    --execution-mode-override "${resolved_execution_mode_override}"
   )
   if [[ -n "${trust_subject}" ]]; then
     bridge_args+=(--trust-subject "${trust_subject}")

--- a/tests/test-route-task-handoff.sh
+++ b/tests/test-route-task-handoff.sh
@@ -41,6 +41,7 @@ assert_case() {
   local expected_confirm="$6"
   local expect_implement_label="$7"
   local execution_mode_override="${8:-auto}"
+  local expected_dispatch_override="${9:-${execution_mode_override}}"
   local out_file="${TMP_DIR}/${name}.out"
   local actual_mode=""
   local workflow_line=""
@@ -103,8 +104,14 @@ assert_case() {
     fi
   done
 
-  if [[ "${execution_mode_override}" != "auto" && "${workflow_line}" != *"-f execution_mode_override=${execution_mode_override}"* ]]; then
-    echo "FAIL [${name}]: workflow dispatch missing execution_mode_override=${execution_mode_override}"
+  if [[ "${expected_dispatch_override}" == "auto" ]]; then
+    if [[ "${workflow_line}" == *"-f execution_mode_override="* ]]; then
+      echo "FAIL [${name}]: workflow dispatch should not include execution_mode_override"
+      failed=$((failed + 1))
+      return
+    fi
+  elif [[ "${workflow_line}" != *"-f execution_mode_override=${expected_dispatch_override}"* ]]; then
+    echo "FAIL [${name}]: workflow dispatch missing execution_mode_override=${expected_dispatch_override}"
     failed=$((failed + 1))
     return
   fi
@@ -146,10 +153,10 @@ assert_case() {
 echo "=== route-task-handoff.sh unit tests ==="
 echo ""
 
-assert_case "vote-default-implement" "通常タスク" "" "implement" "true" "true" "true"
-assert_case "review-heading-wins" $'レビューのみでよい\n\n## Execution Mode\nreview' "" "review" "false" "false" "false"
-assert_case "vote-instruction-review" "通常タスク" "review only" "review" "false" "false" "false"
-assert_case "backup-heavy-override-passthrough" "通常タスク" "" "implement" "true" "true" "true" "backup-heavy"
+assert_case "vote-default-implement" "通常タスク" "" "implement" "true" "true" "true" "auto" "primary"
+assert_case "review-heading-wins" $'レビューのみでよい\n\n## Execution Mode\nreview' "" "review" "false" "false" "false" "auto" "primary"
+assert_case "vote-instruction-review" "通常タスク" "review only" "review" "false" "false" "false" "auto" "primary"
+assert_case "backup-heavy-override-passthrough" "通常タスク" "" "implement" "true" "true" "true" "backup-heavy" "backup-heavy"
 
 echo ""
 echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="

--- a/tests/test-vote-handoff-simulation.sh
+++ b/tests/test-vote-handoff-simulation.sh
@@ -78,6 +78,7 @@ run_case() {
   local expected_request="$6"
   local expected_confirm="$7"
   local expect_vote_instruction="$8"
+  local expected_execution_override="${9:-primary}"
   local handoff_out="${TMP_DIR}/${name}-handoff.out"
   local ctx_out="${TMP_DIR}/${name}-ctx.out"
   local dispatch_line=""
@@ -88,6 +89,7 @@ run_case() {
   local vote_instruction_b64=""
   local allow_processing_rerun=""
   local handoff_target=""
+  local execution_mode_override=""
 
   total=$((total + 1))
   : > "${FAKE_GH_LOG}"
@@ -148,15 +150,17 @@ run_case() {
   vote_instruction_b64="$(dispatch_value "${dispatch_line}" "vote_instruction_b64" || true)"
   allow_processing_rerun="$(dispatch_value "${dispatch_line}" "allow_processing_rerun" || true)"
   handoff_target="$(dispatch_value "${dispatch_line}" "handoff_target" || true)"
+  execution_mode_override="$(dispatch_value "${dispatch_line}" "execution_mode_override" || true)"
 
   if [[ "${requested_execution_mode}" != "${expected_mode}" || \
         "${implement_request}" != "${expected_request}" || \
         "${implement_confirmed}" != "${expected_confirm}" || \
         "${vote_command}" != "true" || \
         "${allow_processing_rerun}" != "true" || \
-        "${handoff_target}" != "kernel" ]]; then
+        "${handoff_target}" != "kernel" || \
+        "${execution_mode_override}" != "${expected_execution_override}" ]]; then
     echo "FAIL [${name}]: unexpected dispatch snapshot"
-    echo "  mode=${requested_execution_mode} request=${implement_request} confirm=${implement_confirmed} vote=${vote_command} rerun=${allow_processing_rerun} handoff=${handoff_target}"
+    echo "  mode=${requested_execution_mode} request=${implement_request} confirm=${implement_confirmed} vote=${vote_command} rerun=${allow_processing_rerun} handoff=${handoff_target} exec_override=${execution_mode_override}"
     failed=$((failed + 1))
     return
   fi


### PR DESCRIPTION
## Summary
- treat `/vote` as an explicit GitHub-hosted handoff signal instead of letting it fall into record-only standby
- auto-resolve `/vote` dispatches to `execution_mode_override=primary` unless an explicit override was provided
- cover the new handoff contract in route-task-handoff and vote simulation tests

## Testing
- bash tests/test-route-task-handoff.sh
- bash tests/test-vote-handoff-simulation.sh
- bash tests/test-fugue-bridge-handoff.sh