### PR TITLE
Record x-auto note linking rule

### DIFF
--- a/.github/workflows/x-auto-note-linking-rule.yml
+++ b/.github/workflows/x-auto-note-linking-rule.yml
@@ -1,0 +1,38 @@
+name: x-auto-note-linking-rule
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/x-auto-note-linking-rule.yml'
+      - 'docs/x-auto-note-linking-rule.md'
+      - 'docs/ADR-005-x-article-defer-note-consolidation.md'
+      - 'tests/test-x-auto-note-linking-rule.sh'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/x-auto-note-linking-rule.yml'
+      - 'docs/x-auto-note-linking-rule.md'
+      - 'docs/ADR-005-x-article-defer-note-consolidation.md'
+      - 'tests/test-x-auto-note-linking-rule.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Shell syntax check
+        run: |
+          set -euo pipefail
+          bash -n tests/test-x-auto-note-linking-rule.sh
+
+      - name: Rule check
+        run: |
+          set -euo pipefail
+          bash tests/test-x-auto-note-linking-rule.sh

--- a/docs/x-auto-note-linking-rule.md
+++ b/docs/x-auto-note-linking-rule.md
@@ -1,0 +1,24 @@
+# X-auto Note Linking Rule
+
+- **Status**: Recorded
+- **Date**: 2026-04-01
+- **Owner**: masayuki
+
+## Scope
+
+This rule applies to `X Post Queue` entries that serve as lead posts for a `note.com` article.
+The Notion database is the operational source of truth for these queue rows.
+
+## Rule
+
+1. The public `note.com` URL must be included in the main post body.
+2. For bilingual queue rows, the same rule applies to both `Body` and `Body JA`.
+3. `Source URLs` stores the canonical article URL used as the source reference.
+4. A separate reply or thread URL is not assumed by default.
+
+## Verification Boundary
+
+As of 2026-04-01, the repository-visible configuration supports the URL in the main body text and
+does not define a separate reply-specific URL field for `X Post Queue`.
+If a reply-thread URL rule is introduced later, document the schema and automation contract before
+changing this rule.

--- a/tests/test-x-auto-note-linking-rule.sh
+++ b/tests/test-x-auto-note-linking-rule.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RULE_DOC="${ROOT_DIR}/docs/x-auto-note-linking-rule.md"
+ADR_DOC="${ROOT_DIR}/docs/ADR-005-x-article-defer-note-consolidation.md"
+
+[[ -f "${RULE_DOC}" ]]
+[[ -f "${ADR_DOC}" ]]
+
+grep -Fq 'The public `note.com` URL must be included in the main post body.' "${RULE_DOC}"
+grep -Fq 'the same rule applies to both `Body` and `Body JA`.' "${RULE_DOC}"
+grep -Fq '`Source URLs` stores the canonical article URL used as the source reference.' "${RULE_DOC}"
+grep -Fq 'A separate reply or thread URL is not assumed by default.' "${RULE_DOC}"
+grep -Fq 'X投稿 → note記事リンクの誘導パターンを標準化' "${ADR_DOC}"
+
+echo "x-auto note linking rule check passed"


### PR DESCRIPTION
## Summary
- record the X-auto rule for note lead posts in repo docs
- add a shell test that enforces the documented rule
- add a dedicated GitHub Actions workflow to run that test on PRs and main pushes

## Verification
- `bash -n tests/test-x-auto-note-linking-rule.sh`
- `bash tests/test-x-auto-note-linking-rule.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/x-auto-note-linking-rule.yml"); puts "workflow-yaml-parse-ok"'`