### PR TITLE
fix: restore canary trust for GitHub Actions app issues

### DIFF
--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -281,7 +281,13 @@ jobs:
           fi
           trust_subject="$(printf '%s' "${TRUST_SUBJECT_INPUT:-}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           if [[ -n "${trust_subject}" ]]; then
-            trust_subject="$(printf '%s' "${trust_subject}" | sed -E 's/[^A-Za-z0-9_.-]//g')"
+            case "${trust_subject}" in
+              "github-actions[bot]"|"github-actions"|"app/github-actions")
+                ;;
+              *)
+                trust_subject="$(printf '%s' "${trust_subject}" | sed -E 's/[^A-Za-z0-9_.-]//g')"
+                ;;
+            esac
           fi
           extra_issue_instruction="$(printf '%s' "${EXTRA_ISSUE_INSTRUCTION_INPUT:-}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           allow_processing_rerun="$(echo "${ALLOW_PROCESSING_RERUN_INPUT:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
@@ -445,9 +451,24 @@ jobs:
           fi
           PERM="none"
 
+          normalize_canary_actor() {
+            local actor
+            actor="$(printf '%s' "${1:-}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+            case "${actor}" in
+              "github-actions[bot]"|"github-actions"|"app/github-actions")
+                printf 'github-actions\n'
+                ;;
+              *)
+                printf '%s\n' "${actor}"
+                ;;
+            esac
+          }
+
           canary_dispatch_owned="$(printf '%s' "${CANARY_DISPATCH_OWNED:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           trust_subject="$(printf '%s' "${TRUST_SUBJECT:-}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           author="$(printf '%s' "${AUTHOR:-}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+          trust_subject_normalized="$(normalize_canary_actor "${trust_subject}")"
+          author_normalized="$(normalize_canary_actor "${author}")"
           issue_title="$(printf '%s' "${ISSUE_TITLE:-}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           issue_body="${ISSUE_BODY:-}"
           canary_dispatch_run_id="$(printf '%s' "${CANARY_DISPATCH_RUN_ID:-}" | tr -cd '0-9')"
@@ -458,8 +479,8 @@ jobs:
           if [[ "${canary_dispatch_owned}" == "true" \
             && "${GITHUB_EVENT_NAME}" == "workflow_call" \
             && -n "${canary_dispatch_run_id}" \
-            && "${trust_subject}" == "github-actions[bot]" \
-            && "${author}" == "github-actions[bot]" \
+            && "${trust_subject_normalized}" == "github-actions" \
+            && "${author_normalized}" == "github-actions" \
             && "${canary_issue_marker}" == "true" ]]; then
             run_endpoint="repos/${GITHUB_REPOSITORY}/actions/runs/${canary_dispatch_run_id}"
             run_json="$(gh_api_retry "${run_endpoint}" 4 || echo '{}')"

--- a/scripts/harness/resolve-orchestration-context.sh
+++ b/scripts/harness/resolve-orchestration-context.sh
@@ -103,7 +103,13 @@ if printf '%s\n%s\n' "${title}" "${body}" | grep -Eiq '^\[canary|^\[canary-lite|
 fi
 trust_subject="$(printf '%s' "${TRUST_SUBJECT_INPUT:-}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
 if [[ -n "${trust_subject}" ]]; then
-  trust_subject="$(printf '%s' "${trust_subject}" | sed -E 's/[^A-Za-z0-9_.-]//g')"
+  case "${trust_subject}" in
+    "github-actions[bot]"|"github-actions"|"app/github-actions")
+      ;;
+    *)
+      trust_subject="$(printf '%s' "${trust_subject}" | sed -E 's/[^A-Za-z0-9_.-]//g')"
+      ;;
+  esac
 fi
 canary_dispatch_run_id="$(printf '%s' "${CANARY_DISPATCH_RUN_ID_INPUT:-}" | tr -cd '0-9')"
 allow_processing_rerun="$(echo "${ALLOW_PROCESSING_RERUN_INPUT:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"

--- a/scripts/lib/canary-trust-policy.sh
+++ b/scripts/lib/canary-trust-policy.sh
@@ -34,6 +34,19 @@ normalize_bool() {
   fi
 }
 
+normalize_canary_actor() {
+  local actor
+  actor="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+  case "${actor}" in
+    "github-actions[bot]"|"github-actions"|"app/github-actions")
+      printf 'github-actions\n'
+      ;;
+    *)
+      printf '%s\n' "${actor}"
+      ;;
+  esac
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --permission)
@@ -78,7 +91,7 @@ done
 permission="$(printf '%s' "${permission:-none}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
 vote_command="$(normalize_bool "${vote_command}")"
 canary_dispatch_owned="$(normalize_bool "${canary_dispatch_owned}")"
