### PR TITLE
fix(canary): trust canary-owned dispatches in tutti router

### DIFF
--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -384,6 +384,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VOTE_COMMAND: ${{ steps.ctx.outputs.vote_command }}
+          CANARY_DISPATCH_OWNED: ${{ steps.ctx.outputs.canary_dispatch_owned }}
         run: |
           set -euo pipefail
           gh_api_retry() {
@@ -413,14 +414,19 @@ jobs:
           fi
           PERM="none"
 
-          perm_endpoint="repos/${GITHUB_REPOSITORY}/collaborators/${TRUST_SUBJECT}/permission"
-          perm_json="$(gh_api_retry "${perm_endpoint}" 4 || echo '{}')"
-          if echo "${perm_json}" | jq -e '.permission' >/dev/null 2>&1; then
-            PERM="$(echo "${perm_json}" | jq -r '.permission')"
+          canary_dispatch_owned="$(printf '%s' "${CANARY_DISPATCH_OWNED:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+          if [[ "${canary_dispatch_owned}" == "true" ]]; then
+            PERM="canary-bypass"
+          else
+            perm_endpoint="repos/${GITHUB_REPOSITORY}/collaborators/${TRUST_SUBJECT}/permission"
+            perm_json="$(gh_api_retry "${perm_endpoint}" 4 || echo '{}')"
+            if echo "${perm_json}" | jq -e '.permission' >/dev/null 2>&1; then
+              PERM="$(echo "${perm_json}" | jq -r '.permission')"
+            fi
           fi
 
           TRUSTED="false"
-          if [[ "${PERM}" == "write" || "${PERM}" == "maintain" || "${PERM}" == "admin" ]]; then
+          if [[ "${PERM}" == "write" || "${PERM}" == "maintain" || "${PERM}" == "admin" || "${PERM}" == "canary-bypass" ]]; then
             TRUSTED="true"
           fi
           if [[ "${VOTE_COMMAND}" == "true" ]]; then

--- a/tests/test-kernel-canary-plan.sh
+++ b/tests/test-kernel-canary-plan.sh
@@ -154,6 +154,14 @@ grep -q 'if \[\[ "\${canary_dispatch_owned}" == "true" \]\]; then' "${ROUTER_WOR
   echo "FAIL: router workflow should trust explicit caller-owned canary dispatch input" >&2
   exit 1
 }
+grep -q 'CANARY_DISPATCH_OWNED: \${{ steps.ctx.outputs.canary_dispatch_owned }}' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should receive canary dispatch ownership env" >&2
+  exit 1
+}
+grep -q 'PERM="canary-bypass"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should bypass collaborator permission for canary-owned dispatches" >&2
+  exit 1
+}
 echo "PASS [workflow-wiring]"
 
 plan_output="$(


### PR DESCRIPTION
## Summary
- bypass collaborator permission checks for caller-owned canary dispatches in the tutti router trust gate
- keep vote-based bypass unchanged and leave non-canary trust checks intact
- extend canary workflow wiring test to pin the trust-bypass path

## Testing
- bash tests/test-kernel-canary-plan.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fugue-tutti-router.yml"); YAML.load_file(".github/workflows/fugue-orchestrator-canary.yml"); YAML.load_file(".github/workflows/fugue-tutti-caller.yml"); puts "YAML OK"'