### PR TITLE
test(kernel): audit workflow checkout ordering

### DIFF
--- a/.github/workflows/fugue-orchestration-gate.yml
+++ b/.github/workflows/fugue-orchestration-gate.yml
@@ -20,6 +20,7 @@ on:
       - 'scripts/local/run-linked-systems.sh'
       - 'tests/test-canary-trust-policy.sh'
       - 'tests/test-kernel-canary-plan.sh'
+      - 'tests/test-workflow-checkout-order.sh'
   push:
     branches:
       - main
@@ -41,6 +42,7 @@ on:
       - 'scripts/local/run-linked-systems.sh'
       - 'tests/test-canary-trust-policy.sh'
       - 'tests/test-kernel-canary-plan.sh'
+      - 'tests/test-workflow-checkout-order.sh'
   workflow_dispatch:
     inputs:
       run_canary_lite:
@@ -76,12 +78,14 @@ jobs:
           bash -n scripts/check-linked-systems-integrity.sh
           bash -n tests/test-canary-trust-policy.sh
           bash -n tests/test-kernel-canary-plan.sh
+          bash -n tests/test-workflow-checkout-order.sh
 
       - name: Canary trust tests
         run: |
           set -euo pipefail
           bash tests/test-canary-trust-policy.sh
           bash tests/test-kernel-canary-plan.sh
+          bash tests/test-workflow-checkout-order.sh
 
       - name: Workflow YAML parse checks
         run: |

--- a/tests/test-workflow-checkout-order.sh
+++ b/tests/test-workflow-checkout-order.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "${ROOT_DIR}"
+
+ruby <<'RUBY'
+require "yaml"
+
+workflow_paths = Dir.glob(".github/workflows/*.yml").sort
+violations = []
+
+def repo_script_step?(step)
+  run = step["run"]
+  return false unless run.is_a?(String)
+
+  run.each_line.any? do |line|
+    stripped = line.strip
+    stripped.match?(%r{\A(?:bash|source)\s+scripts/}) ||
+      stripped.match?(%r{\A\./scripts/}) ||
+      stripped.match?(%r{\Ascripts/[^[:space:]]+}) ||
+      stripped.match?(%r{\A(?:bash|source)\s+tests/[^[:space:]]+\.sh}) ||
+      stripped.match?(%r{\Atests/[^[:space:]]+\.sh})
+  end
+end
+
+def checkout_step?(step)
+  uses = step["uses"]
+  return false unless uses.is_a?(String)
+  uses.start_with?("actions/checkout@")
+end
+
+workflow_paths.each do |path|
+  data = YAML.load_file(path)
+  jobs = data.fetch("jobs", {})
+  jobs.each do |job_name, job|
+    steps = job["steps"]
+    next unless steps.is_a?(Array)
+
+    checked_out = false
+    steps.each do |step|
+      checked_out ||= checkout_step?(step)
+      next unless repo_script_step?(step)
+      next if checked_out
+
+      step_name = step["name"] || "(unnamed step)"
+      violations << "#{path}: job=#{job_name} step=#{step_name}"
+    end
+  end
+end
+
+if violations.empty?
+  puts "PASS [workflow-checkout-order]"
+  exit 0
+end
+
+warn "FAIL: repo-owned scripts are invoked before checkout in:"
+violations.each { |v| warn "  - #{v}" }
+exit 1
+RUBY


### PR DESCRIPTION
## Summary
- add a static workflow audit that fails if repo-owned scripts are invoked before checkout
- wire the audit into fugue-orchestration-gate
- guard against the hosted-runner failure class that broke tutti prepare

## Testing
- bash tests/test-workflow-checkout-order.sh
- bash tests/test-kernel-canary-plan.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fugue-orchestration-gate.yml"); puts "yaml-ok"'