### PR TITLE
Fix tutti router unbound risk-policy inputs

### DIFF
--- a/.github/workflows/fugue-tutti-router.yml
+++ b/.github/workflows/fugue-tutti-router.yml
@@ -1653,6 +1653,10 @@ jobs:
           if [[ "${handoff_target}" == "fugue-bridge" ]]; then
             legacy_bridge_active="true"
           fi
+          implementation_phase="$(echo "${HAS_IMPLEMENT_REQUEST:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+          if [[ "${implementation_phase}" != "true" ]]; then
+            implementation_phase="false"
+          fi
           task_size_tier_input="$(echo "${TASK_SIZE_TIER_INPUT:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           claude_teams_allowed="$(echo "${CLAUDE_TEAMS_ALLOWED:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
           if [[ "${claude_teams_allowed}" != "true" ]]; then

--- a/tests/test-kernel-canary-plan.sh
+++ b/tests/test-kernel-canary-plan.sh
@@ -72,6 +72,14 @@ grep -q 'echo "task_size_tier=${task_size_tier}"' "${ROUTER_WORKFLOW}" || {
   echo "FAIL: router workflow must emit task_size_tier as a job output" >&2
   exit 1
 }
+grep -q 'implementation_phase="$(echo "${HAS_IMPLEMENT_REQUEST:-false}"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router workflow must normalize implementation_phase before workflow-risk-policy" >&2
+  exit 1
+}
+grep -q -- '--has-implement "${implementation_phase}"' "${ROUTER_WORKFLOW}" || {
+  echo "FAIL: router workflow must pass normalized implementation_phase into workflow-risk-policy" >&2
+  exit 1
+}
 grep -q "canary-dispatch-owned" "${TASK_ROUTER_WORKFLOW}" || {
   echo "FAIL: task router should skip canary issues owned by run-canary dispatch" >&2
   exit 1


### PR DESCRIPTION
## Summary
- initialize `implementation_phase` from `HAS_IMPLEMENT_REQUEST` before calling `workflow-risk-policy.sh`
- prevent `set -u` failures in `fugue-tutti-router` regular canary flow
- add a regression assertion in `tests/test-kernel-canary-plan.sh`

## Validation
- `bash tests/test-kernel-canary-plan.sh`
- `bash tests/test-route-task-handoff.sh`
- `bash tests/test-resolve-orchestration-context.sh`
- `fugue-orchestration-gate` run `23853925942` succeeded on `fix/tutti-resolve-unbound-vars`
- `fugue-orchestrator-canary` run `23853925715` succeeded on `fix/tutti-resolve-unbound-vars`
- downstream `Fugue Mainframe` runs `23853936195` and `23853938603` both succeeded

## Root cause
`fugue-tutti-router` passed `--has-implement "${implementation_phase}"` into `workflow-risk-policy.sh` without initializing `implementation_phase`, so the regular canary path failed in `resolve-orchestrator` under `set -u`.