### PR TITLE
Fix LINE article workflow merge conflict markers

### DIFF
--- a/.github/workflows/fugue-orchestration-gate.yml
+++ b/.github/workflows/fugue-orchestration-gate.yml
@@ -213,18 +213,14 @@ jobs:
         run: |
           set -euo pipefail
           python3 - <<'PY'
+          from pathlib import Path
           import yaml
-          files = [
-              ".github/workflows/fugue-orchestrator-canary.yml",
-              ".github/workflows/fugue-orchestration-gate.yml",
-              ".github/workflows/fugue-watchdog.yml",
-              ".github/workflows/fugue-tutti-caller.yml",
-              ".github/workflows/fugue-tutti-router.yml",
-              ".github/workflows/fugue-task-router.yml",
-              ".github/workflows/kernel-decision-journal.yml",
-          ]
+
+          files = sorted(Path(".github/workflows").glob("*.yml"))
+          files.extend(sorted(Path(".github/workflows").glob("*.yaml")))
+
           for p in files:
-              with open(p, "r", encoding="utf-8") as f:
+              with p.open("r", encoding="utf-8") as f:
                   yaml.safe_load(f)
           print("workflow-yaml-parse-ok")
           PY

--- a/.github/workflows/line-send-note-article.yml
+++ b/.github/workflows/line-send-note-article.yml
@@ -16,14 +16,7 @@ concurrency:
 jobs:
   send-article:
     runs-on: ubuntu-latest
-<<<<<<< Updated upstream
     timeout-minutes: 5
-=======
-    timeout-minutes: 3
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
->>>>>>> Stashed changes
 
     steps:
       - name: Quota gate


### PR DESCRIPTION
## Summary
- remove unresolved merge conflict markers from line-send-note-article.yml
- keep timeout-minutes: 5 with a single valid steps block
- add line-send-note-article.yml to orchestration gate YAML parse checks

## Why
The workflow failed immediately with no jobs because the workflow file itself was invalid.

## Validation
- bash tests/test-kernel-canary-plan.sh
- conflict markers removed