### PR TITLE
fix(kernel): restore tutti prepare trust checkout

### DIFF
--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -380,6 +380,10 @@ jobs:
             echo "skip_reason=${SKIP_REASON}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Checkout repository
+        if: ${{ steps.ctx.outputs.should_run == 'true' }}
+        uses: actions/checkout@v4
+
       - name: Check author trust
         id: trust
         if: ${{ steps.ctx.outputs.should_run == 'true' }}
@@ -424,6 +428,9 @@ jobs:
             PERM="$(echo "${perm_json}" | jq -r '.permission')"
           fi
 
+          permission="${PERM}"
+          trusted="false"
+          trust_reason="permission-${PERM}"
           eval "$(
             bash scripts/lib/canary-trust-policy.sh \
               --permission "${PERM}" \

--- a/tests/test-kernel-canary-plan.sh
+++ b/tests/test-kernel-canary-plan.sh
@@ -162,8 +162,28 @@ grep -q 'bash scripts/lib/canary-trust-policy.sh' "${ROUTER_WORKFLOW}" || {
   echo "FAIL: router trust step should delegate trust decisions to canary-trust-policy.sh" >&2
   exit 1
 }
+awk '
+  /- name: Checkout repository/ { seen_checkout=1 }
+  /- name: Check author trust/ { if (!seen_checkout) exit 1; found_trust=1 }
+  END { if (!found_trust) exit 1 }
+' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router prepare job must checkout the repository before invoking canary-trust-policy.sh" >&2
+  exit 1
+}
 grep -Fq 'echo "permission=${permission}"' "${ROUTER_WORKFLOW}" || {
   echo "FAIL: router trust step should export policy-computed permission" >&2
+  exit 1
+}
+grep -Fq 'permission="${PERM}"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should initialize fallback-safe permission before policy eval" >&2
+  exit 1
+}
+grep -Fq 'trusted="false"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should initialize fallback-safe trusted flag before policy eval" >&2
+  exit 1
+}
+grep -Fq 'trust_reason="permission-${PERM}"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should initialize fallback-safe trust reason before policy eval" >&2
   exit 1
 }
 grep -Fq 'echo "trusted=${trusted}"' "${ROUTER_WORKFLOW}" || {


### PR DESCRIPTION
## Summary
- checkout the repository in `tutti / prepare` before invoking `scripts/lib/canary-trust-policy.sh`
- initialize fallback-safe trust outputs before policy eval
- add a regression test that enforces checkout before trust policy invocation

## Testing
- bash tests/test-kernel-canary-plan.sh
- bash tests/test-canary-trust-policy.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fugue-tutti-router.yml"); puts "yaml-ok"'