-issue_author="$(printf '%s' "${issue_author:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+issue_author="$(normalize_canary_actor "${issue_author:-}")"
 
 title_matches="false"
 body_matches="false"
@@ -94,7 +107,7 @@ fi
 if printf '%s' "${issue_body}" | grep -Eqi '^##[[:space:]]+Canary$|Automated orchestration canary\.'; then
   body_matches="true"
 fi
-if [[ "${issue_author}" == "github-actions" || "${issue_author}" == "github-actions[bot]" ]]; then
+if [[ "${issue_author}" == "github-actions" ]]; then
   author_matches="true"
 fi
 if [[ "${title_matches}" == "true" && "${body_matches}" == "true" && "${author_matches}" == "true" ]]; then

--- a/tests/test-canary-trust-policy.sh
+++ b/tests/test-canary-trust-policy.sh
@@ -60,6 +60,14 @@ assert_field "canary-bypass" "permission" "canary-bypass" \
   --issue-body $'## Canary\nAutomated orchestration canary.\n' \
   --issue-author "github-actions"
 
+assert_field "canary-bypass-app-github-actions" "permission" "canary-bypass" \
+  --permission none \
+  --vote-command false \
+  --canary-dispatch-owned true \
+  --issue-title "[canary-lite] regular claude-main request 20260308231024" \
+  --issue-body $'## Canary\nAutomated orchestration canary.\n' \
+  --issue-author "app/github-actions"
+
 assert_field "canary-spoof-rejected" "trusted" "false" \
   --permission none \
   --vote-command false \

--- a/tests/test-kernel-canary-plan.sh
+++ b/tests/test-kernel-canary-plan.sh
@@ -141,12 +141,20 @@ grep -q '"\${GITHUB_EVENT_NAME}" == "workflow_call"' "${ROUTER_WORKFLOW}" || {
   echo "FAIL: router trust step should restrict canary bypass to workflow_call provenance" >&2
   exit 1
 }
-grep -q '"\${trust_subject}" == "github-actions\[bot\]"' "${ROUTER_WORKFLOW}" || {
-  echo "FAIL: router trust step should restrict canary bypass to github-actions bot subject" >&2
+grep -q 'normalize_canary_actor()' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should normalize GitHub Actions actor aliases" >&2
   exit 1
 }
-grep -q '"\${author}" == "github-actions\[bot\]"' "${ROUTER_WORKFLOW}" || {
-  echo "FAIL: router trust step should restrict canary bypass to bot-authored canary issues" >&2
+grep -q '"app/github-actions"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should allow app/github-actions canary authors" >&2
+  exit 1
+}
+grep -q '"\${trust_subject_normalized}" == "github-actions"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should restrict canary bypass to normalized GitHub Actions subject" >&2
+  exit 1
+}
+grep -q '"\${author_normalized}" == "github-actions"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router trust step should restrict canary bypass to normalized GitHub Actions author" >&2
   exit 1
 }
 grep -q 'actions/runs/\${canary_dispatch_run_id}' "${ROUTER_WORKFLOW}" || {

--- a/tests/test-resolve-orchestration-context.sh
+++ b/tests/test-resolve-orchestration-context.sh
@@ -49,6 +49,12 @@ JSON
 JSON
       exit 0
       ;;
+    repos/cursorvers/fugue-orchestrator/issues/128)
+      cat <<'JSON'
+{"title":"[canary-lite] regular claude-main request 20260309061800","body":"## Canary\nAutomated orchestration canary.\n","url":"https://github.com/cursorvers/fugue-orchestrator/issues/128","labels":[{"name":"fugue-task"}]}
+JSON
+      exit 0
+      ;;
     *)
       echo "{}"
       exit 0
@@ -139,6 +145,12 @@ assert_output "workflow-dispatch-intake-source" "127" "intake_source" "workflow-
   "ISSUE_NUMBER_FROM_DISPATCH=127"
 assert_output "explicit-intake-source" "127" "intake_source" "railway-public-edge" \
   "INTAKE_SOURCE_INPUT=railway-public-edge"
+assert_output "canary-trust-subject-preserved" "128" "trust_subject" "app/github-actions" \
+  "GITHUB_EVENT_NAME=workflow_dispatch" \
+  "ISSUE_NUMBER_FROM_ISSUE=" \
+  "ISSUE_NUMBER_FROM_DISPATCH=128" \
+  "CANARY_DISPATCH_RUN_ID_INPUT=22840953864" \
+  "TRUST_SUBJECT_INPUT=app/github-actions"
 
 echo ""
 echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="


### PR DESCRIPTION
## Summary
- preserve GitHub Actions canary trust subjects without stripping app/bot aliases
- normalize canary actor aliases in tutti router trust checks
- add regression coverage for app/github-actions canary authors and preserved trust subjects

## Verification
- bash tests/test-resolve-orchestration-context.sh
- bash tests/test-kernel-canary-plan.sh
- bash tests/test-canary-trust-policy.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fugue-tutti-router.yml"); puts "yaml-ok"'