### PR TITLE
fix(canary): wire canary trust bypass through router ctx

### DIFF
--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -202,6 +202,7 @@ jobs:
       issue_body: ${{ steps.ctx.outputs.issue_body }}
       extra_issue_instruction: ${{ steps.ctx.outputs.extra_issue_instruction }}
       author: ${{ steps.ctx.outputs.author }}
+      canary_dispatch_owned: ${{ steps.ctx.outputs.canary_dispatch_owned }}
       trust_subject: ${{ steps.ctx.outputs.trust_subject }}
       has_implement_request: ${{ steps.ctx.outputs.has_implement_request }}
       emergency_continuity_mode: ${{ steps.ctx.outputs.emergency_continuity_mode }}
@@ -367,6 +368,7 @@ jobs:
             echo "${extra_issue_instruction}"
             echo "EOF"
             echo "author=${AUTHOR}"
+            echo "canary_dispatch_owned=${canary_dispatch_owned}"
             echo "trust_subject=${trust_subject}"
             echo "has_implement_request=${HAS_IMPLEMENT_REQUEST}"
             echo "emergency_continuity_mode=${emergency_continuity_mode}"

--- a/tests/test-kernel-canary-plan.sh
+++ b/tests/test-kernel-canary-plan.sh
@@ -162,6 +162,14 @@ grep -q 'PERM="canary-bypass"' "${ROUTER_WORKFLOW}" || {
   echo "FAIL: router trust step should bypass collaborator permission for canary-owned dispatches" >&2
   exit 1
 }
+grep -Fq 'echo "canary_dispatch_owned=${canary_dispatch_owned}"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router ctx step should emit canary dispatch ownership output" >&2
+  exit 1
+}
+grep -Fq 'canary_dispatch_owned: ${{ steps.ctx.outputs.canary_dispatch_owned }}' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router prepare job should expose canary dispatch ownership output" >&2
+  exit 1
+}
 echo "PASS [workflow-wiring]"
 
 plan_output="$(


### PR DESCRIPTION
## Summary
- emit canary_dispatch_owned from the tutti router ctx step so the trust gate can actually see it
- expose the ctx-derived canary ownership flag on prepare outputs for downstream consistency
- harden the canary wiring test to assert the ctx output path, not just trust-step string presence

## Testing
- bash tests/test-kernel-canary-plan.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fugue-tutti-router.yml"); YAML.load_file(".github/workflows/fugue-orchestrator-canary.yml"); YAML.load_file(".github/workflows/fugue-tutti-caller.yml"); puts "YAML OK"'