### PR TITLE
fix(kernel): patch canary trust hot regression

### DIFF
--- a/.github/workflows/fugue-orchestration-gate.yml
+++ b/.github/workflows/fugue-orchestration-gate.yml
@@ -12,6 +12,7 @@ on:
       - 'scripts/lib/canary-trust-policy.sh'
       - 'scripts/lib/execution-profile-policy.sh'
       - 'scripts/lib/orchestrator-policy.sh'
+      - 'scripts/harness/run-canary.sh'
       - 'scripts/check-agent-matrix-parity.sh'
       - 'scripts/check-linked-systems-integrity.sh'
       - 'scripts/sim-orchestrator-switch.sh'
@@ -32,6 +33,7 @@ on:
       - 'scripts/lib/canary-trust-policy.sh'
       - 'scripts/lib/execution-profile-policy.sh'
       - 'scripts/lib/orchestrator-policy.sh'
+      - 'scripts/harness/run-canary.sh'
       - 'scripts/check-agent-matrix-parity.sh'
       - 'scripts/check-linked-systems-integrity.sh'
       - 'scripts/sim-orchestrator-switch.sh'
@@ -66,6 +68,7 @@ jobs:
           bash -n scripts/lib/canary-trust-policy.sh
           bash -n scripts/lib/execution-profile-policy.sh
           bash -n scripts/lib/orchestrator-policy.sh
+          bash -n scripts/harness/run-canary.sh
           bash -n scripts/local/run-local-orchestration.sh
           bash -n scripts/local/run-linked-systems.sh
           bash -n scripts/sim-orchestrator-switch.sh

--- a/.github/workflows/fugue-orchestrator-canary.yml
+++ b/.github/workflows/fugue-orchestrator-canary.yml
@@ -20,7 +20,7 @@ permissions:
   actions: write
 
 concurrency:
-  group: fugue-orchestrator-canary-${{ github.repository }}-${{ github.ref_name || 'main' }}-${{ github.event.inputs.canary_mode || 'full' }}
+  group: fugue-orchestrator-canary-${{ github.repository }}-${{ github.ref_name || 'main' }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -435,8 +435,8 @@ jobs:
           )"
 
           {
-            echo "permission=${PERM}"
-            echo "trusted=${TRUSTED}"
+            echo "permission=${permission}"
+            echo "trusted=${trusted}"
             echo "trust_reason=${trust_reason}"
           } >> "${GITHUB_OUTPUT}"
 

--- a/scripts/harness/run-canary.sh
+++ b/scripts/harness/run-canary.sh
@@ -77,6 +77,14 @@ gh_var_default() {
   local fallback="$4"
   local resolved="${env_value}"
 
+  if [[ "${CANARY_PLAN_ONLY:-false}" == "true" ]]; then
+    if [[ -n "${resolved}" ]]; then
+      printf '%s\n' "${resolved}"
+    else
+      printf '%s\n' "${fallback}"
+    fi
+    return 0
+  fi
   if [[ -n "${resolved}" ]]; then
     printf '%s\n' "${resolved}"
     return 0
@@ -96,6 +104,14 @@ gh_secret_present_default() {
   local env_value="${2:-}"
   local secret_name="$3"
 
+  if [[ "${CANARY_PLAN_ONLY:-false}" == "true" ]]; then
+    if [[ -n "${env_value}" ]]; then
+      printf '%s\n' "${env_value}"
+    else
+      printf 'false\n'
+    fi
+    return 0
+  fi
   if [[ -n "${env_value}" ]]; then
     printf '%s\n' "${env_value}"
     return 0

--- a/tests/test-kernel-canary-plan.sh
+++ b/tests/test-kernel-canary-plan.sh
@@ -162,6 +162,14 @@ grep -q 'bash scripts/lib/canary-trust-policy.sh' "${ROUTER_WORKFLOW}" || {
   echo "FAIL: router trust step should delegate trust decisions to canary-trust-policy.sh" >&2
   exit 1
 }
+grep -Fq 'echo "permission=${permission}"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should export policy-computed permission" >&2
+  exit 1
+}
+grep -Fq 'echo "trusted=${trusted}"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should export policy-computed trusted flag" >&2
+  exit 1
+}
 grep -Fq 'echo "canary_dispatch_owned=${canary_dispatch_owned}"' "${ROUTER_WORKFLOW}" || {
   echo "FAIL: router ctx step should emit canary dispatch ownership output" >&2
   exit 1
@@ -172,6 +180,10 @@ grep -Fq 'canary_dispatch_owned: ${{ steps.ctx.outputs.canary_dispatch_owned }}'
 }
 grep -q 'group: fugue-orchestrator-canary-' "${CANARY_WORKFLOW}" || {
   echo "FAIL: canary workflow should define a concurrency group to suppress duplicate runs" >&2
+  exit 1
+}
+grep -Fq 'if [[ "${CANARY_PLAN_ONLY:-false}" == "true" ]]' "${CANARY_SCRIPT}" || {
+  echo "FAIL: canary plan-only mode should short-circuit GitHub lookups for hermetic tests" >&2
   exit 1
 }
 echo "PASS [workflow-wiring]"


### PR DESCRIPTION
## Summary
- export trust-policy outputs with the correct lowercase variable names under set -u
- make canary plan-only mode hermetic by short-circuiting GitHub variable/secret lookups
- tighten canary workflow concurrency to suppress duplicate runs across modes on the same ref
- keep gate coverage aligned with run-canary changes

## Testing
- bash tests/test-canary-trust-policy.sh
- bash tests/test-kernel-canary-plan.sh
- bash tests/test-claude-teams-policy.sh
- python3 YAML parse for changed workflows