### PR TITLE
fix(kernel): harden canary trust and gate coverage

### DIFF
--- a/.github/workflows/fugue-orchestration-gate.yml
+++ b/.github/workflows/fugue-orchestration-gate.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/fugue-tutti-router.yml'
       - '.github/workflows/fugue-task-router.yml'
       - 'scripts/lib/build-agent-matrix.sh'
+      - 'scripts/lib/canary-trust-policy.sh'
       - 'scripts/lib/execution-profile-policy.sh'
       - 'scripts/lib/orchestrator-policy.sh'
       - 'scripts/check-agent-matrix-parity.sh'
@@ -16,6 +17,8 @@ on:
       - 'scripts/sim-orchestrator-switch.sh'
       - 'scripts/local/run-local-orchestration.sh'
       - 'scripts/local/run-linked-systems.sh'
+      - 'tests/test-canary-trust-policy.sh'
+      - 'tests/test-kernel-canary-plan.sh'
   push:
     branches:
       - main
@@ -26,6 +29,7 @@ on:
       - '.github/workflows/fugue-tutti-router.yml'
       - '.github/workflows/fugue-task-router.yml'
       - 'scripts/lib/build-agent-matrix.sh'
+      - 'scripts/lib/canary-trust-policy.sh'
       - 'scripts/lib/execution-profile-policy.sh'
       - 'scripts/lib/orchestrator-policy.sh'
       - 'scripts/check-agent-matrix-parity.sh'
@@ -33,6 +37,8 @@ on:
       - 'scripts/sim-orchestrator-switch.sh'
       - 'scripts/local/run-local-orchestration.sh'
       - 'scripts/local/run-linked-systems.sh'
+      - 'tests/test-canary-trust-policy.sh'
+      - 'tests/test-kernel-canary-plan.sh'
   workflow_dispatch:
     inputs:
       run_canary_lite:
@@ -57,6 +63,7 @@ jobs:
         run: |
           set -euo pipefail
           bash -n scripts/lib/build-agent-matrix.sh
+          bash -n scripts/lib/canary-trust-policy.sh
           bash -n scripts/lib/execution-profile-policy.sh
           bash -n scripts/lib/orchestrator-policy.sh
           bash -n scripts/local/run-local-orchestration.sh
@@ -64,6 +71,14 @@ jobs:
           bash -n scripts/sim-orchestrator-switch.sh
           bash -n scripts/check-agent-matrix-parity.sh
           bash -n scripts/check-linked-systems-integrity.sh
+          bash -n tests/test-canary-trust-policy.sh
+          bash -n tests/test-kernel-canary-plan.sh
+
+      - name: Canary trust tests
+        run: |
+          set -euo pipefail
+          bash tests/test-canary-trust-policy.sh
+          bash tests/test-kernel-canary-plan.sh
 
       - name: Workflow YAML parse checks
         run: |

--- a/.github/workflows/fugue-orchestrator-canary.yml
+++ b/.github/workflows/fugue-orchestrator-canary.yml
@@ -19,6 +19,10 @@ permissions:
   contents: read
   actions: write
 
+concurrency:
+  group: fugue-orchestrator-canary-${{ github.repository }}-${{ github.ref_name || 'main' }}-${{ github.event.inputs.canary_mode || 'full' }}
+  cancel-in-progress: false
+
 jobs:
   canary:
     runs-on: ubuntu-latest

--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -387,6 +387,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VOTE_COMMAND: ${{ steps.ctx.outputs.vote_command }}
           CANARY_DISPATCH_OWNED: ${{ steps.ctx.outputs.canary_dispatch_owned }}
+          ISSUE_TITLE: ${{ steps.ctx.outputs.issue_title }}
+          ISSUE_BODY: ${{ steps.ctx.outputs.issue_body }}
+          ISSUE_AUTHOR: ${{ steps.ctx.outputs.author }}
         run: |
           set -euo pipefail
           gh_api_retry() {
@@ -415,32 +418,26 @@ jobs:
             TRUST_SUBJECT="${{ steps.ctx.outputs.author }}"
           fi
           PERM="none"
-
-          canary_dispatch_owned="$(printf '%s' "${CANARY_DISPATCH_OWNED:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-          if [[ "${canary_dispatch_owned}" == "true" ]]; then
-            PERM="canary-bypass"
-          else
-            perm_endpoint="repos/${GITHUB_REPOSITORY}/collaborators/${TRUST_SUBJECT}/permission"
-            perm_json="$(gh_api_retry "${perm_endpoint}" 4 || echo '{}')"
-            if echo "${perm_json}" | jq -e '.permission' >/dev/null 2>&1; then
-              PERM="$(echo "${perm_json}" | jq -r '.permission')"
-            fi
+          perm_endpoint="repos/${GITHUB_REPOSITORY}/collaborators/${TRUST_SUBJECT}/permission"
+          perm_json="$(gh_api_retry "${perm_endpoint}" 4 || echo '{}')"
+          if echo "${perm_json}" | jq -e '.permission' >/dev/null 2>&1; then
+            PERM="$(echo "${perm_json}" | jq -r '.permission')"
           fi
 
-          TRUSTED="false"
-          if [[ "${PERM}" == "write" || "${PERM}" == "maintain" || "${PERM}" == "admin" || "${PERM}" == "canary-bypass" ]]; then
-            TRUSTED="true"
-          fi
-          if [[ "${VOTE_COMMAND}" == "true" ]]; then
-            TRUSTED="true"
-            if [[ "${PERM}" == "none" ]]; then
-              PERM="vote-bypass"
-            fi
-          fi
+          eval "$(
+            bash scripts/lib/canary-trust-policy.sh \
+              --permission "${PERM}" \
+              --vote-command "${VOTE_COMMAND}" \
+              --canary-dispatch-owned "${CANARY_DISPATCH_OWNED}" \
+              --issue-title "${ISSUE_TITLE}" \
+              --issue-body "${ISSUE_BODY}" \
+              --issue-author "${ISSUE_AUTHOR}"
+          )"
 
           {
             echo "permission=${PERM}"
             echo "trusted=${TRUSTED}"
+            echo "trust_reason=${trust_reason}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Add processing label

--- a/scripts/lib/canary-trust-policy.sh
+++ b/scripts/lib/canary-trust-policy.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+permission="none"
+vote_command="false"
+canary_dispatch_owned="false"
+issue_title=""
+issue_body=""
+issue_author=""
+format="env"
+
+usage() {
+  cat <<'EOF'
+Usage: canary-trust-policy.sh [options]
+
+Options:
+  --permission <none|read|triage|write|maintain|admin|...>
+  --vote-command <true|false>
+  --canary-dispatch-owned <true|false>
+  --issue-title <text>
+  --issue-body <text>
+  --issue-author <text>
+  --format <env|json>
+EOF
+}
+
+normalize_bool() {
+  local value
+  value="$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+  if [[ "${value}" == "true" || "${value}" == "1" || "${value}" == "yes" ]]; then
+    printf 'true\n'
+  else
+    printf 'false\n'
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --permission)
+      permission="${2:-none}"
+      shift 2
+      ;;
+    --vote-command)
+      vote_command="${2:-false}"
+      shift 2
+      ;;
+    --canary-dispatch-owned)
+      canary_dispatch_owned="${2:-false}"
+      shift 2
+      ;;
+    --issue-title)
+      issue_title="${2:-}"
+      shift 2
+      ;;
+    --issue-body)
+      issue_body="${2:-}"
+      shift 2
+      ;;
+    --issue-author)
+      issue_author="${2:-}"
+      shift 2
+      ;;
+    --format)
+      format="${2:-env}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+permission="$(printf '%s' "${permission:-none}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+vote_command="$(normalize_bool "${vote_command}")"
+canary_dispatch_owned="$(normalize_bool "${canary_dispatch_owned}")"
+issue_author="$(printf '%s' "${issue_author:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+
+title_matches="false"
+body_matches="false"
+author_matches="false"
+canary_markers_valid="false"
+effective_permission="${permission}"
+trusted="false"
+trust_reason="permission-${permission}"
+
+if printf '%s' "${issue_title}" | grep -Eqi '^\[canary(-lite)?\][[:space:]]'; then
+  title_matches="true"
+fi
+if printf '%s' "${issue_body}" | grep -Eqi '^##[[:space:]]+Canary$|Automated orchestration canary\.'; then
+  body_matches="true"
+fi
+if [[ "${issue_author}" == "github-actions" || "${issue_author}" == "github-actions[bot]" ]]; then
+  author_matches="true"
+fi
+if [[ "${title_matches}" == "true" && "${body_matches}" == "true" && "${author_matches}" == "true" ]]; then
+  canary_markers_valid="true"
+fi
+
+if [[ "${canary_dispatch_owned}" == "true" && "${canary_markers_valid}" == "true" ]]; then
+  effective_permission="canary-bypass"
+  trusted="true"
+  trust_reason="canary-owned-dispatch"
+elif [[ "${vote_command}" == "true" ]]; then
+  trusted="true"
+  trust_reason="vote-command"
+  if [[ "${effective_permission}" == "none" ]]; then
+    effective_permission="vote-bypass"
+  fi
+elif [[ "${effective_permission}" == "write" || "${effective_permission}" == "maintain" || "${effective_permission}" == "admin" ]]; then
+  trusted="true"
+  trust_reason="collaborator-permission"
+else
+  trusted="false"
+  if [[ "${canary_dispatch_owned}" == "true" && "${canary_markers_valid}" != "true" ]]; then
+    trust_reason="canary-markers-invalid"
+  fi
+fi
+
+if [[ "${format}" == "json" ]]; then
+  jq -cn \
+    --arg permission "${effective_permission}" \
+    --arg trusted "${trusted}" \
+    --arg trust_reason "${trust_reason}" \
+    --arg canary_dispatch_owned "${canary_dispatch_owned}" \
+    --arg canary_markers_valid "${canary_markers_valid}" \
+    --arg title_matches "${title_matches}" \
+    --arg body_matches "${body_matches}" \
+    --arg author_matches "${author_matches}" \
+    '{
+      permission:$permission,
+      trusted:($trusted == "true"),
+      trust_reason:$trust_reason,
+      canary_dispatch_owned:($canary_dispatch_owned == "true"),
+      canary_markers_valid:($canary_markers_valid == "true"),
+      title_matches:($title_matches == "true"),
+      body_matches:($body_matches == "true"),
+      author_matches:($author_matches == "true")
+    }'
+  exit 0
+fi
+
+printf 'permission=%q\n' "${effective_permission}"
+printf 'trusted=%q\n' "${trusted}"
+printf 'trust_reason=%q\n' "${trust_reason}"
+printf 'canary_markers_valid=%q\n' "${canary_markers_valid}"
+printf 'title_matches=%q\n' "${title_matches}"
+printf 'body_matches=%q\n' "${body_matches}"
+printf 'author_matches=%q\n' "${author_matches}"

--- a/tests/test-canary-trust-policy.sh
+++ b/tests/test-canary-trust-policy.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+POLICY="${SCRIPT_DIR}/scripts/lib/canary-trust-policy.sh"
+
+passed=0
+failed=0
+total=0
+
+assert_field() {
+  local test_name="$1"
+  local field_name="$2"
+  local expected_value="$3"
+  shift 3
+
+  total=$((total + 1))
+  local output
+  output="$(bash "${POLICY}" "$@")" || {
+    echo "FAIL [${test_name}]: script exited with error"
+    failed=$((failed + 1))
+    return
+  }
+
+  eval "${output}"
+  local actual="${!field_name}"
+  if [[ "${actual}" != "${expected_value}" ]]; then
+    echo "FAIL [${test_name}]: ${field_name}=${actual}(expected ${expected_value})"
+    failed=$((failed + 1))
+  else
+    echo "PASS [${test_name}]"
+    passed=$((passed + 1))
+  fi
+}
+
+echo "=== canary-trust-policy.sh unit tests ==="
+echo ""
+
+assert_field "non-canary-none" "trusted" "false" \
+  --permission none \
+  --vote-command false \
+  --canary-dispatch-owned false \
+  --issue-title "normal task" \
+  --issue-body "plain issue body" \
+  --issue-author "someone"
+
+assert_field "vote-bypass" "permission" "vote-bypass" \
+  --permission none \
+  --vote-command true \
+  --canary-dispatch-owned false \
+  --issue-title "vote task" \
+  --issue-body "plain issue body" \
+  --issue-author "someone"
+
+assert_field "canary-bypass" "permission" "canary-bypass" \
+  --permission none \
+  --vote-command false \
+  --canary-dispatch-owned true \
+  --issue-title "[canary-lite] regular claude-main request 20260308231024" \
+  --issue-body $'## Canary\nAutomated orchestration canary.\n' \
+  --issue-author "github-actions"
+
+assert_field "canary-spoof-rejected" "trusted" "false" \
+  --permission none \
+  --vote-command false \
+  --canary-dispatch-owned true \
+  --issue-title "[canary-lite] regular claude-main request 20260308231024" \
+  --issue-body $'## Canary\nAutomated orchestration canary.\n' \
+  --issue-author "masayuki"
+
+assert_field "collaborator-permission" "trusted" "true" \
+  --permission write \
+  --vote-command false \
+  --canary-dispatch-owned false \
+  --issue-title "normal task" \
+  --issue-body "plain issue body" \
+  --issue-author "masayuki"
+
+echo ""
+echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="
+
+if [[ "${failed}" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/test-kernel-canary-plan.sh
+++ b/tests/test-kernel-canary-plan.sh
@@ -158,8 +158,8 @@ grep -q 'CANARY_DISPATCH_OWNED: \${{ steps.ctx.outputs.canary_dispatch_owned }}'
   echo "FAIL: router trust step should receive canary dispatch ownership env" >&2
   exit 1
 }
-grep -q 'PERM="canary-bypass"' "${ROUTER_WORKFLOW}" || {
-  echo "FAIL: router trust step should bypass collaborator permission for canary-owned dispatches" >&2
+grep -q 'bash scripts/lib/canary-trust-policy.sh' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should delegate trust decisions to canary-trust-policy.sh" >&2
   exit 1
 }
 grep -Fq 'echo "canary_dispatch_owned=${canary_dispatch_owned}"' "${ROUTER_WORKFLOW}" || {
@@ -168,6 +168,10 @@ grep -Fq 'echo "canary_dispatch_owned=${canary_dispatch_owned}"' "${ROUTER_WORKF
 }
 grep -Fq 'canary_dispatch_owned: ${{ steps.ctx.outputs.canary_dispatch_owned }}' "${ROUTER_WORKFLOW}" || {
   echo "FAIL: router prepare job should expose canary dispatch ownership output" >&2
+  exit 1
+}
+grep -q 'group: fugue-orchestrator-canary-' "${CANARY_WORKFLOW}" || {
+  echo "FAIL: canary workflow should define a concurrency group to suppress duplicate runs" >&2
   exit 1
 }
 echo "PASS [workflow-wiring]"


### PR DESCRIPTION
## Summary
- move canary/vote/collaborator trust decisions into a dedicated canary-trust-policy script and harden canary bypass to require real canary markers plus GitHub Actions authorship
- add dynamic unit coverage for canary trust outcomes and wire it into the orchestration gate
- add workflow concurrency to suppress overlapping canary runs on the same ref/mode

## Testing
- bash tests/test-canary-trust-policy.sh
- bash tests/test-kernel-canary-plan.sh
- bash tests/test-claude-teams-policy.sh
- python3 YAML parse for changed workflows
- ./scripts/sim-orchestrator-switch.sh | head -n 15