### PR TITLE
Harden kernel orchestration diagnostics and backup dedupe

### DIFF
--- a/.github/workflows/fugue-orchestrator-canary.yml
+++ b/.github/workflows/fugue-orchestrator-canary.yml
@@ -65,4 +65,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           OPS_TOKEN: ${{ secrets.FUGUE_OPS_PAT || secrets.TARGET_REPO_PAT || '' }}
           CANARY_MODE_INPUT: ${{ github.event.inputs.canary_mode || '' }}
+          CANARY_REPORT_DIR: ${{ runner.temp }}/fugue-orchestrator-canary
         run: bash scripts/harness/run-canary.sh
+
+      - name: Upload canary report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fugue-orchestrator-canary-report
+          path: ${{ runner.temp }}/fugue-orchestrator-canary
+          if-no-files-found: warn

--- a/scripts/codex-kernel-guard.sh
+++ b/scripts/codex-kernel-guard.sh
@@ -12,18 +12,23 @@ COMPACT_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-compact-artifact.sh"
 RECOVERY_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-run-recovery.sh"
 PHASE_GATE_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-phase-gate.sh"
 RUN_COMPLETE_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-run-complete.sh"
+MEMORY_QUERY_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-memory-query.sh"
 BUDGET_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-optional-lane-budget.sh"
 ADOPT_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-session-adopt.sh"
 GLM_STATE_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-glm-run-state.sh"
 STATE_PATH_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-state-paths.sh"
 SHARED_SECRETS_SCRIPT="${ROOT_DIR}/scripts/lib/load-shared-secrets.sh"
 THREAD_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-codex-thread.sh"
+LAUNCH_QUORUM_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-launch-quorum.sh"
+SCHEDULER_SCRIPT="${ROOT_DIR}/scripts/kernel-scheduler.sh"
+CLAIM_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-claim.sh"
 STATIC_CHECK_SCRIPT="${ROOT_DIR}/tests/test-codex-kernel-prompt.sh"
 
 DEFAULT_LANE_COUNT="${KERNEL_BOOTSTRAP_LANE_COUNT:-6}"
 DEFAULT_STALE_HOURS="${KERNEL_STALE_HOURS:-24}"
 STATIC_CHECK_TIMEOUT_SEC="${DOCTOR_STATIC_CHECK_TIMEOUT_SEC:-45}"
 SUMMARY_TIMEOUT_SEC="${KERNEL_DOCTOR_SUMMARY_TIMEOUT_SEC:-15}"
+DOCTOR_TIMEOUTS=0
 
 resolve_codex_bin() {
   local preferred="${CODEX_BIN:-}"
@@ -67,6 +72,7 @@ Usage:
   codex-kernel-guard.sh doctor --run <run_id>
   codex-kernel-guard.sh recover-run <run_id>
   codex-kernel-guard.sh attach-context <run_id> <reference_path> [label]
+  codex-kernel-guard.sh memory-query [--limit N] [--run <run_id>] [--format <text|json>] <query>
   codex-kernel-guard.sh phase-check <phase> [--uiux]
   codex-kernel-guard.sh phase-complete <phase> [--uiux]
   codex-kernel-guard.sh run-complete --summary <text> [--title <text>] [--uiux] [--no-gha] [--dry-run]
@@ -161,6 +167,10 @@ ensure_default_env() {
   export KERNEL_ROOT="${ROOT_DIR}"
 }
 
+interactive_tty_available() {
+  [[ -t 0 && -t 1 && "${TERM:-}" != "dumb" ]]
+}
+
 compact_dir() {
   printf '%s\n' "${KERNEL_COMPACT_DIR:-$(bash "${STATE_PATH_SCRIPT}" compact-dir)}"
 }
@@ -181,6 +191,69 @@ jq_safe_string() {
   local expr="${1:?expr required}"
   local file="${2:?file required}"
   jq -r "${expr} // \"\"" "${file}"
+}
+
+epoch_from_iso8601() {
+  local value="${1:-}"
+  [[ -n "${value}" ]] || return 1
+  python3 - "${value}" <<'PY'
+import datetime
+import sys
+
+try:
+    dt = datetime.datetime.strptime(sys.argv[1], "%Y-%m-%dT%H:%M:%SZ")
+except ValueError:
+    raise SystemExit(1)
+print(int(dt.replace(tzinfo=datetime.timezone.utc).timestamp()))
+PY
+}
+
+age_seconds_from_iso8601() {
+  local value="${1:-}"
+  local updated_epoch now_epoch
+  updated_epoch="$(epoch_from_iso8601 "${value}" 2>/dev/null || true)"
+  [[ "${updated_epoch}" =~ ^[0-9]+$ ]] || return 1
+  now_epoch="$(date -u '+%s')"
+  if (( now_epoch < updated_epoch )); then
+    printf '0\n'
+    return 0
+  fi
+  printf '%s\n' "$(( now_epoch - updated_epoch ))"
+}
+
+format_age_seconds() {
+  local seconds="${1:-}"
+  local days hours minutes
+  [[ "${seconds}" =~ ^[0-9]+$ ]] || {
+    printf 'unknown\n'
+    return 0
+  }
+  if (( seconds < 60 )); then
+    printf '%ss\n' "${seconds}"
+    return 0
+  fi
+  minutes=$(( seconds / 60 ))
+  if (( minutes < 60 )); then
+    printf '%sm\n' "${minutes}"
+    return 0
+  fi
+  hours=$(( minutes / 60 ))
+  minutes=$(( minutes % 60 ))
+  if (( hours < 24 )); then
+    if (( minutes == 0 )); then
+      printf '%sh\n' "${hours}"
+    else
+      printf '%sh%sm\n' "${hours}" "${minutes}"
+    fi
+    return 0
+  fi
+  days=$(( hours / 24 ))
+  hours=$(( hours % 24 ))
+  if (( hours == 0 )); then
+    printf '%sd\n' "${days}"
+  else
+    printf '%sd%sh\n' "${days}" "${hours}"
+  fi
 }
 
 json_compact_files() {
@@ -227,9 +300,32 @@ PY
   (( age_sec >= stale_cutoff ))
 }
 
+compact_age_seconds() {
+  local file="${1:?file required}"
+  local updated_at
+  updated_at="$(jq -r '.updated_at // ""' "${file}")"
+  age_seconds_from_iso8601 "${updated_at}" 2>/dev/null || printf '%s\n' "-1"
+}
+
 workspace_receipt_exists() {
   local path="${1:-}"
   [[ -n "${path}" && -f "${path}" ]]
+}
+
+run_context_exists() {
+  local run_id="${1:-}"
+  local compact_path receipt_path ledger_json
+  [[ -n "${run_id}" && "${run_id}" != "unknown-run" ]] || return 1
+  compact_path="$(compact_path_for "${run_id}")"
+  if [[ -f "${compact_path}" ]]; then
+    return 0
+  fi
+  receipt_path="$(receipt_path_for "${run_id}")"
+  if [[ -f "${receipt_path}" ]]; then
+    return 0
+  fi
+  ledger_json="$(ledger_json_for_run "${run_id}" 2>/dev/null || true)"
+  [[ -n "${ledger_json}" && "${ledger_json}" != "{}" ]]
 }
 
 ledger_json_for_run() {
@@ -281,6 +377,18 @@ print_compact_status() {
   printf '  - path: %s\n' "${path}"
 }
 
+print_run_context_status() {
+  local run_id="${1:-}"
+  printf 'run context status:\n'
+  if run_context_exists "${run_id}"; then
+    printf '  - resolved: true\n'
+    printf '  - run id: %s\n' "${run_id}"
+  else
+    printf '  - resolved: false\n'
+    printf '  - reason: no-active-run-context\n'
+  fi
+}
+
 print_runtime_health_status() {
   local run_id="${1:?run_id required}"
   local out rc
@@ -291,6 +399,7 @@ print_runtime_health_status() {
   set -e
   if [[ "${rc}" -eq 124 ]]; then
     DOCTOR_FAILURE=1
+    DOCTOR_TIMEOUTS=$((DOCTOR_TIMEOUTS + 1))
     printf '  - timeout after %ss\n' "${SUMMARY_TIMEOUT_SEC}"
     return 0
   fi
@@ -319,6 +428,7 @@ print_runtime_status_surface() {
   set -e
   if [[ "${rc}" -eq 124 ]]; then
     DOCTOR_FAILURE=1
+    DOCTOR_TIMEOUTS=$((DOCTOR_TIMEOUTS + 1))
     printf '  - timeout after %ss\n' "${SUMMARY_TIMEOUT_SEC}"
     return 0
   fi
@@ -369,6 +479,57 @@ print_recent_events() {
     | .[]
     | "  - at=\(.at // "") | actor=\(.actor // "") | command=\(.command // "") | summary=\(.summary // "")"
   ' "${file}"
+}
+
+print_doctor_summary() {
+  local scope="${1:?scope required}"
+  local total_runs="${2:-0}"
+  local visible_runs="${3:-0}"
+  local stale_runs="${4:-0}"
+  local hidden_stale_runs="${5:-0}"
+  local oldest_stale_run="${6:-}"
+  local oldest_stale_age="${7:-}"
+  local longest_visible_run="${8:-}"
+  local longest_visible_age="${9:-}"
+
+  printf 'doctor summary:\n'
+  printf '  - total_runs: %s\n' "${total_runs}"
+  printf '  - visible_runs: %s\n' "${visible_runs}"
+  printf '  - stale_runs: %s\n' "${stale_runs}"
+  if [[ "${scope}" == "active" ]]; then
+    printf '  - stale_hidden_from_default: %s\n' "${hidden_stale_runs}"
+  fi
+  if [[ -n "${oldest_stale_run}" && "${oldest_stale_age}" =~ ^[0-9]+$ && "${oldest_stale_age}" -ge 0 ]]; then
+    printf '  - oldest_stale_run: %s (%s)\n' "${oldest_stale_run}" "$(format_age_seconds "${oldest_stale_age}")"
+  fi
+  if [[ -n "${longest_visible_run}" && "${longest_visible_age}" =~ ^[0-9]+$ && "${longest_visible_age}" -ge 0 ]]; then
+    printf '  - longest_visible_run: %s (%s)\n' "${longest_visible_run}" "$(format_age_seconds "${longest_visible_age}")"
+  fi
+}
+
+print_doctor_recovery_hints() {
+  local oldest_stale_run="${1:-}"
+  local longest_visible_run="${2:-}"
+  local recovery_target=""
+
+  if [[ -n "${oldest_stale_run}" ]]; then
+    recovery_target="${oldest_stale_run}"
+  elif [[ -n "${longest_visible_run}" ]]; then
+    recovery_target="${longest_visible_run}"
+  fi
+
+  if [[ -z "${recovery_target}" && "${DOCTOR_TIMEOUTS}" -eq 0 ]]; then
+    return 0
+  fi
+
+  printf 'recovery hints:\n'
+  if [[ -n "${recovery_target}" ]]; then
+    printf '  - inspect: codex-kernel-guard doctor --run %s\n' "${recovery_target}"
+    printf '  - recover: codex-kernel-guard recover-run %s\n' "${recovery_target}"
+  fi
+  if (( DOCTOR_TIMEOUTS > 0 )); then
+    printf '  - doctor surface timed out %s time(s); re-run with: codex-kernel-guard doctor --all-runs\n' "${DOCTOR_TIMEOUTS}"
+  fi
 }
 
 specialist_available() {
@@ -456,6 +617,68 @@ launch_providers_and_models() {
   printf '%s\n%s\n' "${providers_csv}" "${active_models_csv}"
 }
 
+launch_identity() {
+  local run_id="${1:?run id required}"
+  local project="${KERNEL_PROJECT:-$(basename "${ROOT_DIR}")}"
+  printf '%s@%s/launch\n' "${project}" "${run_id}"
+}
+
+build_launch_quorum_command() {
+  local run_id="${1:?run id required}"
+  local mode="${2:?mode required}"
+  local providers_csv="${3:?providers required}"
+  local purpose="${4:?purpose required}"
+  shift 4 || true
+  local command_string=""
+  printf -v command_string 'env KERNEL_RUN_ID=%q bash %q run %q %q %q' \
+    "${run_id}" "${LAUNCH_QUORUM_SCRIPT}" "${mode}" "${providers_csv}" "${purpose}"
+  local focus
+  for focus in "$@"; do
+    printf -v command_string '%s %q' "${command_string}" "${focus}"
+  done
+  printf '%s\n' "${command_string}"
+}
+
+print_codex_launch_command() {
+  local run_id="${1:?run id required}"
+  local prompt
+  prompt="$(env KERNEL_RUN_ID="${run_id}" bash "${THREAD_SCRIPT}" prompt "${run_id}")"
+  printf '%s -C %q %q\n' "$(resolve_codex_bin)" "${ROOT_DIR}" "${prompt}"
+}
+
+stop_launch_driver() {
+  local driver_pid="${1:-}"
+  [[ -n "${driver_pid}" && "${driver_pid}" =~ ^[0-9]+$ ]] || return 0
+  kill "${driver_pid}" 2>/dev/null || true
+}
+
+wait_for_run_driver_envelope() {
+  local driver_pid="${1:-}"
+  local envelope_path="${2:-}"
+  local timeout_sec="${KERNEL_LAUNCH_PRECHECK_TIMEOUT_SEC:-90}"
+  local elapsed=0
+
+  [[ -n "${driver_pid}" && "${driver_pid}" =~ ^[0-9]+$ ]] || return 1
+  [[ -n "${envelope_path}" ]] || return 1
+
+  while (( elapsed < timeout_sec )); do
+    if kill -0 "${driver_pid}" 2>/dev/null; then
+      sleep 1
+      elapsed=$((elapsed + 1))
+      continue
+    fi
+    if [[ -f "${envelope_path}" ]]; then
+      cat "${envelope_path}"
+      return 0
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  [[ -f "${envelope_path}" ]] && cat "${envelope_path}"
+  return 1
+}
+
 launch_validate_shape() {
   local mode="${1:?mode required}"
   local providers_csv="${2:?providers required}"
@@ -491,7 +714,9 @@ cmd_launch() {
   local purpose="${1:-launch}"
   shift || true
   local focus=("$@")
-  local mode providers_csv active_models_csv prompt run_id manifest_lane_count
+  local mode providers_csv active_models_csv run_id manifest_lane_count
+  local command_string queue_json scheduler_out envelope_json envelope_state launch_identity_value
+  local driver_pid envelope_path
 
   ensure_default_env
 
@@ -530,13 +755,65 @@ cmd_launch() {
   export KERNEL_BOOTSTRAP_SUBAGENT_LABELS="${KERNEL_BOOTSTRAP_SUBAGENT_LABELS:-true}"
 
   KERNEL_RUN_ID="${run_id}" bash "${RECEIPT_SCRIPT}" write "${DEFAULT_LANE_COUNT}" "${providers_csv}" "${mode}" "codex-kernel-guard launch" >/dev/null
-  KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" record-provider codex success launch >/dev/null
-  KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" scheduler-state claimed "codex-kernel-guard launch" >/dev/null
   KERNEL_RUN_ID="${run_id}" bash "${COMPACT_SCRIPT}" update status_changed "Kernel launch prepared" >/dev/null
 
+  command_string="$(build_launch_quorum_command "${run_id}" "${mode}" "${providers_csv}" "${purpose}" "${focus[@]+"${focus[@]}"}")"
+  launch_identity_value="$(launch_identity "${run_id}")"
+  queue_json="$(
+    jq -n \
+      --arg identity "${launch_identity_value}" \
+      --arg project "${KERNEL_PROJECT}" \
+      --arg run_id "${run_id}" \
+      --arg command_string "${command_string}" \
+      --arg provider "codex" \
+      '{
+        items: [
+          {
+            identity: $identity,
+            project: $project,
+            task_key: "launch",
+            run_id: $run_id,
+            authorized: true,
+            eligible: true,
+            dispatchable: true,
+            continuity_owner: "local-primary",
+            command_string: $command_string,
+            provider: $provider
+          }
+        ]
+      }'
+  )"
+
   if [[ "${ORCH_DRY_RUN:-0}" == "1" ]]; then
-    prompt="$(env KERNEL_RUN_ID="${run_id}" bash "${THREAD_SCRIPT}" prompt "${run_id}")"
-    printf '%s -C %q %q\n' "$(resolve_codex_bin)" "${ROOT_DIR}" "${prompt}"
+    print_codex_launch_command "${run_id}"
+    return 0
+  fi
+
+  scheduler_out="$(bash "${SCHEDULER_SCRIPT}" once --queue-json "${queue_json}")"
+  if [[ "$(jq -r '(.launched | length) // 0' <<<"${scheduler_out}")" == "0" ]]; then
+    local deferred_reason
+    deferred_reason="$(jq -r '.deferred[0].deferred_reason // "kernel-launch-not-dispatched"' <<<"${scheduler_out}")"
+    KERNEL_RUN_ID="${run_id}" bash "${COMPACT_SCRIPT}" update status_changed "Kernel launch deferred" >/dev/null
+    die "${deferred_reason}" 1
+  fi
+  driver_pid="$(jq -r '.launched[0].claim.run_driver_pid // ""' <<<"${scheduler_out}")"
+  envelope_path="$(jq -r '.launched[0].envelope_path // .launched[0].claim.envelope_path // ""' <<<"${scheduler_out}")"
+  envelope_json="$(wait_for_run_driver_envelope "${driver_pid}" "${envelope_path}")" || {
+    stop_launch_driver "${driver_pid}"
+    KERNEL_RUN_ID="${run_id}" bash "${COMPACT_SCRIPT}" update status_changed "Kernel launch preflight timed out" >/dev/null
+    die "kernel-launch-preflight-timeout:${launch_identity_value}" 1
+  }
+  envelope_state="$(jq -r '.scheduler_state // ""' <<<"${envelope_json}")"
+  if [[ "${envelope_state}" != "terminal" ]]; then
+    stop_launch_driver "${driver_pid}"
+    KERNEL_RUN_ID="${run_id}" bash "${COMPACT_SCRIPT}" update status_changed "Kernel launch preflight failed" >/dev/null
+    jq -r '.reason // "kernel-launch-preflight-failed"' <<<"${envelope_json}" >&2
+    exit 1
+  fi
+  KERNEL_RUN_ID="${run_id}" bash "${COMPACT_SCRIPT}" update status_changed "Kernel launch quorum verified" >/dev/null
+
+  if ! interactive_tty_available; then
+    print_codex_launch_command "${run_id}"
     return 0
   fi
 
@@ -546,9 +823,11 @@ cmd_launch() {
 cmd_doctor() {
   local scope="active"
   local run_id=""
-  local file json line_count
+  local file json line_count total_runs stale_runs hidden_stale_runs age_seconds age_text stale_flag doctor_focus_run_id
+  local longest_visible_run="" longest_visible_age=-1 oldest_stale_run="" oldest_stale_age=-1
   ensure_default_env
   DOCTOR_FAILURE=0
+  DOCTOR_TIMEOUTS=0
 
   while (($#)); do
     case "$1" in
@@ -578,13 +857,37 @@ cmd_doctor() {
 
   printf '%s runs:\n' "${scope}"
   line_count=0
+  total_runs=0
+  stale_runs=0
+  hidden_stale_runs=0
+  doctor_focus_run_id=""
   while IFS= read -r file; do
     [[ -f "${file}" ]] || continue
-    if [[ "${scope}" == "active" ]] && is_stale_compact "${file}"; then
+    total_runs=$((total_runs + 1))
+    stale_flag=false
+    if is_stale_compact "${file}"; then
+      stale_flag=true
+      stale_runs=$((stale_runs + 1))
+    fi
+    age_seconds="$(compact_age_seconds "${file}")"
+    age_text="$(format_age_seconds "${age_seconds}")"
+    if [[ "${stale_flag}" == "true" && "${age_seconds}" =~ ^[0-9]+$ && "${age_seconds}" -gt "${oldest_stale_age}" ]]; then
+      oldest_stale_age="${age_seconds}"
+      oldest_stale_run="$(jq -r '.run_id // ""' "${file}")"
+    fi
+    if [[ "${scope}" == "active" && "${stale_flag}" == "true" ]]; then
+      hidden_stale_runs=$((hidden_stale_runs + 1))
       continue
     fi
+    if [[ "${stale_flag}" != "true" && "${age_seconds}" =~ ^[0-9]+$ && "${age_seconds}" -gt "${longest_visible_age}" ]]; then
+      longest_visible_age="${age_seconds}"
+      longest_visible_run="$(jq -r '.run_id // ""' "${file}")"
+    fi
     json="$(jq -c '.' "${file}")"
-    printf '  - run_id=%s | project=%s | purpose=%s | tmux_session=%s | phase=%s | mode=%s | runtime=%s | next_action=%s | updated_at=%s | stale=%s | scheduler_state=%s | workspace_receipt=%s\n' \
+    if [[ -z "${doctor_focus_run_id}" ]]; then
+      doctor_focus_run_id="$(jq -r '.run_id // ""' <<<"${json}")"
+    fi
+    printf '  - run_id=%s | project=%s | purpose=%s | tmux_session=%s | phase=%s | mode=%s | runtime=%s | next_action=%s | updated_at=%s | age=%s | stale=%s | scheduler_state=%s | workspace_receipt=%s\n' \
       "$(jq -r '.run_id // ""' <<<"${json}")" \
       "$(jq -r '.project // ""' <<<"${json}")" \
       "$(jq -r '.purpose // ""' <<<"${json}")" \
@@ -594,7 +897,8 @@ cmd_doctor() {
       "$(jq -r '.runtime // "kernel"' <<<"${json}")" \
       "$(jq -r '(.next_action // [])[0] // ""' <<<"${json}")" \
       "$(jq -r '.updated_at // ""' <<<"${json}")" \
-      "$(if is_stale_compact "${file}"; then printf 'true'; else printf 'false'; fi)" \
+      "${age_text}" \
+      "${stale_flag}" \
       "$(jq -r '.scheduler_state // "unknown"' <<<"${json}")" \
       "$(if workspace_receipt_exists "$(jq -r '.workspace_receipt_path // ""' <<<"${json}")"; then printf 'true'; else printf 'false'; fi)"
     line_count=$((line_count + 1))
@@ -606,12 +910,31 @@ cmd_doctor() {
   if (( line_count == 0 )); then
     printf '  - none\n'
   fi
+  if [[ -z "${doctor_focus_run_id}" ]]; then
+    if run_context_exists "${KERNEL_RUN_ID:-}"; then
+      doctor_focus_run_id="${KERNEL_RUN_ID}"
+    else
+      doctor_focus_run_id=""
+    fi
+  fi
+  if [[ -n "${doctor_focus_run_id}" ]]; then
+    printf 'kernel run id: %s\n' "${doctor_focus_run_id}"
+  else
+    printf 'kernel run id: none\n'
+  fi
+  print_doctor_summary "${scope}" "${total_runs}" "${line_count}" "${stale_runs}" "${hidden_stale_runs}" "${oldest_stale_run}" "${oldest_stale_age}" "${longest_visible_run}" "${longest_visible_age}"
 
   print_shared_secrets_status
-  print_bootstrap_receipt_status "${KERNEL_RUN_ID:-unknown-run}"
-  print_runtime_health_status "${KERNEL_RUN_ID:-unknown-run}"
-  print_runtime_status_surface "${KERNEL_RUN_ID:-unknown-run}"
-  print_compact_status "${KERNEL_RUN_ID:-unknown-run}"
+  print_run_context_status "${doctor_focus_run_id}"
+  if [[ -n "${doctor_focus_run_id}" ]] && run_context_exists "${doctor_focus_run_id}"; then
+    print_bootstrap_receipt_status "${doctor_focus_run_id}"
+    print_runtime_health_status "${doctor_focus_run_id}"
+    print_runtime_status_surface "${doctor_focus_run_id}"
+    print_compact_status "${doctor_focus_run_id}"
+  else
+    print_runtime_status_surface
+  fi
+  print_doctor_recovery_hints "${oldest_stale_run}" "${longest_visible_run}"
   return "${DOCTOR_FAILURE}"
 }
 
@@ -622,6 +945,7 @@ cmd_doctor_run() {
 
   ensure_default_env
   DOCTOR_FAILURE=0
+  DOCTOR_TIMEOUTS=0
   compact_path="$(compact_path_for "${run_id}")"
   [[ -f "${compact_path}" ]] || die "compact artifact missing for run: ${run_id}" 1
   json="$(jq -c '.' "${compact_path}")"
@@ -636,6 +960,7 @@ cmd_doctor_run() {
   scheduler_reason="$(ledger_json_for_run "${run_id}" 2>/dev/null | jq -r '.scheduler_reason // ""' 2>/dev/null || printf '')"
   workspace_receipt_path="$(ledger_json_for_run "${run_id}" 2>/dev/null | jq -r '.workspace_receipt_path // ""' 2>/dev/null || printf '')"
 
+  printf 'kernel run id: %s\n' "${run_id}"
   printf 'doctor scope run id: %s\n' "${run_id}"
   print_static_contract_status
   print_shared_secrets_status
@@ -656,6 +981,8 @@ cmd_doctor_run() {
   printf '  - next_action: %s\n' "$(jq -r '(.next_action // [])[0] // ""' <<<"${json}")"
   printf '  - summary: %s\n' "$(jq -r '(.summary // []) | join(" || ")' <<<"${json}")"
   printf '  - updated_at: %s\n' "$(jq -r '.updated_at // ""' <<<"${json}")"
+  printf '  - updated_age: %s\n' "$(format_age_seconds "$(age_seconds_from_iso8601 "$(jq -r '.updated_at // ""' <<<"${json}")" 2>/dev/null || printf '%s\n' "-1")")"
+  printf '  - stale: %s\n' "$(if is_stale_compact "${compact_path}"; then printf 'true'; else printf 'false'; fi)"
   printf '  - scheduler_state_compact: %s\n' "${scheduler_state_compact}"
   printf '  - workspace_receipt_path_compact: %s\n' "${workspace_receipt_path_compact}"
   printf '  - phase_artifacts: %s\n' "${phase_artifacts}"
@@ -672,6 +999,7 @@ cmd_doctor_run() {
   printf '  - project: %s\n' "$(jq -r '.project // ""' <<<"${json}")"
   printf '  - purpose: %s\n' "$(jq -r '.purpose // ""' <<<"${json}")"
   print_recent_events "${run_id}"
+  print_doctor_recovery_hints "$(if is_stale_compact "${compact_path}"; then printf '%s' "${run_id}"; fi)" "${run_id}"
   return "${DOCTOR_FAILURE}"
 }
 
@@ -686,7 +1014,7 @@ cmd_attach_context() {
   local run_id="${1:-}"
   local reference_path="${2:-}"
   local label="${3:-}"
-  local compact_path kind default_label issue_number existing_path existing_kind existing_label
+  local compact_path kind default_label issue_number post_id existing_path existing_kind existing_label
   [[ -n "${run_id}" ]] || die "attach-context requires <run_id> <reference_path> [label]" 2
   [[ -n "${reference_path}" ]] || die "attach-context requires <run_id> <reference_path> [label]" 2
   [[ -f "${reference_path}" ]] || die "context reference not found: ${reference_path}" 1
@@ -697,9 +1025,12 @@ cmd_attach_context() {
 
   kind="$(jq -r '.kind // "external-reference"' "${reference_path}" 2>/dev/null || printf 'external-reference')"
   issue_number="$(jq -r '.issue_number // ""' "${reference_path}" 2>/dev/null || printf '')"
+  post_id="$(jq -r '.post_id // ""' "${reference_path}" 2>/dev/null || printf '')"
   default_label="${kind}"
   if [[ -n "${issue_number}" ]]; then
     default_label="${default_label} #${issue_number}"
+  elif [[ -n "${post_id}" ]]; then
+    default_label="${default_label} #${post_id}"
   fi
   if [[ -z "${label}" ]]; then
     label="${default_label}"
@@ -785,6 +1116,11 @@ cmd_adopt_run() {
   exec bash "${ADOPT_SCRIPT}" adopt "${target}" "${purpose}"
 }
 
+cmd_memory_query() {
+  ensure_default_env
+  exec bash "${MEMORY_QUERY_SCRIPT}" search "$@"
+}
+
 main() {
   local cmd="${1:-help}"
   shift || true
@@ -800,6 +1136,9 @@ main() {
       ;;
     attach-context)
       cmd_attach_context "$@"
+      ;;
+    memory-query)
+      cmd_memory_query "$@"
       ;;
     phase-check)
       cmd_phase_check "$@"

--- a/scripts/harness/kernel-handoff.sh
+++ b/scripts/harness/kernel-handoff.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MANIFEST="${ROOT_DIR}/config/orchestration/sovereign-adapters.json"
+
+repo=""
+issue_number=""
+dispatch_nonce=""
+trust_subject=""
+vote_instruction_b64=""
+allow_processing_rerun="false"
+requested_execution_mode=""
+subscription_offline_policy_override=""
+implement_request=""
+implement_confirmed=""
+vote_command="false"
+intake_source=""
+execution_mode_override="auto"
+kernel_run_id=""
+dry_run="false"
+workflow_file="fugue-tutti-caller.yml"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/harness/kernel-handoff.sh --repo <owner/repo> --issue-number <n> --dispatch-nonce <nonce> [options]
+
+Options:
+  --repo <owner/repo>              Target repository
+  --issue-number <n>               Issue number
+  --dispatch-nonce <nonce>         Unique nonce for workflow dispatch
+  --trust-subject <login>          Optional trusted actor login
+  --vote-instruction-b64 <value>   Optional base64-encoded /vote instruction
+  --allow-processing-rerun         Allow rerun while processing label exists
+  --requested-execution-mode <v>   Resolved handoff mode (review|implement)
+  --subscription-offline-policy-override <v>
+                                   Optional offline policy override (hold|continuity)
+  --implement-request <bool>       Resolved implementation intent snapshot
+  --implement-confirmed <bool>     Resolved implementation confirmation snapshot
+  --vote-command <bool>            True when the handoff originated from `/vote`
+  --intake-source <value>          Intake source marker for audit/policy
+  --execution-mode-override <v>    Execution policy override (auto|primary|backup-safe|backup-heavy)
+  --kernel-run-id <value>          Optional Kernel run id for downstream continuity
+  --dry-run                        Print the resolved gh command without executing it
+  -h, --help                       Show help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:-}"
+      shift 2
+      ;;
+    --issue-number)
+      issue_number="${2:-}"
+      shift 2
+      ;;
+    --dispatch-nonce)
+      dispatch_nonce="${2:-}"
+      shift 2
+      ;;
+    --trust-subject)
+      trust_subject="${2:-}"
+      shift 2
+      ;;
+    --vote-instruction-b64)
+      vote_instruction_b64="${2:-}"
+      shift 2
+      ;;
+    --allow-processing-rerun)
+      allow_processing_rerun="true"
+      shift 1
+      ;;
+    --requested-execution-mode)
+      requested_execution_mode="${2:-}"
+      shift 2
+      ;;
+    --subscription-offline-policy-override)
+      subscription_offline_policy_override="${2:-}"
+      shift 2
+      ;;
+    --implement-request)
+      implement_request="${2:-}"
+      shift 2
+      ;;
+    --implement-confirmed)
+      implement_confirmed="${2:-}"
+      shift 2
+      ;;
+    --vote-command)
+      vote_command="${2:-}"
+      shift 2
+      ;;
+    --intake-source)
+      intake_source="${2:-}"
+      shift 2
+      ;;
+    --execution-mode-override)
+      execution_mode_override="${2:-}"
+      shift 2
+      ;;
+    --kernel-run-id)
+      kernel_run_id="${2:-}"
+      shift 2
+      ;;
+    --dry-run)
+      dry_run="true"
+      shift 1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${repo}" || -z "${issue_number}" || -z "${dispatch_nonce}" ]]; then
+  echo "Error: --repo, --issue-number, and --dispatch-nonce are required." >&2
+  usage >&2
+  exit 2
+fi
+
+if [[ ! -f "${MANIFEST}" ]]; then
+  echo "Error: sovereign adapter manifest not found: ${MANIFEST}" >&2
+  exit 1
+fi
+
+if ! jq -e '.adapters[] | select(.id == "codex-sovereign") | .provider == "codex" and .class == "sovereign" and .availability == "active"' "${MANIFEST}" >/dev/null 2>&1; then
+  echo "Error: codex-sovereign adapter is not active in ${MANIFEST}" >&2
+  exit 1
+fi
+
+dispatch_cmd=(
+  gh workflow run "${workflow_file}"
+  --repo "${repo}"
+  -f issue_number="${issue_number}"
+  -f dispatch_nonce="${dispatch_nonce}"
+  -f handoff_target="kernel"
+)
+
+trust_subject="$(printf '%s' "${trust_subject}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+if [[ -n "${trust_subject}" ]]; then
+  dispatch_cmd+=(-f trust_subject="${trust_subject}")
+fi
+vote_instruction_b64="$(printf '%s' "${vote_instruction_b64}" | tr -d '\n\r[:space:]')"
+if [[ -n "${vote_instruction_b64}" ]]; then
+  dispatch_cmd+=(-f vote_instruction_b64="${vote_instruction_b64}")
+fi
+if [[ "${allow_processing_rerun}" == "true" ]]; then
+  dispatch_cmd+=(-f allow_processing_rerun="true")
+fi
+requested_execution_mode="$(printf '%s' "${requested_execution_mode}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+if [[ "${requested_execution_mode}" == "review" || "${requested_execution_mode}" == "implement" ]]; then
+  dispatch_cmd+=(-f requested_execution_mode="${requested_execution_mode}")
+fi
+subscription_offline_policy_override="$(printf '%s' "${subscription_offline_policy_override}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+if [[ "${subscription_offline_policy_override}" == "hold" || "${subscription_offline_policy_override}" == "continuity" ]]; then
+  dispatch_cmd+=(-f subscription_offline_policy_override="${subscription_offline_policy_override}")
+fi
+implement_request="$(printf '%s' "${implement_request}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+if [[ "${implement_request}" == "true" || "${implement_request}" == "false" ]]; then
+  dispatch_cmd+=(-f implement_request="${implement_request}")
+fi
+implement_confirmed="$(printf '%s' "${implement_confirmed}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+if [[ "${implement_confirmed}" == "true" || "${implement_confirmed}" == "false" ]]; then
+  dispatch_cmd+=(-f implement_confirmed="${implement_confirmed}")
+fi
+vote_command="$(printf '%s' "${vote_command}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+if [[ "${vote_command}" == "true" ]]; then
+  dispatch_cmd+=(-f vote_command="true")
+fi
+intake_source="$(printf '%s' "${intake_source}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+case "${intake_source}" in
+  github-issue-label|github-vote-comment|github-issue-handoff|workflow-dispatch|github-recovery-console|railway-public-edge)
+    dispatch_cmd+=(-f intake_source="${intake_source}")
+    ;;
+esac
+execution_mode_override="$(printf '%s' "${execution_mode_override}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+case "${execution_mode_override}" in
+  auto|primary|backup-safe|backup-heavy) ;;
+  *) execution_mode_override="auto" ;;
+esac
+if [[ "${execution_mode_override}" != "auto" ]]; then
+  dispatch_cmd+=(-f execution_mode_override="${execution_mode_override}")
+fi
+kernel_run_id="$(printf '%s' "${kernel_run_id}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+if [[ -n "${kernel_run_id}" ]]; then
+  dispatch_cmd+=(-f kernel_run_id="${kernel_run_id}")
+fi
+
+if [[ "${dry_run}" == "true" ]]; then
+  printf '%q ' "${dispatch_cmd[@]}"
+  printf '\n'
+  exit 0
+fi
+
+"${dispatch_cmd[@]}" >/dev/null
+echo "handoff_target=kernel"
+echo "workflow_file=${workflow_file}"

--- a/scripts/harness/route-task-handoff.sh
+++ b/scripts/harness/route-task-handoff.sh
@@ -531,6 +531,10 @@ bridge_handoff_script="scripts/harness/fugue-bridge-handoff.sh"
 if [[ ! -x "${bridge_handoff_script}" && -x ".fugue-orchestrator/scripts/harness/fugue-bridge-handoff.sh" ]]; then
   bridge_handoff_script=".fugue-orchestrator/scripts/harness/fugue-bridge-handoff.sh"
 fi
+kernel_handoff_script="scripts/harness/kernel-handoff.sh"
+if [[ ! -x "${kernel_handoff_script}" && -x ".fugue-orchestrator/scripts/harness/kernel-handoff.sh" ]]; then
+  kernel_handoff_script=".fugue-orchestrator/scripts/harness/kernel-handoff.sh"
+fi
 
 if [[ "${handoff_target}" == "fugue-bridge" ]]; then
   if [[ ! -x "${bridge_handoff_script}" ]]; then
@@ -561,6 +565,37 @@ if [[ "${handoff_target}" == "fugue-bridge" ]]; then
     bridge_args+=(--subscription-offline-policy-override "${subscription_offline_policy_override}")
   fi
   bash "${bridge_handoff_script}" "${bridge_args[@]}" >/dev/null
+elif [[ -x "${kernel_handoff_script}" ]]; then
+  kernel_args=(
+    --repo "${GITHUB_REPOSITORY}"
+    --issue-number "${ISSUE_NUMBER}"
+    --dispatch-nonce "${dispatch_nonce}"
+    --requested-execution-mode "${mode}"
+    --implement-request "${wants_implement}"
+    --implement-confirmed "${confirm_implement}"
+    --vote-command "${IS_VOTE_COMMAND}"
+    --intake-source "${intake_source}"
+    --execution-mode-override "${resolved_execution_mode_override}"
+  )
+  if [[ -n "${trust_subject}" ]]; then
+    kernel_args+=(--trust-subject "${trust_subject}")
+  fi
+  if [[ -n "${vote_instruction_b64}" ]]; then
+    kernel_args+=(--vote-instruction-b64 "${vote_instruction_b64}")
+  fi
+  if [[ -n "${kernel_run_id_input}" ]]; then
+    kernel_args+=(--kernel-run-id "${kernel_run_id_input}")
+  fi
+  if [[ "${IS_VOTE_COMMAND}" == "true" || "${allow_processing_rerun_input}" == "true" ]]; then
+    kernel_args+=(--allow-processing-rerun)
+  fi
+  if [[ -n "${subscription_offline_policy_override}" ]]; then
+    kernel_args+=(--subscription-offline-policy-override "${subscription_offline_policy_override}")
+  fi
+  bash "${kernel_handoff_script}" "${kernel_args[@]}" >/dev/null
+elif [[ "${handoff_target}" == "kernel" ]]; then
+  echo "kernel handoff requested, but adapter script is missing: ${kernel_handoff_script}" >&2
+  exit 1
 else
   gh workflow run fugue-tutti-caller.yml "${dispatch_args[@]}" >/dev/null
 fi

--- a/scripts/harness/route-task-handoff.sh
+++ b/scripts/harness/route-task-handoff.sh
@@ -565,7 +565,7 @@ if [[ "${handoff_target}" == "fugue-bridge" ]]; then
     bridge_args+=(--subscription-offline-policy-override "${subscription_offline_policy_override}")
   fi
   bash "${bridge_handoff_script}" "${bridge_args[@]}" >/dev/null
-elif [[ -x "${kernel_handoff_script}" ]]; then
+elif [[ "${handoff_target}" == "kernel" && -x "${kernel_handoff_script}" ]]; then
   kernel_args=(
     --repo "${GITHUB_REPOSITORY}"
     --issue-number "${ISSUE_NUMBER}"

--- a/scripts/harness/run-canary.sh
+++ b/scripts/harness/run-canary.sh
@@ -150,6 +150,185 @@ verify_rollback_case="false"
 plan_only="$(normalize_bool "${CANARY_PLAN_ONLY:-false}")"
 primary_handoff_target="kernel"
 rollback_handoff_target="fugue-bridge"
+canary_started_epoch="$(date -u '+%s')"
+report_dir="${CANARY_REPORT_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/fugue-orchestrator-canary}"
+report_json="${report_dir}/canary-report.json"
+report_md="${report_dir}/canary-report.md"
+case_results_file="${report_dir}/case-results.jsonl"
+progress_file="${report_dir}/progress-events.jsonl"
+mkdir -p "${report_dir}"
+: >"${case_results_file}"
+: >"${progress_file}"
+
+record_case_result() {
+  local case_name="$1"
+  local status="$2"
+  local reason="$3"
+  local requested_main="$4"
+  local expected_main="$5"
+  local expected_assist="$6"
+  local expected_profile="$7"
+  local expected_runner="$8"
+  local expected_handoff_target="$9"
+  local expected_mode_source="${10}"
+  local expected_task_size_tier="${11}"
+  local actual_main="${12}"
+  local actual_assist="${13}"
+  local actual_profile="${14}"
+  local actual_runner="${15}"
+  local actual_lanes="${16}"
+  local actual_handoff_target="${17}"
+  local actual_mode_source="${18}"
+  local actual_task_size_tier="${19}"
+  local issue_number="${20}"
+
+  jq -cn \
+    --arg case_name "${case_name}" \
+    --arg status "${status}" \
+    --arg reason "${reason}" \
+    --arg requested_main "${requested_main}" \
+    --arg expected_main "${expected_main}" \
+    --arg expected_assist "${expected_assist}" \
+    --arg expected_profile "${expected_profile}" \
+    --arg expected_runner "${expected_runner}" \
+    --arg expected_handoff_target "${expected_handoff_target}" \
+    --arg expected_mode_source "${expected_mode_source}" \
+    --arg expected_task_size_tier "${expected_task_size_tier}" \
+    --arg actual_main "${actual_main}" \
+    --arg actual_assist "${actual_assist}" \
+    --arg actual_profile "${actual_profile}" \
+    --arg actual_runner "${actual_runner}" \
+    --arg actual_lanes "${actual_lanes}" \
+    --arg actual_handoff_target "${actual_handoff_target}" \
+    --arg actual_mode_source "${actual_mode_source}" \
+    --arg actual_task_size_tier "${actual_task_size_tier}" \
+    --arg issue_number "${issue_number}" \
+    '{
+      case: $case_name,
+      status: $status,
+      reason: $reason,
+      requested_main: $requested_main,
+      expected: {
+        main: $expected_main,
+        assist: $expected_assist,
+        profile: $expected_profile,
+        runner: $expected_runner,
+        handoff_target: $expected_handoff_target,
+        multi_agent_mode_source: $expected_mode_source,
+        task_size_tier: $expected_task_size_tier
+      },
+      actual: {
+        main: $actual_main,
+        assist: $actual_assist,
+        profile: $actual_profile,
+        runner: $actual_runner,
+        lanes: $actual_lanes,
+        handoff_target: $actual_handoff_target,
+        multi_agent_mode_source: $actual_mode_source,
+        task_size_tier: $actual_task_size_tier
+      },
+      issue_number: (if $issue_number == "" then null else ($issue_number | tonumber) end)
+    }' >>"${case_results_file}"
+}
+
+record_canary_progress() {
+  local phase="$1"
+  local detail="$2"
+  local status="${3:-running}"
+  jq -cn \
+    --arg at "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    --arg phase "${phase}" \
+    --arg detail "${detail}" \
+    --arg status "${status}" \
+    '{
+      at: $at,
+      phase: $phase,
+      detail: $detail,
+      status: $status
+    }' >>"${progress_file}"
+  printf 'Canary progress [%s] %s\n' "${phase}" "${detail}" >&2
+}
+
+write_canary_report() {
+  local final_status="$1"
+  local elapsed_seconds
+  elapsed_seconds="$(( $(date -u '+%s') - canary_started_epoch ))"
+
+  jq -n \
+    --arg generated_at "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+    --arg repo "${repo}" \
+    --arg canary_mode "${canary_mode}" \
+    --arg final_status "${final_status}" \
+    --arg default_main_provider "${default_main_provider:-}" \
+    --arg canary_alternate_main "${canary_alternate_main:-}" \
+    --arg primary_handoff_target "${primary_handoff_target:-}" \
+    --arg rollback_handoff_target "${rollback_handoff_target:-}" \
+    --arg github_run_id "${GITHUB_RUN_ID:-}" \
+    --arg github_ref_name "${GITHUB_REF_NAME:-}" \
+    --arg report_dir "${report_dir}" \
+    --argjson plan_only "$( [[ "${plan_only}" == "true" ]] && printf 'true' || printf 'false' )" \
+    --argjson run_force_case "$( [[ "${run_force_case}" == "true" ]] && printf 'true' || printf 'false' )" \
+    --argjson verify_rollback_case "$( [[ "${verify_rollback_case}" == "true" ]] && printf 'true' || printf 'false' )" \
+    --argjson failures "${failures}" \
+    --argjson elapsed_seconds "${elapsed_seconds}" \
+    --slurpfile cases "${case_results_file}" \
+    --slurpfile progress "${progress_file}" \
+    '{
+      version: 1,
+      generated_at: $generated_at,
+      repository: $repo,
+      canary_mode: $canary_mode,
+      final_status: $final_status,
+      plan_only: $plan_only,
+      run_force_case: $run_force_case,
+      verify_rollback_case: $verify_rollback_case,
+      failures: $failures,
+      elapsed_seconds: $elapsed_seconds,
+      default_main_provider: $default_main_provider,
+      alternate_main_provider: $canary_alternate_main,
+      primary_handoff_target: $primary_handoff_target,
+      rollback_handoff_target: $rollback_handoff_target,
+      github_run_id: (if $github_run_id == "" then null else $github_run_id end),
+      github_ref_name: (if $github_ref_name == "" then null else $github_ref_name end),
+      report_dir: $report_dir,
+      progress: ($progress // []),
+      cases: ($cases // [])
+    }' >"${report_json}"
+
+  {
+    echo "## Fugue Orchestrator Canary"
+    echo ""
+    echo "- Status: ${final_status}"
+    echo "- Repository: ${repo}"
+    echo "- Mode: ${canary_mode}"
+    echo "- Plan only: ${plan_only}"
+    echo "- Failures: ${failures}"
+    echo "- Elapsed seconds: ${elapsed_seconds}"
+    echo "- Default main: ${default_main_provider}"
+    echo "- Alternate main: ${canary_alternate_main}"
+    echo ""
+    echo "### Progress"
+    jq -r '
+      (.progress // [])
+      | if length == 0 then
+          "- none"
+        else
+          .[] | "- [\(.status)] \(.phase): \(.detail) (\(.at))"
+        end
+    ' "${report_json}"
+    echo ""
+    echo "| Case | Status | Reason | Expected Main | Actual Main | Expected Runner | Actual Runner | Issue |"
+    echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+    jq -r '
+      .cases[]
+      | "| \(.case) | \(.status) | \(.reason) | \(.expected.main // "") | \(.actual.main // "") | \(.expected.runner // "") | \(.actual.runner // "") | \(.issue_number // "-") |"
+    ' "${report_json}"
+  } >"${report_md}"
+
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    cat "${report_md}" >>"${GITHUB_STEP_SUMMARY}"
+  fi
+}
 
 claude_state="$(lower_trim "$(gh_var_default "${repo}" "${CLAUDE_RATE_LIMIT_STATE:-}" "FUGUE_CLAUDE_RATE_LIMIT_STATE" "ok")")"
 canary_mode="$(lower_trim "${CANARY_MODE_INPUT:-full}")"
@@ -260,6 +439,7 @@ if [[ "${plan_only}" != "true" ]]; then
     exit 0
   fi
 fi
+record_canary_progress "bootstrap" "inputs normalized for mode=${canary_mode}, plan_only=${plan_only}" "ok"
 
 # --- Runner availability check ---
 
@@ -298,6 +478,7 @@ fi
 if (( online_count > 0 )); then
   self_hosted_online="true"
 fi
+record_canary_progress "runner-probe" "self_hosted_online=${self_hosted_online}, online_count=${online_count}, offline_policy=${subscription_offline_policy}" "ok"
 
 # --- Policy resolution (regular case) ---
 
@@ -306,7 +487,7 @@ eval "$(
     --main "${default_main_provider}" \
     --assist "claude" \
     --default-main "${default_main_provider}" \
-    --default-assist "claude" \
+    --default-assist "none" \
     --claude-state "${claude_state}" \
     --force-claude "false" \
     --assist-policy "${main_assist_policy}" \
@@ -346,7 +527,7 @@ eval "$(
     --main "${canary_alternate_main}" \
     --assist "claude" \
     --default-main "${default_main_provider}" \
-    --default-assist "claude" \
+    --default-assist "none" \
     --claude-state "${claude_state}" \
     --force-claude "${canary_alternate_force}" \
     --assist-policy "${main_assist_policy}" \
@@ -440,6 +621,7 @@ if [[ "${primary_handoff_target}" == "fugue-bridge" && "${verify_rollback_case}"
   expected_force_mode_source="${expected_rollback_mode_source}"
   expected_force_task_size_tier="${expected_rollback_task_size_tier}"
 fi
+record_canary_progress "policy-resolution" "regular=${expected_regular_main}/${expected_regular_profile}, alternate=${expected_force_main}/${expected_force_profile}, rollback_enabled=${verify_rollback_case}" "ok"
 
 print_plan_case() {
   local case_name="$1"
@@ -475,13 +657,21 @@ print_plan_case() {
 }
 
 if [[ "${plan_only}" == "true" ]]; then
-  print_plan_case "regular" "${default_main_provider}" "${expected_regular_main}" "${expected_regular_assist_effective}" "${expected_regular_profile}" "${expected_regular_runner}" "${expected_regular_handoff_target}" "${expected_regular_mode_source}" "${expected_regular_task_size_tier}"
+  regular_plan_case="$(print_plan_case "regular" "${default_main_provider}" "${expected_regular_main}" "${expected_regular_assist_effective}" "${expected_regular_profile}" "${expected_regular_runner}" "${expected_regular_handoff_target}" "${expected_regular_mode_source}" "${expected_regular_task_size_tier}")"
+  printf '%s\n' "${regular_plan_case}"
+  record_case_result "regular" "planned" "plan-only" "${default_main_provider}" "${expected_regular_main}" "${expected_regular_assist_effective}" "${expected_regular_profile}" "${expected_regular_runner}" "${expected_regular_handoff_target}" "${expected_regular_mode_source}" "${expected_regular_task_size_tier}" "" "" "" "" "" "" "" "" ""
   if [[ "${run_force_case}" == "true" ]]; then
-    print_plan_case "alternate" "${canary_alternate_main}" "${expected_force_main}" "${expected_force_assist_effective}" "${expected_force_profile}" "${expected_force_runner}" "${expected_force_handoff_target}" "${expected_force_mode_source}" "${expected_force_task_size_tier}"
+    force_plan_case="$(print_plan_case "alternate" "${canary_alternate_main}" "${expected_force_main}" "${expected_force_assist_effective}" "${expected_force_profile}" "${expected_force_runner}" "${expected_force_handoff_target}" "${expected_force_mode_source}" "${expected_force_task_size_tier}")"
+    printf '%s\n' "${force_plan_case}"
+    record_case_result "alternate" "planned" "plan-only" "${canary_alternate_main}" "${expected_force_main}" "${expected_force_assist_effective}" "${expected_force_profile}" "${expected_force_runner}" "${expected_force_handoff_target}" "${expected_force_mode_source}" "${expected_force_task_size_tier}" "" "" "" "" "" "" "" "" ""
   fi
   if [[ "${verify_rollback_case}" == "true" ]]; then
-    print_plan_case "rollback" "${legacy_main_provider}" "${expected_rollback_main}" "${expected_rollback_assist_effective}" "${expected_rollback_profile}" "${expected_rollback_runner}" "${expected_rollback_handoff_target}" "${expected_rollback_mode_source}" "${expected_rollback_task_size_tier}"
+    rollback_plan_case="$(print_plan_case "rollback" "${legacy_main_provider}" "${expected_rollback_main}" "${expected_rollback_assist_effective}" "${expected_rollback_profile}" "${expected_rollback_runner}" "${expected_rollback_handoff_target}" "${expected_rollback_mode_source}" "${expected_rollback_task_size_tier}")"
+    printf '%s\n' "${rollback_plan_case}"
+    record_case_result "rollback" "planned" "plan-only" "${legacy_main_provider}" "${expected_rollback_main}" "${expected_rollback_assist_effective}" "${expected_rollback_profile}" "${expected_rollback_runner}" "${expected_rollback_handoff_target}" "${expected_rollback_mode_source}" "${expected_rollback_task_size_tier}" "" "" "" "" "" "" "" "" ""
   fi
+  record_canary_progress "plan-only" "resolved planned cases and wrote report" "ok"
+  write_canary_report "planned"
   exit 0
 fi
 
@@ -540,6 +730,7 @@ create_issue() {
   fi
   echo "Canary: dispatching tutti caller for issue #${issue_num} handoff=${handoff_target}" >&2
   GH_TOKEN="${gh_ops_token}" gh_timeout_cmd 30s "${run_cmd[@]}" >/dev/null
+  record_canary_progress "dispatch" "issue=${issue_num}, requested_main=${orch_provider}, handoff=${handoff_target}" "ok"
   echo "${issue_num}"
 }
 
@@ -735,6 +926,9 @@ if wait "${regular_wait_pid}"; then
   regular_pair="$(tail -n1 "${regular_pair_file}" | tr -d '\r')"
   regular_wait_ok="true"
   echo "Canary: regular issue #${regular_issue} resolved -> ${regular_pair}"
+  record_canary_progress "case-regular-wait" "issue=${regular_issue}, resolved=${regular_pair}" "ok"
+else
+  record_canary_progress "case-regular-wait" "issue=${regular_issue}, timeout-no-integrated-review" "failed"
 fi
 
 force_pair=""
@@ -745,6 +939,9 @@ elif wait "${force_wait_pid}"; then
   force_pair="$(tail -n1 "${force_pair_file}" | tr -d '\r')"
   force_wait_ok="true"
   echo "Canary: alternate issue #${force_issue} resolved -> ${force_pair}"
+  record_canary_progress "case-alternate-wait" "issue=${force_issue}, resolved=${force_pair}" "ok"
+else
+  record_canary_progress "case-alternate-wait" "issue=${force_issue}, timeout-no-integrated-review" "failed"
 fi
 
 rollback_pair=""
@@ -755,6 +952,9 @@ elif wait "${rollback_wait_pid}"; then
   rollback_pair="$(tail -n1 "${rollback_pair_file}" | tr -d '\r')"
   rollback_wait_ok="true"
   echo "Canary: rollback issue #${rollback_issue} resolved -> ${rollback_pair}"
+  record_canary_progress "case-rollback-wait" "issue=${rollback_issue}, resolved=${rollback_pair}" "ok"
+else
+  record_canary_progress "case-rollback-wait" "issue=${rollback_issue}, timeout-no-integrated-review" "failed"
 fi
 
 # --- Verify regular case ---
@@ -799,12 +999,15 @@ if [[ "${regular_wait_ok}" == "true" && -n "${regular_pair}" ]]; then
   fi
   if [[ "${regular_ok}" == "true" ]]; then
     conclude_issue "${regular_issue}" "${expected_regular_main}" "${expected_regular_assist_effective}" "${expected_regular_profile}" "${expected_regular_runner}" "${expected_regular_handoff_target}" "${expected_regular_mode_source}" "${expected_regular_task_size_tier}" "${regular_main}" "${regular_assist}" "${regular_profile}" "${regular_runner}" "${regular_lanes}" "${regular_handoff_target}" "${regular_mode_source}" "${regular_task_size_tier}" "true" "regular" "ok"
+    record_case_result "regular" "passed" "ok" "${default_main_provider}" "${expected_regular_main}" "${expected_regular_assist_effective}" "${expected_regular_profile}" "${expected_regular_runner}" "${expected_regular_handoff_target}" "${expected_regular_mode_source}" "${expected_regular_task_size_tier}" "${regular_main}" "${regular_assist}" "${regular_profile}" "${regular_runner}" "${regular_lanes}" "${regular_handoff_target}" "${regular_mode_source}" "${regular_task_size_tier}" "${regular_issue}"
   else
     conclude_issue "${regular_issue}" "${expected_regular_main}" "${expected_regular_assist_effective}" "${expected_regular_profile}" "${expected_regular_runner}" "${expected_regular_handoff_target}" "${expected_regular_mode_source}" "${expected_regular_task_size_tier}" "${regular_main}" "${regular_assist}" "${regular_profile}" "${regular_runner}" "${regular_lanes}" "${regular_handoff_target}" "${regular_mode_source}" "${regular_task_size_tier}" "false" "regular" "${regular_reason}"
+    record_case_result "regular" "failed" "${regular_reason}" "${default_main_provider}" "${expected_regular_main}" "${expected_regular_assist_effective}" "${expected_regular_profile}" "${expected_regular_runner}" "${expected_regular_handoff_target}" "${expected_regular_mode_source}" "${expected_regular_task_size_tier}" "${regular_main}" "${regular_assist}" "${regular_profile}" "${regular_runner}" "${regular_lanes}" "${regular_handoff_target}" "${regular_mode_source}" "${regular_task_size_tier}" "${regular_issue}"
     failures="$((failures + 1))"
   fi
 else
   conclude_issue "${regular_issue}" "${expected_regular_main}" "${expected_regular_assist_effective}" "${expected_regular_profile}" "${expected_regular_runner}" "${expected_regular_handoff_target}" "${expected_regular_mode_source}" "${expected_regular_task_size_tier}" "" "" "" "" "" "" "" "" "false" "regular" "timeout-no-integrated-review"
+  record_case_result "regular" "failed" "timeout-no-integrated-review" "${default_main_provider}" "${expected_regular_main}" "${expected_regular_assist_effective}" "${expected_regular_profile}" "${expected_regular_runner}" "${expected_regular_handoff_target}" "${expected_regular_mode_source}" "${expected_regular_task_size_tier}" "" "" "" "" "" "" "" "" "${regular_issue}"
   failures="$((failures + 1))"
 fi
 
@@ -852,12 +1055,15 @@ elif [[ "${force_wait_ok}" == "true" && -n "${force_pair}" ]]; then
   fi
   if [[ "${force_ok}" == "true" ]]; then
     conclude_issue "${force_issue}" "${expected_force_main}" "${expected_force_assist_effective}" "${expected_force_profile}" "${expected_force_runner}" "${expected_force_handoff_target}" "${expected_force_mode_source}" "${expected_force_task_size_tier}" "${force_main}" "${force_assist}" "${force_profile}" "${force_runner}" "${force_lanes}" "${force_handoff_target}" "${force_mode_source}" "${force_task_size_tier}" "true" "force" "ok"
+    record_case_result "alternate" "passed" "ok" "${canary_alternate_main}" "${expected_force_main}" "${expected_force_assist_effective}" "${expected_force_profile}" "${expected_force_runner}" "${expected_force_handoff_target}" "${expected_force_mode_source}" "${expected_force_task_size_tier}" "${force_main}" "${force_assist}" "${force_profile}" "${force_runner}" "${force_lanes}" "${force_handoff_target}" "${force_mode_source}" "${force_task_size_tier}" "${force_issue}"
   else
     conclude_issue "${force_issue}" "${expected_force_main}" "${expected_force_assist_effective}" "${expected_force_profile}" "${expected_force_runner}" "${expected_force_handoff_target}" "${expected_force_mode_source}" "${expected_force_task_size_tier}" "${force_main}" "${force_assist}" "${force_profile}" "${force_runner}" "${force_lanes}" "${force_handoff_target}" "${force_mode_source}" "${force_task_size_tier}" "false" "force" "${force_reason}"
+    record_case_result "alternate" "failed" "${force_reason}" "${canary_alternate_main}" "${expected_force_main}" "${expected_force_assist_effective}" "${expected_force_profile}" "${expected_force_runner}" "${expected_force_handoff_target}" "${expected_force_mode_source}" "${expected_force_task_size_tier}" "${force_main}" "${force_assist}" "${force_profile}" "${force_runner}" "${force_lanes}" "${force_handoff_target}" "${force_mode_source}" "${force_task_size_tier}" "${force_issue}"
     failures="$((failures + 1))"
   fi
 else
   conclude_issue "${force_issue}" "${expected_force_main}" "${expected_force_assist_effective}" "${expected_force_profile}" "${expected_force_runner}" "${expected_force_handoff_target}" "${expected_force_mode_source}" "${expected_force_task_size_tier}" "" "" "" "" "" "" "" "" "false" "force" "timeout-no-integrated-review"
+  record_case_result "alternate" "failed" "timeout-no-integrated-review" "${canary_alternate_main}" "${expected_force_main}" "${expected_force_assist_effective}" "${expected_force_profile}" "${expected_force_runner}" "${expected_force_handoff_target}" "${expected_force_mode_source}" "${expected_force_task_size_tier}" "" "" "" "" "" "" "" "" "${force_issue}"
   failures="$((failures + 1))"
 fi
 
@@ -911,18 +1117,23 @@ elif [[ "${rollback_wait_ok}" == "true" && -n "${rollback_pair}" ]]; then
   fi
   if [[ "${rollback_ok}" == "true" ]]; then
     conclude_issue "${rollback_issue}" "${expected_rollback_main}" "${expected_rollback_assist_effective}" "${expected_rollback_profile}" "${expected_rollback_runner}" "${expected_rollback_handoff_target}" "${expected_rollback_mode_source}" "${expected_rollback_task_size_tier}" "${rollback_main}" "${rollback_assist}" "${rollback_profile}" "${rollback_runner}" "${rollback_lanes}" "${rollback_handoff_target_actual}" "${rollback_mode_source_actual}" "${rollback_task_size_tier_actual}" "true" "rollback" "ok"
+    record_case_result "rollback" "passed" "ok" "${legacy_main_provider}" "${expected_rollback_main}" "${expected_rollback_assist_effective}" "${expected_rollback_profile}" "${expected_rollback_runner}" "${expected_rollback_handoff_target}" "${expected_rollback_mode_source}" "${expected_rollback_task_size_tier}" "${rollback_main}" "${rollback_assist}" "${rollback_profile}" "${rollback_runner}" "${rollback_lanes}" "${rollback_handoff_target_actual}" "${rollback_mode_source_actual}" "${rollback_task_size_tier_actual}" "${rollback_issue}"
   else
     conclude_issue "${rollback_issue}" "${expected_rollback_main}" "${expected_rollback_assist_effective}" "${expected_rollback_profile}" "${expected_rollback_runner}" "${expected_rollback_handoff_target}" "${expected_rollback_mode_source}" "${expected_rollback_task_size_tier}" "${rollback_main}" "${rollback_assist}" "${rollback_profile}" "${rollback_runner}" "${rollback_lanes}" "${rollback_handoff_target_actual}" "${rollback_mode_source_actual}" "${rollback_task_size_tier_actual}" "false" "rollback" "${rollback_reason}"
+    record_case_result "rollback" "failed" "${rollback_reason}" "${legacy_main_provider}" "${expected_rollback_main}" "${expected_rollback_assist_effective}" "${expected_rollback_profile}" "${expected_rollback_runner}" "${expected_rollback_handoff_target}" "${expected_rollback_mode_source}" "${expected_rollback_task_size_tier}" "${rollback_main}" "${rollback_assist}" "${rollback_profile}" "${rollback_runner}" "${rollback_lanes}" "${rollback_handoff_target_actual}" "${rollback_mode_source_actual}" "${rollback_task_size_tier_actual}" "${rollback_issue}"
     failures="$((failures + 1))"
   fi
 else
   conclude_issue "${rollback_issue}" "${expected_rollback_main}" "${expected_rollback_assist_effective}" "${expected_rollback_profile}" "${expected_rollback_runner}" "${expected_rollback_handoff_target}" "${expected_rollback_mode_source}" "${expected_rollback_task_size_tier}" "" "" "" "" "" "" "" "" "false" "rollback" "timeout-no-integrated-review"
+  record_case_result "rollback" "failed" "timeout-no-integrated-review" "${legacy_main_provider}" "${expected_rollback_main}" "${expected_rollback_assist_effective}" "${expected_rollback_profile}" "${expected_rollback_runner}" "${expected_rollback_handoff_target}" "${expected_rollback_mode_source}" "${expected_rollback_task_size_tier}" "" "" "" "" "" "" "" "" "${rollback_issue}"
   failures="$((failures + 1))"
 fi
 
 # --- Final result ---
 
 if [[ "${failures}" -gt 0 ]]; then
+  record_canary_progress "finalize" "failures=${failures}" "failed"
+  write_canary_report "failed"
   echo "Canary failed: ${failures} case(s)"
   exit 1
 fi
@@ -933,7 +1144,11 @@ if [[ "${verify_rollback_case}" == "true" ]]; then
 fi
 
 if [[ "${run_force_case}" == "true" ]]; then
+  record_canary_progress "finalize" "all cases passed (alternate included)" "ok"
+  write_canary_report "passed"
   echo "Canary passed (${canary_mode}): regular(main=${expected_regular_main},assist_effective=${expected_regular_assist_effective},profile=${expected_regular_profile},runner=${expected_regular_runner},handoff=${expected_regular_handoff_target}), alternate(main=${expected_force_main},assist_effective=${expected_force_assist_effective},profile=${expected_force_profile},runner=${expected_force_runner},handoff=${expected_force_handoff_target}), ${rollback_summary}, default_main=${default_main_provider}, alternate_main=${canary_alternate_main}, strict_expected=${strict_expected}"
 else
+  record_canary_progress "finalize" "all required cases passed (alternate skipped)" "ok"
+  write_canary_report "passed"
   echo "Canary passed (${canary_mode}): regular(main=${expected_regular_main},assist_effective=${expected_regular_assist_effective},profile=${expected_regular_profile},runner=${expected_regular_runner},handoff=${expected_regular_handoff_target}), alternate=skipped, ${rollback_summary}, default_main=${default_main_provider}, strict_expected=${strict_expected}"
 fi

--- a/scripts/kernel-scheduler.sh
+++ b/scripts/kernel-scheduler.sh
@@ -177,7 +177,7 @@ normalize_queue_json() {
         terminal: inferred_terminal,
         dispatchable: (
           if .dispatchable == null then (inferred_authorized and inferred_eligible and (inferred_terminal | not))
-          else (.dispatchable | bool_or(false))
+          else ((.dispatchable | bool_or(false)) and inferred_authorized and inferred_eligible and (inferred_terminal | not))
           end
         ),
         refresh_token: (.refresh_token // .refresh_requested_at // .updated_at // .etag // ""),
@@ -360,13 +360,14 @@ tick_once() {
 
   while IFS= read -r item_json; do
     [[ -n "${item_json}" ]] || continue
-    local identity project dispatchable terminal eligible existing_claim busy_identity launch_result action
+    local identity project authorized dispatchable terminal eligible existing_claim busy_identity launch_result action
     identity="$(jq -r '.identity' <<<"${item_json}")"
     project="$(jq -r '.project' <<<"${item_json}")"
+    authorized="$(jq -r '.authorized // false' <<<"${item_json}")"
     dispatchable="$(jq -r '.dispatchable // false' <<<"${item_json}")"
     terminal="$(jq -r '.terminal // false' <<<"${item_json}")"
     eligible="$(jq -r '.eligible // true' <<<"${item_json}")"
-    if [[ "${terminal}" == "true" || "${eligible}" != "true" || "${dispatchable}" != "true" ]]; then
+    if [[ "${terminal}" == "true" || "${authorized}" != "true" || "${eligible}" != "true" || "${dispatchable}" != "true" ]]; then
       continue
     fi
     existing_claim="$(claim_by_identity "${claims_json}" "${identity}")"

--- a/scripts/kernel-scheduler.sh
+++ b/scripts/kernel-scheduler.sh
@@ -1,0 +1,486 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CLAIM_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-claim.sh"
+RECONCILER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-reconciler.sh"
+RUN_DRIVER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-run-driver.sh"
+STATUS_SURFACE_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-status-surface.sh"
+WORKSPACE_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-workspace.sh"
+STATE_ROOT="${KERNEL_SUBSTRATE_STATE_ROOT:-${ROOT_DIR}/.fugue/kernel-state}"
+SCHEDULER_DIR="${KERNEL_RUNTIME_SCHEDULER_DIR:-${STATE_ROOT}/scheduler}"
+SCHEDULER_STATE_PATH="${KERNEL_RUNTIME_SCHEDULER_STATE_PATH:-${SCHEDULER_DIR}/state.json}"
+LOCK_DIR="${KERNEL_RUNTIME_SCHEDULER_LOCK_DIR:-${SCHEDULER_DIR}/.lock}"
+LOCK_OWNER_FILE="${LOCK_DIR}/owner.pid"
+LOCK_HELD=0
+source "${ROOT_DIR}/scripts/lib/kernel-lock.sh"
+
+trap cleanup_lock EXIT INT TERM
+
+usage() {
+  cat <<'EOF'
+Usage:
+  kernel-scheduler.sh once [--queue-file <path>] [--queue-json <json>]
+  kernel-scheduler.sh daemon [--queue-file <path>] [--queue-json <json>]
+  kernel-scheduler.sh status
+EOF
+}
+
+utc_timestamp() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+epoch_now() {
+  date -u '+%s'
+}
+
+write_json_atomic() {
+  local path="${1:?path is required}"
+  local payload="${2:?payload is required}"
+  local tmp_file
+  mkdir -p "$(dirname "${path}")"
+  tmp_file="$(umask 077 && mktemp "${path}.tmp.XXXXXXXXXX")"
+  printf '%s\n' "${payload}" >"${tmp_file}"
+  mv "${tmp_file}" "${path}"
+}
+
+write_scheduler_topology() {
+  local run_id="${1:?run_id is required}"
+  local identity="${2:?identity is required}"
+  local project="${3:?project is required}"
+  local issue_number="${4:-}"
+  local task_key="${5:-}"
+  local provider="${6:-codex}"
+  local command_string="${7:?command_string is required}"
+  local continuity_owner="${8:-local-primary}"
+  local workspace_dir topology_path topology_json
+
+  workspace_dir="$(KERNEL_RUN_ID="${run_id}" bash "${WORKSPACE_SCRIPT}" ensure)"
+  topology_path="${workspace_dir}/traces/scheduler-topology.json"
+  topology_json="$(
+    jq -n \
+      --arg generated_at "$(utc_timestamp)" \
+      --arg run_id "${run_id}" \
+      --arg identity "${identity}" \
+      --arg project "${project}" \
+      --arg issue_number "${issue_number}" \
+      --arg task_key "${task_key}" \
+      --arg provider "${provider}" \
+      --arg command_string "${command_string}" \
+      --arg continuity_owner "${continuity_owner}" \
+      '{
+        version: 1,
+        generated_at: $generated_at,
+        source: "kernel-scheduler",
+        approved: true,
+        ok_to_execute: true,
+        run_id: $run_id,
+        identity: $identity,
+        project: $project,
+        issue_number: (if $issue_number == "" then null else ($issue_number | tonumber) end),
+        task_key: $task_key,
+        continuity_owner: $continuity_owner,
+        launch: {
+          provider: $provider,
+          command_string: $command_string
+        }
+      }'
+  )"
+  write_json_atomic "${topology_path}" "${topology_json}"
+  printf '%s\n' "${topology_path}"
+}
+
+default_run_id_for_item() {
+  local project="${1:-kernel-workspace}"
+  local issue_number="${2:-}"
+  local task_key="${3:-}"
+  local ts slug
+  ts="$(date -u '+%Y%m%dT%H%M%SZ')"
+  slug="$(printf '%s' "${project}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-')"
+  if [[ -n "${issue_number}" ]]; then
+    if [[ -n "${task_key}" ]]; then
+      printf 'kernel:%s:issue-%s:%s:%s\n' "${slug}" "${issue_number}" "${task_key}" "${ts}"
+    else
+      printf 'kernel:%s:issue-%s:%s\n' "${slug}" "${issue_number}" "${ts}"
+    fi
+  elif [[ -n "${task_key}" ]]; then
+    printf 'kernel:%s:task-%s:%s\n' "${slug}" "${task_key}" "${ts}"
+  else
+    printf 'kernel:%s:adhoc:%s\n' "${slug}" "${ts}"
+  fi
+}
+
+load_queue_json() {
+  local queue_file="${1:-}"
+  local queue_json="${2:-}"
+  local source_cmd="${KERNEL_SCHEDULER_SOURCE_CMD:-}"
+  if [[ -n "${queue_json}" ]]; then
+    printf '%s\n' "${queue_json}"
+    return 0
+  fi
+  if [[ -n "${queue_file}" && -f "${queue_file}" ]]; then
+    cat "${queue_file}"
+    return 0
+  fi
+  if [[ -n "${KERNEL_SCHEDULER_QUEUE_JSON:-}" ]]; then
+    printf '%s\n' "${KERNEL_SCHEDULER_QUEUE_JSON}"
+    return 0
+  fi
+  if [[ -n "${KERNEL_SCHEDULER_QUEUE_FILE:-}" && -f "${KERNEL_SCHEDULER_QUEUE_FILE}" ]]; then
+    cat "${KERNEL_SCHEDULER_QUEUE_FILE}"
+    return 0
+  fi
+  if [[ -n "${source_cmd}" ]]; then
+    bash -lc "${source_cmd}"
+    return 0
+  fi
+  printf '{"items":[]}\n'
+}
+
+normalize_queue_json() {
+  local raw_json="${1:-}"
+  if [[ -z "${raw_json}" ]]; then
+    raw_json='{"items":[]}'
+  fi
+  jq -c '
+    def bool_or($fallback):
+      if . == null then $fallback
+      elif type == "boolean" then .
+      elif type == "string" then
+        ((ascii_downcase) as $v | ($v == "true" or $v == "1" or $v == "yes" or $v == "on"))
+      else $fallback end;
+    def inferred_authorized:
+      (.authorized | bool_or(false))
+      or ((.start_signal // "") | ascii_downcase | test("^/(vote|v)$|^tutti$|^workflow_dispatch$"))
+      or ((.signals // []) | map((. // "") | tostring | ascii_downcase) | any(. == "/vote" or . == "/v" or . == "tutti" or . == "workflow_dispatch"));
+    def inferred_terminal:
+      (.terminal | bool_or(false))
+      or ((.state // .issue_state // "") | ascii_downcase | test("closed|done|terminal|merged|cancelled"));
+    def inferred_eligible:
+      if .eligible == null then true else (.eligible | bool_or(true)) end;
+    def derive_identity:
+      if (.identity // "") != "" then .identity
+      elif (.issue_number // "") != "" and (.task_key // "") != "" then "\(.project // "kernel-workspace")#\(.issue_number)/\(.task_key)"
+      elif (.issue_number // "") != "" then "\(.project // "kernel-workspace")#\(.issue_number)"
+      elif (.task_key // "") != "" then "\(.project // "kernel-workspace")/\(.task_key)"
+      else "\(.project // "kernel-workspace")@\(.run_id // "unknown")" end;
+    ((.items // .work_items // .issues // .) | if type == "array" then . else [] end)
+    | map({
+        identity: derive_identity,
+        project: (.project // "kernel-workspace"),
+        issue_number: (if (.issue_number // "") == "" then null else (.issue_number | tonumber) end),
+        task_key: (.task_key // ""),
+        run_id: (.run_id // ""),
+        authorized: inferred_authorized,
+        eligible: inferred_eligible,
+        terminal: inferred_terminal,
+        dispatchable: (
+          if .dispatchable == null then (inferred_authorized and inferred_eligible and (inferred_terminal | not))
+          else (.dispatchable | bool_or(false))
+          end
+        ),
+        refresh_token: (.refresh_token // .refresh_requested_at // .updated_at // .etag // ""),
+        refresh_requested_at: (.refresh_requested_at // .updated_at // ""),
+        reason: (.reason // .blocking_reason // ""),
+        continuity_owner: (.continuity_owner // "local-primary"),
+        topology_path: (.topology_path // ""),
+        command_string: (.command_string // .launch_command // ""),
+        provider: (.provider // "codex")
+      })
+      | sort_by(.project, (.issue_number // 0), .identity)
+  ' <<<"${raw_json}"
+}
+
+reconstruct_claim_queue() {
+  local claims_json="${1:-[]}"
+  jq -c '
+    map(select((.claim_active // false) == true and ((.status // "") == "claimed" or (.status // "") == "retry_queued" or (.status // "") == "continuity_degraded")))
+    | map({
+        identity: .identity,
+        project: (.project // "kernel-workspace"),
+        issue_number: (.issue_number // null),
+        task_key: (.task_key // ""),
+        run_id: (.run_id // ""),
+        authorized: true,
+        eligible: ((.status // "") != "awaiting_human"),
+        terminal: false,
+        dispatchable: ((.status // "") != "awaiting_human"),
+        refresh_token: (.refresh_token // ""),
+        refresh_requested_at: (.updated_at // ""),
+        reason: (.reason // ""),
+        continuity_owner: (.continuity_owner // "local-primary"),
+        topology_path: (.topology_path // ""),
+        command_string: (.command_string // ""),
+        provider: (.provider // "codex")
+      })
+  ' <<<"${claims_json}"
+}
+
+project_running_map() {
+  local claims_json="${1:-[]}"
+  jq -c '
+    reduce map(select((.claim_active // false) == true and ((.status // "") == "running" or (.status // "") == "continuity_degraded")))[] as $claim
+      ({}; .[$claim.project] = ($claim.identity))
+  ' <<<"${claims_json}"
+}
+
+claim_by_identity() {
+  local claims_json="${1:-[]}"
+  local identity="${2:-}"
+  jq -c --arg identity "${identity}" 'map(select(.identity == $identity)) | .[0] // {}' <<<"${claims_json}"
+}
+
+record_scheduler_state() {
+  local queue_json="${1:-}"
+  local claims_json="${2:-[]}"
+  local launched_json="${3:-[]}"
+  local deferred_json="${4:-[]}"
+  local scheduler_json
+  if [[ -z "${queue_json}" ]]; then
+    queue_json='{"items":[]}'
+  fi
+  scheduler_json="$(
+    jq -n \
+      --arg generated_at "$(utc_timestamp)" \
+      --argjson queue "${queue_json}" \
+      --argjson claims "${claims_json}" \
+      --argjson launched "${launched_json}" \
+      --argjson deferred "${deferred_json}" \
+      '{
+        version: 1,
+        generated_at: $generated_at,
+        queue_count: ($queue | length),
+        active_claims: ($claims | map(select((.claim_active // false) == true and (.status // "") != "terminal")) | length),
+        launched: $launched,
+        deferred: $deferred
+      }'
+  )"
+  write_json_atomic "${SCHEDULER_STATE_PATH}" "${scheduler_json}"
+}
+
+launch_item() {
+  local item_json="${1:?item is required}"
+  local run_id identity project issue_number task_key provider topology_path command_string continuity_owner refresh_token reason
+  local claim_result claim_json action workspace_receipt_path envelope_path driver_pid existing_pid existing_status
+  identity="$(jq -r '.identity' <<<"${item_json}")"
+  project="$(jq -r '.project // "kernel-workspace"' <<<"${item_json}")"
+  issue_number="$(jq -r '.issue_number // ""' <<<"${item_json}")"
+  task_key="$(jq -r '.task_key // ""' <<<"${item_json}")"
+  run_id="$(jq -r '.run_id // ""' <<<"${item_json}")"
+  provider="$(jq -r '.provider // "codex"' <<<"${item_json}")"
+  topology_path="$(jq -r '.topology_path // ""' <<<"${item_json}")"
+  command_string="$(jq -r '.command_string // ""' <<<"${item_json}")"
+  continuity_owner="$(jq -r '.continuity_owner // "local-primary"' <<<"${item_json}")"
+  refresh_token="$(jq -r '.refresh_token // ""' <<<"${item_json}")"
+  reason="$(jq -r '.reason // "dispatchable"' <<<"${item_json}")"
+  if [[ -z "${run_id}" ]]; then
+    run_id="$(default_run_id_for_item "${project}" "${issue_number}" "${task_key}")"
+  fi
+  if [[ -z "${topology_path}" && -n "${command_string}" ]]; then
+    topology_path="$(write_scheduler_topology "${run_id}" "${identity}" "${project}" "${issue_number}" "${task_key}" "${provider}" "${command_string}" "${continuity_owner}")"
+  fi
+
+  claim_result="$(bash "${CLAIM_SCRIPT}" claim \
+    --identity "${identity}" \
+    --project "${project}" \
+    --issue-number "${issue_number}" \
+    --task-key "${task_key}" \
+    --run-id "${run_id}" \
+    --source "kernel-scheduler" \
+    --reason "${reason}" \
+    --refresh-token "${refresh_token}" \
+    --state claimed \
+    --topology-path "${topology_path}" \
+    --command-string "${command_string}" \
+    --provider "${provider}" \
+    --continuity-owner "${continuity_owner}")"
+  action="$(jq -r '.action' <<<"${claim_result}")"
+  claim_json="$(jq -c '.claim' <<<"${claim_result}")"
+  existing_pid="$(jq -r '.run_driver_pid // ""' <<<"${claim_json}")"
+  existing_status="$(jq -r '.status // ""' <<<"${claim_json}")"
+  if [[ -n "${existing_pid}" && "${existing_pid}" =~ ^[0-9]+$ ]] && kill -0 "${existing_pid}" 2>/dev/null; then
+    jq -n --arg action "already-running" --argjson claim "${claim_json}" '{action: $action, claim: $claim}'
+    return 0
+  fi
+  if [[ -z "${command_string}" && -z "${topology_path}" ]]; then
+    bash "${CLAIM_SCRIPT}" set-state --identity "${identity}" --state awaiting_human --reason "launch-metadata-missing" >/dev/null
+    jq -n --arg action "awaiting-human" --argjson claim "$(bash "${CLAIM_SCRIPT}" status --identity "${identity}" | jq '.claim')" '{action: $action, claim: $claim}'
+    return 0
+  fi
+  workspace_receipt_path="$(KERNEL_RUN_ID="${run_id}" bash "${WORKSPACE_SCRIPT}" write)"
+  envelope_path="$(KERNEL_RUN_ID="${run_id}" bash "${RUN_DRIVER_SCRIPT}" path)"
+  mkdir -p "${SCHEDULER_DIR}"
+  env \
+    KERNEL_RUN_ID="${run_id}" \
+    KERNEL_PROJECT="${project}" \
+    KERNEL_PURPOSE="issue-${issue_number:-task}" \
+    bash "${RUN_DRIVER_SCRIPT}" run \
+      --run-id "${run_id}" \
+      --identity "${identity}" \
+      --project "${project}" \
+      --issue-number "${issue_number}" \
+      --task-key "${task_key}" \
+      --provider "${provider}" \
+      --topology-file "${topology_path}" \
+      --continuity-owner "${continuity_owner}" \
+      >>"${SCHEDULER_DIR}/scheduler.log" 2>&1 &
+  driver_pid=$!
+  bash "${CLAIM_SCRIPT}" set-state --identity "${identity}" --state running --reason "scheduler-dispatch" --workspace-receipt-path "${workspace_receipt_path}" --envelope-path "${envelope_path}" --continuity-owner "${continuity_owner}" --run-driver-pid "${driver_pid}" >/dev/null
+  jq -n \
+    --arg action "${action}" \
+    --arg run_id "${run_id}" \
+    --arg envelope_path "${envelope_path}" \
+    --arg workspace_receipt_path "${workspace_receipt_path}" \
+    --argjson claim "$(bash "${CLAIM_SCRIPT}" status --identity "${identity}" | jq '.claim')" \
+    '{action: $action, run_id: $run_id, envelope_path: $envelope_path, workspace_receipt_path: $workspace_receipt_path, claim: $claim}'
+}
+
+tick_once() {
+  local queue_file="${1:-}"
+  local queue_json="${2:-}"
+  local raw_queue normalized_queue claims_json reconstructed_items merged_items running_projects
+  local launched='[]' deferred='[]'
+
+  raw_queue="$(load_queue_json "${queue_file}" "${queue_json}")"
+  normalized_queue="$(normalize_queue_json "${raw_queue}")"
+  claims_json="$(bash "${CLAIM_SCRIPT}" list)"
+  reconstructed_items="$(reconstruct_claim_queue "${claims_json}")"
+  merged_items="$(
+    jq -s '
+      add
+      | unique_by(.identity)
+      | sort_by(.project, (.issue_number // 0), .identity)
+    ' <(printf '%s\n' "${normalized_queue}") <(printf '%s\n' "${reconstructed_items}")
+  )"
+
+  bash "${RECONCILER_SCRIPT}" reconcile --queue-json "{\"items\":${merged_items}}" >/dev/null
+  claims_json="$(bash "${CLAIM_SCRIPT}" list)"
+  running_projects="$(project_running_map "${claims_json}")"
+
+  while IFS= read -r item_json; do
+    [[ -n "${item_json}" ]] || continue
+    local identity project dispatchable terminal eligible existing_claim busy_identity launch_result action
+    identity="$(jq -r '.identity' <<<"${item_json}")"
+    project="$(jq -r '.project' <<<"${item_json}")"
+    dispatchable="$(jq -r '.dispatchable // false' <<<"${item_json}")"
+    terminal="$(jq -r '.terminal // false' <<<"${item_json}")"
+    eligible="$(jq -r '.eligible // true' <<<"${item_json}")"
+    if [[ "${terminal}" == "true" || "${eligible}" != "true" || "${dispatchable}" != "true" ]]; then
+      continue
+    fi
+    existing_claim="$(claim_by_identity "${claims_json}" "${identity}")"
+    if [[ "$(jq -r '.claim_active // false' <<<"${existing_claim}")" == "true" ]]; then
+      local pid status
+      pid="$(jq -r '.run_driver_pid // ""' <<<"${existing_claim}")"
+      status="$(jq -r '.status // ""' <<<"${existing_claim}")"
+      if [[ -n "${pid}" && "${pid}" =~ ^[0-9]+$ ]] && kill -0 "${pid}" 2>/dev/null; then
+        continue
+      fi
+      if [[ "${status}" == "running" || "${status}" == "continuity_degraded" ]]; then
+        continue
+      fi
+    fi
+    busy_identity="$(jq -r --arg project "${project}" '.[$project] // ""' <<<"${running_projects}")"
+    if [[ -n "${busy_identity}" && "${busy_identity}" != "${identity}" ]]; then
+      bash "${CLAIM_SCRIPT}" claim \
+        --identity "${identity}" \
+        --project "${project}" \
+        --issue-number "$(jq -r '.issue_number // ""' <<<"${item_json}")" \
+        --task-key "$(jq -r '.task_key // ""' <<<"${item_json}")" \
+        --run-id "$(jq -r '.run_id // ""' <<<"${item_json}")" \
+        --source "kernel-scheduler" \
+        --reason "project-concurrency-bound" \
+        --refresh-token "$(jq -r '.refresh_token // ""' <<<"${item_json}")" \
+        --state retry_queued \
+        --topology-path "$(jq -r '.topology_path // ""' <<<"${item_json}")" \
+        --command-string "$(jq -r '.command_string // ""' <<<"${item_json}")" \
+        --provider "$(jq -r '.provider // "codex"' <<<"${item_json}")" \
+        --continuity-owner "$(jq -r '.continuity_owner // "local-primary"' <<<"${item_json}")" >/dev/null
+      deferred="$(jq -c --argjson item "${item_json}" '. + [$item + {deferred_reason:"project-concurrency-bound"}]' <<<"${deferred}")"
+      continue
+    fi
+
+    launch_result="$(launch_item "${item_json}")"
+    action="$(jq -r '.action // ""' <<<"${launch_result}")"
+    launched="$(jq -c --argjson item "${launch_result}" '. + [$item]' <<<"${launched}")"
+    if [[ "${action}" != "already-running" ]]; then
+      running_projects="$(jq -c --arg project "${project}" --arg identity "${identity}" '. + {($project): $identity}' <<<"${running_projects}")"
+    fi
+    claims_json="$(bash "${CLAIM_SCRIPT}" list)"
+  done < <(jq -c '.[]' <<<"${merged_items}")
+
+  record_scheduler_state "${merged_items}" "${claims_json}" "${launched}" "${deferred}"
+  bash "${STATUS_SURFACE_SCRIPT}" snapshot --queue-json "{\"items\":${merged_items}}" --write >/dev/null
+  jq -n --arg generated_at "$(utc_timestamp)" --argjson launched "${launched}" --argjson deferred "${deferred}" \
+    '{generated_at: $generated_at, launched: $launched, deferred: $deferred}'
+}
+
+cmd_status() {
+  if [[ ! -f "${SCHEDULER_STATE_PATH}" ]]; then
+    jq -n --arg status_path "${SCHEDULER_STATE_PATH}" '{present:false,status_path:$status_path}'
+    return 1
+  fi
+  cat "${SCHEDULER_STATE_PATH}"
+}
+
+cmd_once() {
+  local queue_file="" queue_json=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --queue-file) queue_file="${2:-}"; shift 2 ;;
+      --queue-json) queue_json="${2:-}"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+  acquire_lock "kernel scheduler"
+  tick_once "${queue_file}" "${queue_json}"
+  release_lock
+}
+
+cmd_daemon() {
+  local queue_file="" queue_json="" interval_sec="${KERNEL_SCHEDULER_INTERVAL_SEC:-60}"
+  local stop_file="${KERNEL_SCHEDULER_STOP_FILE:-${SCHEDULER_DIR}/stop}"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --queue-file) queue_file="${2:-}"; shift 2 ;;
+      --queue-json) queue_json="${2:-}"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+  [[ "${interval_sec}" =~ ^[0-9]+$ ]] || interval_sec=60
+
+  mkdir -p "${SCHEDULER_DIR}"
+  while true; do
+    if [[ -f "${stop_file}" ]]; then
+      rm -f "${stop_file}"
+      exit 0
+    fi
+    acquire_lock "kernel scheduler"
+    tick_once "${queue_file}" "${queue_json}" >/dev/null
+    release_lock
+    sleep "${interval_sec}"
+  done
+}
+
+cmd="${1:-help}"
+shift || true
+case "${cmd}" in
+  once)
+    cmd_once "$@"
+    ;;
+  daemon)
+    cmd_daemon "$@"
+    ;;
+  status)
+    cmd_status "$@"
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    echo "Unknown subcommand: ${cmd}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/lib/kernel-launch-quorum.sh
+++ b/scripts/lib/kernel-launch-quorum.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LEDGER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh"
+GLM_EXEC_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-glm-exec.sh"
+OPTIONAL_EXEC_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-optional-lane-exec.sh"
+THREAD_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-codex-thread.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  kernel-launch-quorum.sh run <mode> <providers_csv> <purpose> [focus...]
+EOF
+}
+
+default_run_id() {
+  if [[ -n "${KERNEL_RUN_ID:-}" ]]; then
+    printf '%s\n' "${KERNEL_RUN_ID}"
+    return 0
+  fi
+  printf 'unknown-run\n'
+}
+
+canonical_provider() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    codex) printf 'codex\n' ;;
+    glm) printf 'glm\n' ;;
+    gemini|gemini-cli) printf 'gemini-cli\n' ;;
+    cursor|cursor-cli) printf 'cursor-cli\n' ;;
+    copilot|copilot-cli) printf 'copilot-cli\n' ;;
+    *) printf '%s\n' "${1:-}" ;;
+  esac
+}
+
+trim() {
+  printf '%s' "${1:-}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g'
+}
+
+build_prompt() {
+  local mode="${1:?mode required}"
+  local providers_csv="${2:?providers required}"
+  local purpose="${3:?purpose required}"
+  shift 3 || true
+  local focus_text
+  focus_text="$(printf '%s ' "$@" | sed -E 's/[[:space:]]+/ /g; s/[[:space:]]+$//')"
+  cat <<EOF
+Kernel launch quorum preflight for run $(default_run_id).
+Purpose: ${purpose}
+Mode: ${mode}
+Providers: ${providers_csv}
+Focus: ${focus_text:-general implementation}
+Return a short execution-oriented critique that helps the Codex implementation lane start correctly.
+EOF
+}
+
+run_glm_lane() {
+  local prompt="${1:?prompt required}"
+  bash "${GLM_EXEC_SCRIPT}" -p "${prompt}" >/dev/null
+}
+
+run_specialist_lane() {
+  local provider="${1:?provider required}"
+  local prompt="${2:?prompt required}"
+  bash "${OPTIONAL_EXEC_SCRIPT}" "${provider}" -p "${prompt}" >/dev/null
+}
+
+run_codex_prompt_check() {
+  local run_id="${1:?run_id required}"
+  local prompt
+  prompt="$(env KERNEL_RUN_ID="${run_id}" bash "${THREAD_SCRIPT}" prompt "${run_id}")"
+  [[ -n "${prompt}" ]]
+}
+
+cmd_run() {
+  local mode="${1:-}"
+  local providers_csv="${2:-}"
+  local purpose="${3:-launch}"
+  shift 3 || true
+  [[ -n "${mode}" && -n "${providers_csv}" ]] || {
+    usage >&2
+    exit 2
+  }
+
+  local run_id prompt provider specialist_count=0
+  run_id="$(default_run_id)"
+  prompt="$(build_prompt "${mode}" "${providers_csv}" "${purpose}" "$@")"
+
+  KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" record-event kernel-launch-quorum start "mode=${mode}; providers=${providers_csv}" >/dev/null
+
+  run_codex_prompt_check "${run_id}"
+
+  if [[ "${mode}" != "degraded-allowed" ]]; then
+    run_glm_lane "${prompt}"
+  fi
+
+  while IFS= read -r provider; do
+    provider="$(canonical_provider "$(trim "${provider}")")"
+    [[ -n "${provider}" ]] || continue
+    case "${provider}" in
+      codex|glm) continue ;;
+    esac
+    run_specialist_lane "${provider}" "${prompt}"
+    specialist_count=$((specialist_count + 1))
+  done < <(printf '%s\n' "${providers_csv}" | tr ',' '\n')
+
+  if [[ "${mode}" == "degraded-allowed" ]]; then
+    (( specialist_count >= 2 )) || {
+      echo "launch quorum requires two specialists in degraded mode" >&2
+      exit 1
+    }
+  else
+    (( specialist_count >= 1 )) || {
+      echo "launch quorum requires one specialist in normal mode" >&2
+      exit 1
+    }
+  fi
+
+  KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" record-event kernel-launch-quorum finish "mode=${mode}; specialists=${specialist_count}" >/dev/null
+}
+
+cmd="${1:-help}"
+shift || true
+case "${cmd}" in
+  run)
+    cmd_run "$@"
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/lib/kernel-memory-query.sh
+++ b/scripts/lib/kernel-memory-query.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+STATE_PATH_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-state-paths.sh"
+COMPACT_DIR="${KERNEL_COMPACT_DIR:-$(bash "${STATE_PATH_SCRIPT}" compact-dir)}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  kernel-memory-query.sh search [--limit N] [--run <run_id>] [--format <text|json>] <query>
+EOF
+}
+
+compact_files() {
+  [[ -d "${COMPACT_DIR}" ]] || return 0
+  find "${COMPACT_DIR}" -maxdepth 1 -type f -name '*.json' | sort
+}
+
+valid_docs_json() {
+  local run_filter="${1:-}"
+  local json path run_id
+  local docs=""
+
+  while IFS= read -r path; do
+    [[ -n "${path}" ]] || continue
+    json="$(jq -c '.' "${path}" 2>/dev/null || true)"
+    [[ -n "${json}" ]] || continue
+    jq -e 'type == "object"' <<<"${json}" >/dev/null 2>&1 || continue
+    if [[ -n "${run_filter}" ]]; then
+      run_id="$(jq -r '.run_id // ""' <<<"${json}" 2>/dev/null || true)"
+      [[ "${run_id}" == "${run_filter}" ]] || continue
+    fi
+    json="$(jq -cn --arg path "${path}" --argjson doc "${json}" '$doc + {compact_path: $path}')"
+    if [[ -z "${docs}" ]]; then
+      docs="${json}"
+    else
+      docs="${docs}"$'\n'"${json}"
+    fi
+  done < <(compact_files)
+
+  if [[ -z "${docs}" ]]; then
+    printf '[]\n'
+    return 0
+  fi
+  printf '%s\n' "${docs}" | jq -cs '.'
+}
+
+normalize_query() {
+  local value="${1:-}"
+  value="$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')"
+  value="$(printf '%s' "${value}" | sed -E 's/[^a-z0-9]+/ /g; s/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]{2,}/ /g')"
+  printf '%s\n' "${value}"
+}
+
+cmd_search_json() {
+  local query="${1:?query is required}"
+  local limit="${2:-5}"
+  local run_filter="${3:-}"
+  local normalized_query
+  local normalized_tokens
+  local docs_json
+
+  normalized_query="$(normalize_query "${query}")"
+  normalized_tokens="$(printf '%s\n' "${normalized_query}" | awk '{count=0; for (i=1; i<=NF; i++) if (length($i) > 1) count++; print count}')"
+  [[ -n "${normalized_query}" && "${normalized_tokens}" -gt 0 ]] || {
+    echo "query must contain at least one alphanumeric token with 2 or more characters" >&2
+    exit 2
+  }
+
+  docs_json="$(valid_docs_json "${run_filter}")"
+  if [[ "${docs_json}" == "[]" ]]; then
+    jq -cn \
+      --arg query "${normalized_query}" \
+      --arg run_filter "${run_filter}" \
+      '{
+        query: $query,
+        run_filter: (if $run_filter == "" then null else $run_filter end),
+        searched_runs: 0,
+        matched_runs: 0,
+        results: []
+      }'
+    return 0
+  fi
+
+  jq -cn \
+    --argjson docs "${docs_json}" \
+    --arg query "${normalized_query}" \
+    --arg run_filter "${run_filter}" \
+    --argjson limit "${limit}" \
+    '
+      def norm:
+        if . == null then ""
+        elif (type == "string") then .
+        elif (type == "array") then map(tostring) | join(" ")
+        elif (type == "object") then tojson
+        else tostring
+        end
+        | ascii_downcase
+        | gsub("[^a-z0-9]+"; " ")
+        | gsub("^ +| +$"; "");
+
+      def phase_value:
+        .current_phase // .phase // "";
+
+      def matched_tokens($haystack; $tokens):
+        [ $tokens[] as $token | select($haystack | contains($token)) | $token ];
+
+      $docs as $docs
+      | ($query | norm) as $normalized_query
+      | ($normalized_query | split(" ") | map(select(length > 1)) | unique) as $tokens
+      | [ $docs[]
+          | . as $doc
+          | (.summary // []) as $summary
+          | (.decisions // []) as $decisions
+          | (.next_action // []) as $next_action
+          | ((.phase_artifacts // {}) | keys) as $phase_artifact_keys
+          | (.context_reference // {}) as $context_reference
+          | ([
+              .run_id,
+              .project,
+              .purpose,
+              phase_value,
+              .mode,
+              $summary,
+              $decisions,
+              $next_action,
+              $phase_artifact_keys,
+              .workspace_receipt_path,
+              .consensus_receipt_path,
+              $context_reference.path,
+              $context_reference.label
+            ] | map(norm) | join(" ")) as $haystack
+          | (((.run_id // "") | norm) == $normalized_query
+              or ((.project // "") | norm) == $normalized_query
+              or ((.purpose // "") | norm) == $normalized_query) as $exact
+          | (($normalized_query != "") and ($haystack | contains($normalized_query))) as $phrase
+          | (matched_tokens($haystack; $tokens) | unique) as $matched_tokens
+          | ($matched_tokens | length) as $token_hits
+          | (if $exact then 1000 elif $phrase then 200 else 0 end) as $base_score
+          | ($base_score + ($token_hits * 10)) as $score
+          | select($score > 0)
+          | {
+              run_id: (.run_id // ""),
+              project: (.project // ""),
+              purpose: (.purpose // ""),
+              phase: phase_value,
+              mode: (.mode // ""),
+              updated_at: (.updated_at // ""),
+              score: $score,
+              match_stage: (if $exact then "exact" elif $phrase then "phrase" else "token" end),
+              matched_tokens: $matched_tokens,
+              summary: $summary,
+              decisions: $decisions,
+              next_action: $next_action,
+              phase_artifact_keys: $phase_artifact_keys,
+              compact_path: (.compact_path // ""),
+              workspace_receipt_path: (.workspace_receipt_path // ""),
+              consensus_receipt_path: (.consensus_receipt_path // ""),
+              context_reference_path: ($context_reference.path // ""),
+              context_reference_label: ($context_reference.label // "")
+            }
+        ] as $matches
+      | {
+          query: $normalized_query,
+          run_filter: (if $run_filter == "" then null else $run_filter end),
+          searched_runs: ($docs | length),
+          matched_runs: ($matches | length),
+          results: ($matches | sort_by(.score, .updated_at) | reverse | .[:$limit])
+        }
+    '
+}
+
+cmd_search() {
+  local format="${1:-text}"
+  local query="${2:?query is required}"
+  local limit="${3:-5}"
+  local run_filter="${4:-}"
+  local json
+
+  json="$(cmd_search_json "${query}" "${limit}" "${run_filter}")"
+  if [[ "${format}" == "json" ]]; then
+    printf '%s\n' "${json}"
+    return 0
+  fi
+
+  printf 'kernel memory query:\n'
+  jq -r '
+    "  - query: \(.query)",
+    "  - run filter: \(.run_filter // "none")",
+    "  - searched runs: \(.searched_runs)",
+    "  - matched runs: \(.matched_runs)"
+  ' <<<"${json}"
+
+  if [[ "$(jq -r '.matched_runs' <<<"${json}")" == "0" ]]; then
+    printf '  - results: none\n'
+    return 0
+  fi
+
+  jq -r '
+    .results
+    | to_entries[]
+    | "  - result \(.key + 1): run=\(.value.run_id) | stage=\(.value.match_stage) | score=\(.value.score) | project=\(.value.project) | purpose=\(.value.purpose) | phase=\(.value.phase) | updated_at=\(.value.updated_at) | summary=\((.value.summary // []) | join(" || "))"
+  ' <<<"${json}"
+}
+
+cmd="${1:-help}"
+case "${cmd}" in
+  search)
+    shift || true
+    limit=5
+    run_filter=""
+    format="text"
+    query=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --limit)
+          limit="${2:-}"
+          [[ "${limit}" =~ ^[1-9][0-9]*$ ]] || {
+            echo "--limit must be a positive integer" >&2
+            exit 2
+          }
+          shift 2
+          ;;
+        --run)
+          run_filter="${2:-}"
+          [[ -n "${run_filter}" ]] || {
+            echo "--run requires a run id" >&2
+            exit 2
+          }
+          shift 2
+          ;;
+        --format)
+          format="${2:-}"
+          case "${format}" in
+            text|json) ;;
+            *)
+              echo "--format must be text or json" >&2
+              exit 2
+              ;;
+          esac
+          shift 2
+          ;;
+        -h|--help)
+          usage
+          exit 0
+          ;;
+        *)
+          if [[ -z "${query}" ]]; then
+            query="$1"
+          else
+            query="${query} $1"
+          fi
+          shift
+          ;;
+      esac
+    done
+    [[ -n "${query}" ]] || {
+      echo "search requires a query" >&2
+      exit 2
+    }
+    cmd_search "${format}" "${query}" "${limit}" "${run_filter}"
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    echo "Unknown subcommand: ${cmd}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/lib/kernel-runtime-claim.sh
+++ b/scripts/lib/kernel-runtime-claim.sh
@@ -317,23 +317,23 @@ claim_upsert() {
 
   state="$(normalize_state "${state}")"
   claim_path="$(claim_path_for_identity "${identity}")"
-  existing_json="$(load_claim_json "${claim_path}")"
   now="$(utc_timestamp)"
   now_epoch="$(epoch_now)"
   identity_hash="$(hash_text "${identity}")"
   identity_slug="$(slugify "${identity}")"
+  claim_token="claim:${identity_hash:0:16}"
+
+  acquire_lock "kernel runtime claims"
+  existing_json="$(load_claim_json "${claim_path}")"
   existing_run_id="$(resolve_existing_run_id "${existing_json}")"
   if [[ -n "${existing_run_id}" && -z "${run_id}" ]]; then
     run_id="${existing_run_id}"
   fi
-  claim_token="claim:${identity_hash:0:16}"
   if [[ "$(jq -r '((.claim_active // false) and ((.status // "") != "terminal"))' <<<"${existing_json}")" == "true" ]]; then
     action="coalesced"
   else
     action="claimed"
   fi
-
-  acquire_lock "kernel runtime claims"
   local next_json
   next_json="$(
     jq -n \
@@ -429,11 +429,11 @@ set_state_for_identity() {
 
   requested_state="$(normalize_state "${requested_state}")"
   claim_path="$(claim_path_for_identity "${identity}")"
-  existing_json="$(load_claim_json "${claim_path}")"
   now="$(utc_timestamp)"
   now_epoch="$(epoch_now)"
 
   acquire_lock "kernel runtime claims"
+  existing_json="$(load_claim_json "${claim_path}")"
   next_json="$(
     jq -n \
       --argjson prev "${existing_json}" \

--- a/scripts/lib/kernel-runtime-claim.sh
+++ b/scripts/lib/kernel-runtime-claim.sh
@@ -5,10 +5,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 LEDGER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh"
 STATE_PATHS_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-state-paths.sh"
+COMPACT_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-compact-artifact.sh"
 STATE_ROOT="${KERNEL_SUBSTRATE_STATE_ROOT:-$(bash "${STATE_PATHS_SCRIPT}" state-root)}"
 CLAIMS_DIR="${KERNEL_RUNTIME_CLAIMS_DIR:-${STATE_ROOT}/claims}"
 LOCK_DIR="${KERNEL_RUNTIME_CLAIMS_LOCK_DIR:-${CLAIMS_DIR}/.lock}"
 LOCK_OWNER_FILE="${LOCK_DIR}/owner.pid"
+TMUX_BIN="${TMUX_BIN:-tmux}"
 LOCK_HELD=0
 source "${SCRIPT_DIR}/kernel-lock.sh"
 
@@ -55,6 +57,21 @@ utc_timestamp() {
 
 epoch_now() {
   date -u '+%s'
+}
+
+epoch_from_iso8601() {
+  local value="${1:-}"
+  [[ -n "${value}" ]] || return 1
+  python3 - "${value}" <<'PY'
+import datetime
+import sys
+
+try:
+    dt = datetime.datetime.strptime(sys.argv[1], "%Y-%m-%dT%H:%M:%SZ")
+except ValueError:
+    raise SystemExit(1)
+print(int(dt.replace(tzinfo=datetime.timezone.utc).timestamp()))
+PY
 }
 
 normalize_state() {
@@ -166,6 +183,90 @@ claim_status_active() {
     terminal|"") return 1 ;;
     *) return 0 ;;
   esac
+}
+
+compact_path_for_run() {
+  local run_id="${1:-}"
+  [[ -n "${run_id}" ]] || return 1
+  KERNEL_RUN_ID="${run_id}" bash "${COMPACT_SCRIPT}" path "${run_id}" 2>/dev/null || true
+}
+
+compact_path_for_claim() {
+  local claim_json="${1:-}"
+  local compact_path run_id workspace_receipt_path
+  compact_path="$(jq -r '.compact_artifact_path // ""' <<<"${claim_json}")"
+  if [[ -n "${compact_path}" && -f "${compact_path}" ]]; then
+    printf '%s\n' "${compact_path}"
+    return 0
+  fi
+  workspace_receipt_path="$(jq -r '.workspace_receipt_path // ""' <<<"${claim_json}")"
+  if [[ -n "${workspace_receipt_path}" && -f "${workspace_receipt_path}" ]]; then
+    compact_path="$(jq -r '.compact_artifact_path // ""' "${workspace_receipt_path}" 2>/dev/null || true)"
+    if [[ -n "${compact_path}" && -f "${compact_path}" ]]; then
+      printf '%s\n' "${compact_path}"
+      return 0
+    fi
+  fi
+  run_id="$(jq -r '.run_id // ""' <<<"${claim_json}")"
+  if [[ -n "${run_id}" ]]; then
+    compact_path="$(compact_path_for_run "${run_id}")"
+    if [[ -n "${compact_path}" && -f "${compact_path}" ]]; then
+      printf '%s\n' "${compact_path}"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+compact_updated_epoch() {
+  local compact_path="${1:-}"
+  local updated_at
+  [[ -n "${compact_path}" && -f "${compact_path}" ]] || return 1
+  updated_at="$(jq -r '.updated_at // ""' "${compact_path}" 2>/dev/null || true)"
+  epoch_from_iso8601 "${updated_at}" 2>/dev/null || return 1
+}
+
+tmux_session_exists() {
+  local session_name="${1:-}"
+  [[ -n "${session_name}" ]] || return 1
+  command -v "${TMUX_BIN}" >/dev/null 2>&1 || return 2
+  "${TMUX_BIN}" has-session -t "=${session_name}" 2>/dev/null
+  return $?
+}
+
+claim_release_safe() {
+  local claim_json="${1:-}"
+  local ttl_seconds="${2:-3600}"
+  local now compact_path compact_tmux_session compact_updated tmux_status
+
+  compact_path="$(compact_path_for_claim "${claim_json}" || true)"
+  if [[ -z "${compact_path}" ]]; then
+    return 0
+  fi
+
+  compact_tmux_session="$(jq -r '.tmux_session // ""' "${compact_path}" 2>/dev/null || true)"
+  if [[ -n "${compact_tmux_session}" ]]; then
+    tmux_session_exists "${compact_tmux_session}"
+    tmux_status=$?
+    if (( tmux_status == 0 )); then
+      return 1
+    fi
+    if (( tmux_status > 1 )); then
+      return 1
+    fi
+  fi
+
+  compact_updated="$(compact_updated_epoch "${compact_path}" || true)"
+  if [[ ! "${compact_updated}" =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
+
+  now="$(epoch_now)"
+  if (( now - compact_updated < ttl_seconds )); then
+    return 1
+  fi
+
+  return 0
 }
 
 resolve_existing_run_id() {
@@ -570,7 +671,7 @@ cmd_rebuild() {
     if [[ "${live_pid}" == "true" ]]; then
       continue
     fi
-    if claim_status_active "${status}" && (( age >= ttl_seconds )); then
+    if claim_status_active "${status}" && (( age >= ttl_seconds )) && claim_release_safe "${claim_json}" "${ttl_seconds}"; then
       cmd_release --identity "${identity}" --reason "stale-claim-released" >/dev/null
       released=$((released + 1))
     fi

--- a/scripts/lib/kernel-runtime-claim.sh
+++ b/scripts/lib/kernel-runtime-claim.sh
@@ -1,0 +1,619 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+LEDGER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh"
+STATE_PATHS_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-state-paths.sh"
+STATE_ROOT="${KERNEL_SUBSTRATE_STATE_ROOT:-$(bash "${STATE_PATHS_SCRIPT}" state-root)}"
+CLAIMS_DIR="${KERNEL_RUNTIME_CLAIMS_DIR:-${STATE_ROOT}/claims}"
+LOCK_DIR="${KERNEL_RUNTIME_CLAIMS_LOCK_DIR:-${CLAIMS_DIR}/.lock}"
+LOCK_OWNER_FILE="${LOCK_DIR}/owner.pid"
+LOCK_HELD=0
+source "${SCRIPT_DIR}/kernel-lock.sh"
+
+trap cleanup_lock EXIT INT TERM
+
+usage() {
+  cat <<'EOF'
+Usage:
+  kernel-runtime-claim.sh path --identity <identity>
+  kernel-runtime-claim.sh status --identity <identity>
+  kernel-runtime-claim.sh list [--active-only]
+  kernel-runtime-claim.sh claim [options]
+  kernel-runtime-claim.sh set-state [options] --state <state>
+  kernel-runtime-claim.sh release [options]
+  kernel-runtime-claim.sh rebuild [--ttl-seconds <seconds>]
+
+Options:
+  --identity <identity>
+  --project <project>
+  --issue-number <number>
+  --task-key <task_key>
+  --run-id <run_id>
+  --source <source>
+  --reason <reason>
+  --refresh-token <token>
+  --state <claimed|running|retry_queued|continuity_degraded|awaiting_human|terminal>
+  --workspace-receipt-path <path>
+  --envelope-path <path>
+  --topology-path <path>
+  --command-string <command>
+  --provider <provider>
+  --continuity-owner <local-primary|gha-continuity|unknown>
+  --run-driver-pid <pid>
+EOF
+}
+
+ensure_claims_dir() {
+  mkdir -p "${CLAIMS_DIR}"
+}
+
+utc_timestamp() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+epoch_now() {
+  date -u '+%s'
+}
+
+normalize_state() {
+  local state="${1:-claimed}"
+  case "${state}" in
+    claimed|running|retry_queued|continuity_degraded|awaiting_human|terminal)
+      printf '%s\n' "${state}"
+      ;;
+    *)
+      echo "unsupported claim state: ${state}" >&2
+      exit 2
+      ;;
+  esac
+}
+
+bool_string() {
+  case "$(printf '%s' "${1:-false}" | tr '[:upper:]' '[:lower:]')" in
+    true|1|yes|on) printf 'true\n' ;;
+    *) printf 'false\n' ;;
+  esac
+}
+
+slugify() {
+  local value="${1:-}"
+  value="$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')"
+  value="$(printf '%s' "${value}" | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g')"
+  if [[ -z "${value}" ]]; then
+    printf 'claim\n'
+  else
+    printf '%s\n' "${value}"
+  fi
+}
+
+hash_text() {
+  local payload="${1:-}"
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "${payload}" | shasum -a 256 | awk '{print $1}'
+    return 0
+  fi
+  python3 - "${payload}" <<'PY'
+import hashlib
+import sys
+
+print(hashlib.sha256(sys.argv[1].encode("utf-8")).hexdigest())
+PY
+}
+
+derive_identity() {
+  local identity="${1:-}"
+  local project="${2:-${KERNEL_PROJECT:-kernel-workspace}}"
+  local issue_number="${3:-}"
+  local task_key="${4:-}"
+  local run_id="${5:-}"
+  if [[ -n "${identity}" ]]; then
+    printf '%s\n' "${identity}"
+    return 0
+  fi
+  if [[ -n "${issue_number}" ]]; then
+    if [[ -n "${task_key}" ]]; then
+      printf '%s#%s/%s\n' "${project}" "${issue_number}" "${task_key}"
+    else
+      printf '%s#%s\n' "${project}" "${issue_number}"
+    fi
+    return 0
+  fi
+  if [[ -n "${task_key}" ]]; then
+    printf '%s/%s\n' "${project}" "${task_key}"
+    return 0
+  fi
+  if [[ -n "${run_id}" ]]; then
+    printf '%s@%s\n' "${project}" "${run_id}"
+    return 0
+  fi
+  echo "unable to derive claim identity" >&2
+  exit 2
+}
+
+claim_path_for_identity() {
+  local identity="${1:?identity is required}"
+  local identity_slug identity_hash
+  identity_slug="$(slugify "${identity}")"
+  identity_hash="$(hash_text "${identity}")"
+  ensure_claims_dir
+  printf '%s/%s-%s.json\n' "${CLAIMS_DIR}" "${identity_slug:0:72}" "${identity_hash:0:12}"
+}
+
+load_claim_json() {
+  local claim_path="${1:?claim_path is required}"
+  if [[ -f "${claim_path}" ]]; then
+    jq -c '.' "${claim_path}"
+  else
+    printf '{}\n'
+  fi
+}
+
+write_json_atomic() {
+  local path="${1:?path is required}"
+  local payload="${2:?payload is required}"
+  local tmp_file
+  mkdir -p "$(dirname "${path}")"
+  tmp_file="$(umask 077 && mktemp "${path}.tmp.XXXXXXXXXX")"
+  printf '%s\n' "${payload}" >"${tmp_file}"
+  mv "${tmp_file}" "${path}"
+}
+
+claim_status_active() {
+  local status="${1:-}"
+  case "${status}" in
+    terminal|"") return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+resolve_existing_run_id() {
+  local claim_json="${1:-}"
+  if [[ -z "${claim_json}" ]]; then
+    claim_json='{}'
+  fi
+  jq -r '.run_id // ""' <<<"${claim_json}"
+}
+
+record_scheduler_state() {
+  local run_id="${1:-}"
+  local scheduler_state="${2:-}"
+  local reason="${3:-}"
+  local workspace_receipt_path="${4:-}"
+  [[ -n "${run_id}" ]] || return 0
+  [[ -x "${LEDGER_SCRIPT}" || -f "${LEDGER_SCRIPT}" ]] || return 0
+  KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" scheduler-state "${scheduler_state}" "${reason}" "${workspace_receipt_path}" >/dev/null 2>&1 || true
+}
+
+record_event() {
+  local run_id="${1:-}"
+  local command_name="${2:-}"
+  local summary="${3:-}"
+  [[ -n "${run_id}" ]] || return 0
+  [[ -x "${LEDGER_SCRIPT}" || -f "${LEDGER_SCRIPT}" ]] || return 0
+  KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" record-event kernel-runtime-claim "${command_name}" "${summary}" >/dev/null 2>&1 || true
+}
+
+claim_upsert() {
+  local identity="${1:?identity is required}"
+  local project="${2:-${KERNEL_PROJECT:-kernel-workspace}}"
+  local issue_number="${3:-}"
+  local task_key="${4:-}"
+  local run_id="${5:-}"
+  local source="${6:-scheduler}"
+  local reason="${7:-dispatchable}"
+  local refresh_token="${8:-}"
+  local state="${9:-claimed}"
+  local workspace_receipt_path="${10:-}"
+  local envelope_path="${11:-}"
+  local topology_path="${12:-}"
+  local command_string="${13:-}"
+  local provider="${14:-}"
+  local continuity_owner="${15:-local-primary}"
+  local run_driver_pid="${16:-}"
+  local claim_path existing_json now now_epoch claim_token identity_hash identity_slug action existing_run_id
+
+  state="$(normalize_state "${state}")"
+  claim_path="$(claim_path_for_identity "${identity}")"
+  existing_json="$(load_claim_json "${claim_path}")"
+  now="$(utc_timestamp)"
+  now_epoch="$(epoch_now)"
+  identity_hash="$(hash_text "${identity}")"
+  identity_slug="$(slugify "${identity}")"
+  existing_run_id="$(resolve_existing_run_id "${existing_json}")"
+  if [[ -n "${existing_run_id}" && -z "${run_id}" ]]; then
+    run_id="${existing_run_id}"
+  fi
+  claim_token="claim:${identity_hash:0:16}"
+  if [[ "$(jq -r '((.claim_active // false) and ((.status // "") != "terminal"))' <<<"${existing_json}")" == "true" ]]; then
+    action="coalesced"
+  else
+    action="claimed"
+  fi
+
+  acquire_lock "kernel runtime claims"
+  local next_json
+  next_json="$(
+    jq -n \
+      --argjson prev "${existing_json}" \
+      --arg identity "${identity}" \
+      --arg identity_slug "${identity_slug}" \
+      --arg identity_hash "${identity_hash}" \
+      --arg project "${project}" \
+      --arg issue_number "${issue_number}" \
+      --arg task_key "${task_key}" \
+      --arg run_id "${run_id}" \
+      --arg source "${source}" \
+      --arg reason "${reason}" \
+      --arg refresh_token "${refresh_token}" \
+      --arg state "${state}" \
+      --arg workspace_receipt_path "${workspace_receipt_path}" \
+      --arg envelope_path "${envelope_path}" \
+      --arg topology_path "${topology_path}" \
+      --arg command_string "${command_string}" \
+      --arg provider "${provider}" \
+      --arg continuity_owner "${continuity_owner}" \
+      --arg run_driver_pid "${run_driver_pid}" \
+      --arg claim_token "${claim_token}" \
+      --arg claimed_at "${now}" \
+      --arg updated_at "${now}" \
+      --argjson claimed_at_epoch "${now_epoch}" \
+      --argjson updated_at_epoch "${now_epoch}" \
+      '
+        ($prev // {}) as $p
+        | (($p.claim_active // false) and (($p.status // "") != "terminal")) as $active
+        | {
+            version: 1,
+            identity: $identity,
+            identity_slug: $identity_slug,
+            identity_hash: $identity_hash,
+            project: (if $project != "" then $project else ($p.project // "kernel-workspace") end),
+            issue_number: (if $issue_number == "" then ($p.issue_number // null) else ($issue_number | tonumber) end),
+            task_key: (if $task_key != "" then $task_key else ($p.task_key // "") end),
+            run_id: (if $run_id != "" then $run_id else ($p.run_id // "") end),
+            claim_token: (if ($p.claim_token // "") != "" then ($p.claim_token // "") else $claim_token end),
+            source: (if $source != "" then $source else ($p.source // "") end),
+            reason: (if $reason != "" then $reason else ($p.reason // "") end),
+            refresh_token: (if $refresh_token != "" then $refresh_token else ($p.refresh_token // "") end),
+            refresh_count: (if $active then (($p.refresh_count // 0) + 1) else 1 end),
+            first_refresh_at: (if $active and (($p.first_refresh_at // "") != "") then ($p.first_refresh_at // "") else $claimed_at end),
+            first_refresh_epoch: (if $active and (($p.first_refresh_epoch // 0) > 0) then ($p.first_refresh_epoch // 0) else $claimed_at_epoch end),
+            last_refresh_at: $updated_at,
+            last_refresh_epoch: $updated_at_epoch,
+            status: (if $state != "" then $state else (if $active and (($p.status // "") != "") then ($p.status // "") else "claimed" end) end),
+            claim_active: ($state != "terminal"),
+            claimed_at: (if $active and (($p.claimed_at // "") != "") then ($p.claimed_at // "") else $claimed_at end),
+            claimed_at_epoch: (if $active and (($p.claimed_at_epoch // 0) > 0) then ($p.claimed_at_epoch // 0) else $claimed_at_epoch end),
+            updated_at: $updated_at,
+            updated_at_epoch: $updated_at_epoch,
+            released_at: (if $state == "terminal" then $updated_at else ($p.released_at // "") end),
+            released_at_epoch: (if $state == "terminal" then $updated_at_epoch else ($p.released_at_epoch // null) end),
+            workspace_receipt_path: (if $workspace_receipt_path != "" then $workspace_receipt_path else ($p.workspace_receipt_path // "") end),
+            envelope_path: (if $envelope_path != "" then $envelope_path else ($p.envelope_path // "") end),
+            topology_path: (if $topology_path != "" then $topology_path else ($p.topology_path // "") end),
+            command_string: (if $command_string != "" then $command_string else ($p.command_string // "") end),
+            provider: (if $provider != "" then $provider else ($p.provider // "") end),
+            continuity_owner: (if $continuity_owner != "" then $continuity_owner else ($p.continuity_owner // "local-primary") end),
+            run_driver_pid: (if $run_driver_pid != "" then ($run_driver_pid | tonumber) else ($p.run_driver_pid // null) end),
+            stop_reason: ($p.stop_reason // ""),
+            retry_reason: ($p.retry_reason // ""),
+            downgrade_reason: ($p.downgrade_reason // ""),
+            last_action: "claim"
+          }
+      '
+  )"
+  write_json_atomic "${claim_path}" "${next_json}"
+  release_lock
+
+  local effective_run_id effective_workspace
+  effective_run_id="$(jq -r '.run_id // ""' <<<"${next_json}")"
+  effective_workspace="$(jq -r '.workspace_receipt_path // ""' <<<"${next_json}")"
+  record_scheduler_state "${effective_run_id}" "$(jq -r '.status' <<<"${next_json}")" "${reason}" "${effective_workspace}"
+  record_event "${effective_run_id}" claim "${identity}; action=${action}; reason=${reason}"
+
+  jq -n --arg action "${action}" --arg claim_path "${claim_path}" --argjson claim "${next_json}" \
+    '{action: $action, claim_path: $claim_path, claim: $claim}'
+}
+
+set_state_for_identity() {
+  local identity="${1:?identity is required}"
+  local requested_state="${2:?state is required}"
+  local reason="${3:-state-updated}"
+  local workspace_receipt_path="${4:-}"
+  local envelope_path="${5:-}"
+  local continuity_owner="${6:-}"
+  local run_driver_pid="${7:-}"
+  local claim_path existing_json now now_epoch next_json run_id
+
+  requested_state="$(normalize_state "${requested_state}")"
+  claim_path="$(claim_path_for_identity "${identity}")"
+  existing_json="$(load_claim_json "${claim_path}")"
+  now="$(utc_timestamp)"
+  now_epoch="$(epoch_now)"
+
+  acquire_lock "kernel runtime claims"
+  next_json="$(
+    jq -n \
+      --argjson prev "${existing_json}" \
+      --arg state "${requested_state}" \
+      --arg reason "${reason}" \
+      --arg workspace_receipt_path "${workspace_receipt_path}" \
+      --arg envelope_path "${envelope_path}" \
+      --arg continuity_owner "${continuity_owner}" \
+      --arg run_driver_pid "${run_driver_pid}" \
+      --arg updated_at "${now}" \
+      --argjson updated_at_epoch "${now_epoch}" \
+      '
+        ($prev // {}) as $p
+        | ($state != "terminal") as $active
+        | ($p + {
+            status: $state,
+            claim_active: $active,
+            reason: $reason,
+            updated_at: $updated_at,
+            updated_at_epoch: $updated_at_epoch,
+            last_action: "set-state",
+            workspace_receipt_path: (if $workspace_receipt_path != "" then $workspace_receipt_path else ($p.workspace_receipt_path // "") end),
+            envelope_path: (if $envelope_path != "" then $envelope_path else ($p.envelope_path // "") end),
+            continuity_owner: (if $continuity_owner != "" then $continuity_owner else ($p.continuity_owner // "local-primary") end),
+            run_driver_pid: (if $run_driver_pid != "" then ($run_driver_pid | tonumber) else ($p.run_driver_pid // null) end)
+          })
+        | if $state == "terminal" then . + {
+            released_at: $updated_at,
+            released_at_epoch: $updated_at_epoch,
+            stop_reason: $reason,
+            run_driver_pid: null
+          } else . end
+        | if $state == "retry_queued" then . + { retry_reason: $reason } else . end
+        | if $state == "continuity_degraded" then . + { downgrade_reason: $reason } else . end
+        | if $state == "awaiting_human" then . + { stop_reason: $reason } else . end
+      '
+  )"
+  write_json_atomic "${claim_path}" "${next_json}"
+  release_lock
+
+  run_id="$(jq -r '.run_id // ""' <<<"${next_json}")"
+  record_scheduler_state "${run_id}" "${requested_state}" "${reason}" "$(jq -r '.workspace_receipt_path // ""' <<<"${next_json}")"
+  record_event "${run_id}" set-state "${identity}; state=${requested_state}; reason=${reason}"
+
+  jq -n --arg claim_path "${claim_path}" --argjson claim "${next_json}" \
+    '{claim_path: $claim_path, claim: $claim}'
+}
+
+release_identity() {
+  local identity="${1:?identity is required}"
+  local reason="${2:-claim-released}"
+  set_state_for_identity "${identity}" terminal "${reason}"
+}
+
+cmd_path() {
+  local identity=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --identity) identity="${2:-}"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+  [[ -n "${identity}" ]] || { echo "--identity is required" >&2; exit 2; }
+  claim_path_for_identity "${identity}"
+}
+
+cmd_status() {
+  local identity=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --identity) identity="${2:-}"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+  [[ -n "${identity}" ]] || { echo "--identity is required" >&2; exit 2; }
+  local claim_path
+  claim_path="$(claim_path_for_identity "${identity}")"
+  if [[ ! -f "${claim_path}" ]]; then
+    jq -n --arg identity "${identity}" --arg claim_path "${claim_path}" \
+      '{present: false, identity: $identity, claim_path: $claim_path}'
+    return 1
+  fi
+  jq -n --arg claim_path "${claim_path}" --slurpfile claim "${claim_path}" \
+    '{present: true, claim_path: $claim_path, claim: $claim[0]}'
+}
+
+cmd_list() {
+  local active_only=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --active-only) active_only=true; shift ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+  ensure_claims_dir
+  local files=()
+  while IFS= read -r file; do
+    files+=("${file}")
+  done < <(find "${CLAIMS_DIR}" -maxdepth 1 -type f -name '*.json' | sort)
+  if ((${#files[@]} == 0)); then
+    printf '[]\n'
+    return 0
+  fi
+  local claims_json='[]'
+  local file payload
+  for file in "${files[@]}"; do
+    payload="$(jq -c --arg claim_path "${file}" '. + {claim_path: $claim_path}' "${file}")"
+    claims_json="$(jq -c --argjson claim "${payload}" '. + [$claim]' <<<"${claims_json}")"
+  done
+  jq --arg active_only "$(bool_string "${active_only}")" '
+    if $active_only == "true" then map(select(.claim_active == true and (.status // "") != "terminal")) else . end
+    | sort_by(.project // "", .issue_number // 0, .identity // "")
+  ' <<<"${claims_json}"
+}
+
+cmd_claim() {
+  local identity="" project="${KERNEL_PROJECT:-kernel-workspace}" issue_number="" task_key="" run_id=""
+  local source="scheduler" reason="dispatchable" refresh_token="" state="claimed"
+  local workspace_receipt_path="" envelope_path="" topology_path="" command_string="" provider=""
+  local continuity_owner="local-primary" run_driver_pid=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --identity) identity="${2:-}"; shift 2 ;;
+      --project) project="${2:-}"; shift 2 ;;
+      --issue-number) issue_number="${2:-}"; shift 2 ;;
+      --task-key) task_key="${2:-}"; shift 2 ;;
+      --run-id) run_id="${2:-}"; shift 2 ;;
+      --source) source="${2:-}"; shift 2 ;;
+      --reason) reason="${2:-}"; shift 2 ;;
+      --refresh-token) refresh_token="${2:-}"; shift 2 ;;
+      --state) state="${2:-}"; shift 2 ;;
+      --workspace-receipt-path) workspace_receipt_path="${2:-}"; shift 2 ;;
+      --envelope-path) envelope_path="${2:-}"; shift 2 ;;
+      --topology-path) topology_path="${2:-}"; shift 2 ;;
+      --command-string) command_string="${2:-}"; shift 2 ;;
+      --provider) provider="${2:-}"; shift 2 ;;
+      --continuity-owner) continuity_owner="${2:-}"; shift 2 ;;
+      --run-driver-pid) run_driver_pid="${2:-}"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+  identity="$(derive_identity "${identity}" "${project}" "${issue_number}" "${task_key}" "${run_id}")"
+  claim_upsert "${identity}" "${project}" "${issue_number}" "${task_key}" "${run_id}" "${source}" "${reason}" "${refresh_token}" "${state}" "${workspace_receipt_path}" "${envelope_path}" "${topology_path}" "${command_string}" "${provider}" "${continuity_owner}" "${run_driver_pid}"
+}
+
+cmd_set_state() {
+  local identity="" project="${KERNEL_PROJECT:-kernel-workspace}" issue_number="" task_key="" run_id=""
+  local requested_state="" reason="state-updated" workspace_receipt_path="" envelope_path=""
+  local continuity_owner="" run_driver_pid=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --identity) identity="${2:-}"; shift 2 ;;
+      --project) project="${2:-}"; shift 2 ;;
+      --issue-number) issue_number="${2:-}"; shift 2 ;;
+      --task-key) task_key="${2:-}"; shift 2 ;;
+      --run-id) run_id="${2:-}"; shift 2 ;;
+      --state) requested_state="${2:-}"; shift 2 ;;
+      --reason) reason="${2:-}"; shift 2 ;;
+      --workspace-receipt-path) workspace_receipt_path="${2:-}"; shift 2 ;;
+      --envelope-path) envelope_path="${2:-}"; shift 2 ;;
+      --continuity-owner) continuity_owner="${2:-}"; shift 2 ;;
+      --run-driver-pid) run_driver_pid="${2:-}"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+  [[ -n "${requested_state}" ]] || { echo "--state is required" >&2; exit 2; }
+  identity="$(derive_identity "${identity}" "${project}" "${issue_number}" "${task_key}" "${run_id}")"
+  set_state_for_identity "${identity}" "${requested_state}" "${reason}" "${workspace_receipt_path}" "${envelope_path}" "${continuity_owner}" "${run_driver_pid}"
+}
+
+cmd_release() {
+  local identity="" project="${KERNEL_PROJECT:-kernel-workspace}" issue_number="" task_key="" run_id=""
+  local reason="claim-released"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --identity) identity="${2:-}"; shift 2 ;;
+      --project) project="${2:-}"; shift 2 ;;
+      --issue-number) issue_number="${2:-}"; shift 2 ;;
+      --task-key) task_key="${2:-}"; shift 2 ;;
+      --run-id) run_id="${2:-}"; shift 2 ;;
+      --reason) reason="${2:-}"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+  identity="$(derive_identity "${identity}" "${project}" "${issue_number}" "${task_key}" "${run_id}")"
+  release_identity "${identity}" "${reason}"
+}
+
+cmd_rebuild() {
+  local ttl_seconds="${KERNEL_RUNTIME_CLAIM_STALE_TTL_SEC:-3600}"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --ttl-seconds) ttl_seconds="${2:-}"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+  [[ "${ttl_seconds}" =~ ^[0-9]+$ ]] || ttl_seconds=3600
+
+  local claims_json
+  claims_json="$(cmd_list --active-only)"
+  local count=0 released=0 updated=0
+  while IFS= read -r claim_json; do
+    [[ -n "${claim_json}" ]] || continue
+    count=$((count + 1))
+    local identity run_id claim_path status pid updated_epoch envelope_path live_pid=false age=0 envelope_state envelope_reason ledger_state ledger_reason
+    identity="$(jq -r '.identity // ""' <<<"${claim_json}")"
+    run_id="$(jq -r '.run_id // ""' <<<"${claim_json}")"
+    claim_path="$(jq -r '.claim_path // ""' <<<"${claim_json}")"
+    status="$(jq -r '.status // ""' <<<"${claim_json}")"
+    pid="$(jq -r '.run_driver_pid // ""' <<<"${claim_json}")"
+    updated_epoch="$(jq -r '.updated_at_epoch // 0' <<<"${claim_json}")"
+    envelope_path="$(jq -r '.envelope_path // ""' <<<"${claim_json}")"
+    if [[ -n "${pid}" && "${pid}" =~ ^[0-9]+$ ]] && kill -0 "${pid}" 2>/dev/null; then
+      live_pid=true
+    fi
+    age="$(( $(epoch_now) - updated_epoch ))"
+    if [[ -n "${envelope_path}" && -f "${envelope_path}" ]]; then
+      envelope_state="$(jq -r '.scheduler_state // ""' "${envelope_path}")"
+      envelope_reason="$(jq -r '.reason // .status_reason // "run-envelope"' "${envelope_path}")"
+      if [[ -n "${envelope_state}" ]]; then
+        cmd_set_state --identity "${identity}" --state "${envelope_state}" --reason "${envelope_reason}" --envelope-path "${envelope_path}" >/dev/null
+        updated=$((updated + 1))
+        continue
+      fi
+    fi
+    if [[ -n "${run_id}" && -f "${KERNEL_RUNTIME_LEDGER_FILE:-${STATE_ROOT}/runtime-ledger.json}" ]]; then
+      ledger_state="$(jq -r --arg run_id "${run_id}" '.runs[$run_id].scheduler_state // ""' "${KERNEL_RUNTIME_LEDGER_FILE:-${STATE_ROOT}/runtime-ledger.json}" 2>/dev/null || true)"
+      ledger_reason="$(jq -r --arg run_id "${run_id}" '.runs[$run_id].scheduler_reason // "runtime-ledger"' "${KERNEL_RUNTIME_LEDGER_FILE:-${STATE_ROOT}/runtime-ledger.json}" 2>/dev/null || true)"
+      if [[ "${ledger_state}" == "terminal" ]]; then
+        cmd_set_state --identity "${identity}" --state terminal --reason "${ledger_reason}" >/dev/null
+        updated=$((updated + 1))
+        continue
+      fi
+    fi
+    if [[ "${live_pid}" == "true" ]]; then
+      continue
+    fi
+    if claim_status_active "${status}" && (( age >= ttl_seconds )); then
+      cmd_release --identity "${identity}" --reason "stale-claim-released" >/dev/null
+      released=$((released + 1))
+    fi
+  done < <(jq -c '.[]' <<<"${claims_json}")
+
+  jq -n \
+    --arg generated_at "$(utc_timestamp)" \
+    --argjson scanned "${count}" \
+    --argjson released "${released}" \
+    --argjson updated "${updated}" \
+    '{generated_at: $generated_at, scanned: $scanned, released: $released, updated: $updated}'
+}
+
+cmd="${1:-help}"
+shift || true
+case "${cmd}" in
+  path)
+    cmd_path "$@"
+    ;;
+  status)
+    cmd_status "$@"
+    ;;
+  list)
+    cmd_list "$@"
+    ;;
+  claim)
+    cmd_claim "$@"
+    ;;
+  set-state)
+    cmd_set_state "$@"
+    ;;
+  release)
+    cmd_release "$@"
+    ;;
+  rebuild)
+    cmd_rebuild "$@"
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    echo "Unknown subcommand: ${cmd}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/lib/kernel-runtime-reconciler.sh
+++ b/scripts/lib/kernel-runtime-reconciler.sh
@@ -234,10 +234,11 @@ is_stale_claim_candidate() {
   if [[ -n "${compact_path}" ]]; then
     compact_tmux_session="$(jq -r '.tmux_session // ""' "${compact_path}" 2>/dev/null || true)"
     if [[ -n "${compact_tmux_session}" ]]; then
-      if tmux_session_exists "${compact_tmux_session}"; then
+      tmux_session_exists "${compact_tmux_session}"
+      tmux_status=$?
+      if (( tmux_status == 0 )); then
         return 1
       fi
-      tmux_status=$?
       if (( tmux_status > 1 )); then
         return 1
       fi

--- a/scripts/lib/kernel-runtime-reconciler.sh
+++ b/scripts/lib/kernel-runtime-reconciler.sh
@@ -106,7 +106,7 @@ normalize_queue_json() {
         stop_reason: (.stop_reason // .reason // ""),
         dispatchable: (
           if .dispatchable == null then (inferred_authorized and inferred_eligible and (inferred_terminal | not))
-          else (.dispatchable | bool_or(false))
+          else ((.dispatchable | bool_or(false)) and inferred_authorized and inferred_eligible and (inferred_terminal | not))
           end
         )
       })

--- a/scripts/lib/kernel-runtime-reconciler.sh
+++ b/scripts/lib/kernel-runtime-reconciler.sh
@@ -1,0 +1,493 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CLAIM_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-claim.sh"
+WORKSPACE_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-workspace.sh"
+COMPACT_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-compact-artifact.sh"
+STATE_PATHS_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-state-paths.sh"
+STATE_ROOT="${KERNEL_SUBSTRATE_STATE_ROOT:-$(bash "${STATE_PATHS_SCRIPT}" state-root)}"
+COMPACT_DIR="${KERNEL_COMPACT_DIR:-$(bash "${STATE_PATHS_SCRIPT}" compact-dir)}"
+TMUX_BIN="${TMUX_BIN:-tmux}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  kernel-runtime-reconciler.sh reconcile [options]
+
+Options:
+  --queue-file <path>
+  --queue-json <json>
+  --ttl-seconds <seconds>
+  --archive-ttl-seconds <seconds>
+EOF
+}
+
+utc_timestamp() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+epoch_now() {
+  date -u '+%s'
+}
+
+load_queue_json() {
+  local queue_file="${1:-}"
+  local queue_json="${2:-}"
+  local source_cmd="${KERNEL_SCHEDULER_SOURCE_CMD:-}"
+  if [[ -n "${queue_json}" ]]; then
+    printf '%s\n' "${queue_json}"
+    return 0
+  fi
+  if [[ -n "${queue_file}" && -f "${queue_file}" ]]; then
+    cat "${queue_file}"
+    return 0
+  fi
+  if [[ -n "${KERNEL_SCHEDULER_QUEUE_FILE:-}" && -f "${KERNEL_SCHEDULER_QUEUE_FILE}" ]]; then
+    cat "${KERNEL_SCHEDULER_QUEUE_FILE}"
+    return 0
+  fi
+  if [[ -n "${KERNEL_SCHEDULER_QUEUE_JSON:-}" ]]; then
+    printf '%s\n' "${KERNEL_SCHEDULER_QUEUE_JSON}"
+    return 0
+  fi
+  if [[ -n "${source_cmd}" ]]; then
+    bash -lc "${source_cmd}"
+    return 0
+  fi
+  printf '{"items":[]}\n'
+}
+
+normalize_queue_json() {
+  local raw_json="${1:-}"
+  if [[ -z "${raw_json}" ]]; then
+    raw_json='{"items":[]}'
+  fi
+  jq -c '
+    def bool_or($fallback):
+      if . == null then $fallback
+      elif type == "boolean" then .
+      elif type == "string" then
+        ((ascii_downcase) as $v | ($v == "true" or $v == "1" or $v == "yes" or $v == "on"))
+      else $fallback end;
+    def inferred_authorized:
+      (.authorized | bool_or(false))
+      or ((.start_signal // "") | ascii_downcase | test("^/(vote|v)$|^tutti$|^workflow_dispatch$"))
+      or ((.signals // []) | map((. // "") | tostring | ascii_downcase) | any(. == "/vote" or . == "/v" or . == "tutti" or . == "workflow_dispatch"));
+    def inferred_terminal:
+      (.terminal | bool_or(false))
+      or ((.state // .issue_state // "") | ascii_downcase | test("closed|done|terminal|merged|cancelled"));
+    def inferred_eligible:
+      if .eligible == null then true else (.eligible | bool_or(true)) end;
+    def derive_identity:
+      if (.identity // "") != "" then .identity
+      elif (.issue_number // "") != "" and (.task_key // "") != "" then "\(.project // "kernel-workspace")#\(.issue_number)/\(.task_key)"
+      elif (.issue_number // "") != "" then "\(.project // "kernel-workspace")#\(.issue_number)"
+      elif (.task_key // "") != "" then "\(.project // "kernel-workspace")/\(.task_key)"
+      else "\(.project // "kernel-workspace")@\(.run_id // "unknown")" end;
+    ((.items // .work_items // .issues // .claims // .) | if type == "array" then . else [] end)
+    | map({
+        identity: derive_identity,
+        project: (.project // "kernel-workspace"),
+        issue_number: (if (.issue_number // "") == "" then null else (.issue_number | tonumber) end),
+        task_key: (.task_key // ""),
+        run_id: (.run_id // ""),
+        authorized: inferred_authorized,
+        eligible: inferred_eligible,
+        terminal: inferred_terminal,
+        refresh_token: (.refresh_token // .refresh_requested_at // .updated_at // .etag // ""),
+        refresh_requested_at: (.refresh_requested_at // .updated_at // ""),
+        reason: (.reason // .status_reason // .blocking_reason // ""),
+        continuity_owner: (.continuity_owner // "local-primary"),
+        topology_path: (.topology_path // ""),
+        command_string: (.command_string // .launch_command // ""),
+        provider: (.provider // ""),
+        stop_reason: (.stop_reason // .reason // ""),
+        dispatchable: (
+          if .dispatchable == null then (inferred_authorized and inferred_eligible and (inferred_terminal | not))
+          else (.dispatchable | bool_or(false))
+          end
+        )
+      })
+  ' <<<"${raw_json}"
+}
+
+reason_to_state() {
+  local fallback="${1:-retry_queued}"
+  local reason="${2:-}"
+  local lower
+  lower="$(printf '%s' "${reason}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${lower}" == *"human"* || "${lower}" == *"approval"* || "${lower}" == *"manual"* || "${lower}" == *"auth"* ]]; then
+    printf 'awaiting_human\n'
+  else
+    printf '%s\n' "${fallback}"
+  fi
+}
+
+workspace_stop_file_for_claim() {
+  local run_id="${1:-}"
+  [[ -n "${run_id}" ]] || return 1
+  local workspace_dir
+  workspace_dir="$(KERNEL_RUN_ID="${run_id}" bash "${WORKSPACE_SCRIPT}" path 2>/dev/null || true)"
+  [[ -n "${workspace_dir}" ]] || return 1
+  printf '%s/stop\n' "${workspace_dir}"
+}
+
+workspace_receipt_for_run() {
+  local run_id="${1:-}"
+  [[ -n "${run_id}" ]] || return 1
+  KERNEL_RUN_ID="${run_id}" bash "${WORKSPACE_SCRIPT}" receipt-path "${run_id}" 2>/dev/null || true
+}
+
+compact_path_for_run() {
+  local run_id="${1:-}"
+  [[ -n "${run_id}" ]] || return 1
+  KERNEL_RUN_ID="${run_id}" bash "${COMPACT_SCRIPT}" path "${run_id}" 2>/dev/null || true
+}
+
+epoch_from_iso8601() {
+  local value="${1:-}"
+  [[ -n "${value}" ]] || return 1
+  python3 - "${value}" <<'PY'
+import datetime
+import sys
+
+try:
+    dt = datetime.datetime.strptime(sys.argv[1], "%Y-%m-%dT%H:%M:%SZ")
+except ValueError:
+    raise SystemExit(1)
+print(int(dt.replace(tzinfo=datetime.timezone.utc).timestamp()))
+PY
+}
+
+compact_updated_epoch() {
+  local compact_path="${1:-}"
+  local updated_at
+  [[ -n "${compact_path}" && -f "${compact_path}" ]] || return 1
+  updated_at="$(jq -r '.updated_at // ""' "${compact_path}" 2>/dev/null || true)"
+  epoch_from_iso8601 "${updated_at}" 2>/dev/null || return 1
+}
+
+tmux_session_exists() {
+  local session_name="${1:-}"
+  local tmux_bin="${TMUX_BIN:-tmux}"
+  [[ -n "${session_name}" ]] || return 1
+  command -v "${tmux_bin}" >/dev/null 2>&1 || return 2
+  "${tmux_bin}" has-session -t "=${session_name}" 2>/dev/null
+  return $?
+}
+
+compact_path_for_claim() {
+  local claim_json="${1:-}"
+  local compact_path run_id workspace_receipt_path
+  compact_path="$(jq -r '.compact_artifact_path // ""' <<<"${claim_json}")"
+  if [[ -n "${compact_path}" ]]; then
+    [[ -f "${compact_path}" ]] && {
+      printf '%s\n' "${compact_path}"
+      return 0
+    }
+  fi
+  workspace_receipt_path="$(jq -r '.workspace_receipt_path // ""' <<<"${claim_json}")"
+  if [[ -n "${workspace_receipt_path}" && -f "${workspace_receipt_path}" ]]; then
+    compact_path="$(jq -r '.compact_artifact_path // ""' "${workspace_receipt_path}" 2>/dev/null || true)"
+    [[ -n "${compact_path}" && -f "${compact_path}" ]] && {
+      printf '%s\n' "${compact_path}"
+      return 0
+    }
+  fi
+  run_id="$(jq -r '.run_id // ""' <<<"${claim_json}")"
+  if [[ -n "${run_id}" ]]; then
+    compact_path="$(compact_path_for_run "${run_id}")"
+    [[ -f "${compact_path}" ]] && {
+      printf '%s\n' "${compact_path}"
+      return 0
+    }
+  fi
+  return 1
+}
+
+is_stale_claim_candidate() {
+  local claim_json="${1:-}"
+  local ttl_seconds="${2:-3600}"
+  local now updated_epoch updated_at_age status claim_active pid compact_path compact_tmux_session compact_updated tmux_status
+
+  status="$(jq -r '.status // ""' <<<"${claim_json}")"
+  claim_active="$(jq -r '.claim_active // false' <<<"${claim_json}")"
+  updated_epoch="$(jq -r '.updated_at_epoch // 0' <<<"${claim_json}")"
+  pid="$(jq -r '.run_driver_pid // ""' <<<"${claim_json}")"
+
+  if [[ "${claim_active}" != "true" || "${status}" == "terminal" ]]; then
+    return 1
+  fi
+  now="$(epoch_now)"
+  [[ "${updated_epoch}" =~ ^[0-9]+$ ]] || updated_epoch=0
+  updated_at_age=$(( now - updated_epoch ))
+  if (( updated_at_age < ttl_seconds )); then
+    return 1
+  fi
+  if [[ -n "${pid}" && "${pid}" =~ ^[0-9]+$ ]] && kill -0 "${pid}" 2>/dev/null; then
+    return 1
+  fi
+
+  compact_path="$(compact_path_for_claim "${claim_json}" || true)"
+  if [[ -n "${compact_path}" ]]; then
+    compact_tmux_session="$(jq -r '.tmux_session // ""' "${compact_path}" 2>/dev/null || true)"
+    if [[ -n "${compact_tmux_session}" ]]; then
+      if tmux_session_exists "${compact_tmux_session}"; then
+        return 1
+      fi
+      tmux_status=$?
+      if (( tmux_status > 1 )); then
+        return 1
+      fi
+    fi
+    compact_updated="$(compact_updated_epoch "${compact_path}" || true)"
+    if [[ ! "${compact_updated}" =~ ^[0-9]+$ ]]; then
+      return 1
+    fi
+    if (( now - compact_updated < ttl_seconds )); then
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
+archive_root() {
+  printf '%s/archive/runtime-reconciler\n' "${STATE_ROOT}"
+}
+
+archive_file_if_present() {
+  local path="${1:-}"
+  local run_id="${2:-}"
+  local category="${3:-misc}"
+  local archive_dir archive_path base safe_run
+  [[ -n "${path}" && -f "${path}" ]] || return 1
+  safe_run="$(printf '%s' "${run_id:-unknown-run}" | tr '/:' '__')"
+  base="$(basename "${path}")"
+  archive_dir="$(archive_root)/${category}"
+  mkdir -p "${archive_dir}"
+  archive_path="${archive_dir}/${safe_run}--${base}"
+  if [[ -e "${archive_path}" ]]; then
+    archive_path="${archive_dir}/${safe_run}--$(date -u '+%Y%m%dT%H%M%SZ')--${base}"
+  fi
+  mv "${path}" "${archive_path}"
+  printf '%s\n' "${archive_path}"
+}
+
+archive_stale_artifacts_for_run() {
+  local run_id="${1:-}"
+  local workspace_receipt_path="${2:-}"
+  local envelope_path="${3:-}"
+  local compact_path_override="${4:-}"
+  local compact_path archived=0
+  [[ -n "${run_id}" ]] || {
+    printf '0\n'
+    return 0
+  }
+  if [[ -z "${workspace_receipt_path}" ]]; then
+    workspace_receipt_path="$(workspace_receipt_for_run "${run_id}" || true)"
+  fi
+  if [[ -n "${workspace_receipt_path}" && -f "${workspace_receipt_path}" ]]; then
+    compact_path="$(jq -r '.compact_artifact_path // ""' "${workspace_receipt_path}" 2>/dev/null || true)"
+  fi
+  [[ -n "${compact_path_override}" ]] && compact_path="${compact_path_override}"
+  [[ -n "${compact_path:-}" ]] || compact_path="$(compact_path_for_run "${run_id}" || true)"
+  if archive_file_if_present "${compact_path}" "${run_id}" compact >/dev/null 2>&1; then
+    archived=$((archived + 1))
+  fi
+  if archive_file_if_present "${workspace_receipt_path}" "${run_id}" workspace-receipts >/dev/null 2>&1; then
+    archived=$((archived + 1))
+  fi
+  if archive_file_if_present "${envelope_path}" "${run_id}" envelopes >/dev/null 2>&1; then
+    archived=$((archived + 1))
+  fi
+  printf '%s\n' "${archived}"
+}
+
+compact_files() {
+  mkdir -p "${COMPACT_DIR}"
+  find "${COMPACT_DIR}" -maxdepth 1 -type f -name '*.json' | sort
+}
+
+kill_pid_if_live() {
+  local pid="${1:-}"
+  if [[ -n "${pid}" && "${pid}" =~ ^[0-9]+$ ]] && kill -0 "${pid}" 2>/dev/null; then
+    kill "${pid}" 2>/dev/null || true
+    return 0
+  fi
+  return 1
+}
+
+cmd_reconcile() {
+  local queue_file="" queue_json="" ttl_seconds="${KERNEL_RUNTIME_RECONCILE_STALE_TTL_SEC:-3600}"
+  local archive_ttl_seconds="${KERNEL_RUNTIME_RECONCILE_ARCHIVE_TTL_SEC:-${KERNEL_RUNTIME_RECONCILE_STALE_TTL_SEC:-3600}}"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --queue-file) queue_file="${2:-}"; shift 2 ;;
+      --queue-json) queue_json="${2:-}"; shift 2 ;;
+      --ttl-seconds) ttl_seconds="${2:-}"; shift 2 ;;
+      --archive-ttl-seconds) archive_ttl_seconds="${2:-}"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+  [[ "${ttl_seconds}" =~ ^[0-9]+$ ]] || ttl_seconds=3600
+  [[ "${archive_ttl_seconds}" =~ ^[0-9]+$ ]] || archive_ttl_seconds="${ttl_seconds}"
+
+  local live_queue_raw live_queue claims_json scanned=0 stopped=0 updated=0 released=0 continued=0 archived_files=0 orphan_archived=0
+  local archived_runs_json='[]'
+  live_queue_raw="$(load_queue_json "${queue_file}" "${queue_json}")"
+  live_queue="$(normalize_queue_json "${live_queue_raw}")"
+  bash "${CLAIM_SCRIPT}" rebuild --ttl-seconds "${ttl_seconds}" >/dev/null
+  claims_json="$(bash "${CLAIM_SCRIPT}" list)"
+
+  while IFS= read -r claim_json; do
+    [[ -n "${claim_json}" ]] || continue
+    scanned=$((scanned + 1))
+    local identity run_id status pid updated_epoch envelope_path issue_item issue_terminal issue_eligible issue_reason live_pid=false stop_file target_state claim_active archived_now stop_reason
+    identity="$(jq -r '.identity // ""' <<<"${claim_json}")"
+    run_id="$(jq -r '.run_id // ""' <<<"${claim_json}")"
+    status="$(jq -r '.status // ""' <<<"${claim_json}")"
+    claim_active="$(jq -r '.claim_active // false' <<<"${claim_json}")"
+    stop_reason="$(jq -r '.stop_reason // ""' <<<"${claim_json}")"
+    pid="$(jq -r '.run_driver_pid // ""' <<<"${claim_json}")"
+    updated_epoch="$(jq -r '.updated_at_epoch // 0' <<<"${claim_json}")"
+    envelope_path="$(jq -r '.envelope_path // ""' <<<"${claim_json}")"
+    if [[ -n "${pid}" && "${pid}" =~ ^[0-9]+$ ]] && kill -0 "${pid}" 2>/dev/null; then
+      live_pid=true
+    fi
+
+    issue_item="$(jq -c --arg identity "${identity}" 'map(select(.identity == $identity)) | .[0] // {}' <<<"${live_queue}")"
+    issue_terminal="$(jq -r 'if .terminal == null then "false" else (.terminal | tostring) end' <<<"${issue_item}")"
+    issue_eligible="$(jq -r 'if .eligible == null then "true" else (.eligible | tostring) end' <<<"${issue_item}")"
+    issue_reason="$(jq -r '.reason // .stop_reason // ""' <<<"${issue_item}")"
+
+    if [[ "${claim_active}" != "true" ]]; then
+      if [[ "${status}" == "terminal" && "${stop_reason}" == "stale-claim-released" && -n "${run_id}" ]]; then
+        archived_now="$(archive_stale_artifacts_for_run "${run_id}" "$(jq -r '.workspace_receipt_path // ""' <<<"${claim_json}")" "${envelope_path}")"
+        if [[ "${archived_now}" =~ ^[0-9]+$ ]] && (( archived_now > 0 )); then
+          archived_files=$((archived_files + archived_now))
+          archived_runs_json="$(jq -c --arg run_id "${run_id}" '. + [$run_id] | unique' <<<"${archived_runs_json}")"
+        fi
+      fi
+      continue
+    fi
+
+    if [[ -n "${envelope_path}" && -f "${envelope_path}" ]]; then
+      target_state="$(jq -r '.scheduler_state // ""' "${envelope_path}")"
+      if [[ -n "${target_state}" ]]; then
+        bash "${CLAIM_SCRIPT}" set-state --identity "${identity}" --state "${target_state}" --reason "$(jq -r '.reason // .status_reason // "run-envelope"' "${envelope_path}")" --envelope-path "${envelope_path}" >/dev/null
+        updated=$((updated + 1))
+        continue
+      fi
+    fi
+
+    if [[ "${issue_terminal}" == "true" ]]; then
+      stop_file="$(workspace_stop_file_for_claim "${run_id}" || true)"
+      if [[ -n "${stop_file}" ]]; then
+        mkdir -p "$(dirname "${stop_file}")"
+        : >"${stop_file}"
+      fi
+      if kill_pid_if_live "${pid}"; then
+        :
+      fi
+      bash "${CLAIM_SCRIPT}" set-state --identity "${identity}" --state terminal --reason "${issue_reason:-issue-terminal}" >/dev/null
+      stopped=$((stopped + 1))
+      continue
+    fi
+
+    if [[ "${issue_eligible}" != "true" ]]; then
+      target_state="$(reason_to_state retry_queued "${issue_reason:-issue-ineligible}")"
+      stop_file="$(workspace_stop_file_for_claim "${run_id}" || true)"
+      if [[ -n "${stop_file}" ]]; then
+        mkdir -p "$(dirname "${stop_file}")"
+        : >"${stop_file}"
+      fi
+      kill_pid_if_live "${pid}" || true
+      bash "${CLAIM_SCRIPT}" set-state --identity "${identity}" --state "${target_state}" --reason "${issue_reason:-issue-ineligible}" >/dev/null
+      stopped=$((stopped + 1))
+      continue
+    fi
+
+    if [[ "${live_pid}" == "true" ]]; then
+      if [[ "${status}" == "continuity_degraded" ]]; then
+        bash "${CLAIM_SCRIPT}" set-state --identity "${identity}" --state continuity_degraded --reason "$(jq -r '.reason // "live-continuity-degraded"' <<<"${claim_json}")" >/dev/null
+      else
+        bash "${CLAIM_SCRIPT}" set-state --identity "${identity}" --state running --reason "$(jq -r '.reason // "run-still-live"' <<<"${claim_json}")" >/dev/null
+      fi
+      continued=$((continued + 1))
+      continue
+    fi
+
+    if is_stale_claim_candidate "${claim_json}" "${ttl_seconds}"; then
+      bash "${CLAIM_SCRIPT}" release --identity "${identity}" --reason "stale-claim-released" >/dev/null
+      released=$((released + 1))
+      archived_now="$(archive_stale_artifacts_for_run "${run_id}" "$(jq -r '.workspace_receipt_path // ""' <<<"${claim_json}")" "${envelope_path}")"
+      if [[ "${archived_now}" =~ ^[0-9]+$ ]] && (( archived_now > 0 )); then
+        archived_files=$((archived_files + archived_now))
+        archived_runs_json="$(jq -c --arg run_id "${run_id}" '. + [$run_id] | unique' <<<"${archived_runs_json}")"
+      fi
+    fi
+  done < <(jq -c '.[]' <<<"${claims_json}")
+
+  local active_run_ids_json compact_path compact_run_id compact_epoch
+  active_run_ids_json="$(jq -c '[.[] | select((.claim_active // false) == true) | .run_id | select(length > 0)] | unique' <<<"${claims_json}")"
+  while IFS= read -r compact_path; do
+    [[ -f "${compact_path}" ]] || continue
+    compact_run_id="$(jq -r '.run_id // ""' "${compact_path}" 2>/dev/null || true)"
+    [[ -n "${compact_run_id}" ]] || continue
+    if jq -e --arg run_id "${compact_run_id}" 'index($run_id) != null' <<<"${active_run_ids_json}" >/dev/null 2>&1; then
+      continue
+    fi
+    compact_epoch="$(compact_updated_epoch "${compact_path}" || true)"
+    [[ "${compact_epoch}" =~ ^[0-9]+$ ]] || continue
+    if (( $(epoch_now) - compact_epoch < archive_ttl_seconds )); then
+      continue
+    fi
+    archived_now="$(archive_stale_artifacts_for_run "${compact_run_id}" "" "" "${compact_path}")"
+    if [[ "${archived_now}" =~ ^[0-9]+$ ]] && (( archived_now > 0 )); then
+      archived_files=$((archived_files + archived_now))
+      orphan_archived=$((orphan_archived + 1))
+      archived_runs_json="$(jq -c --arg run_id "${compact_run_id}" '. + [$run_id] | unique' <<<"${archived_runs_json}")"
+    fi
+  done < <(compact_files)
+
+  jq -n \
+    --arg generated_at "$(utc_timestamp)" \
+    --argjson scanned "${scanned}" \
+    --argjson stopped "${stopped}" \
+    --argjson updated "${updated}" \
+    --argjson continued "${continued}" \
+    --argjson released "${released}" \
+    --argjson archived_files "${archived_files}" \
+    --argjson orphan_archived "${orphan_archived}" \
+    --argjson archived_runs "${archived_runs_json}" \
+    '{
+      generated_at: $generated_at,
+      scanned: $scanned,
+      stopped: $stopped,
+      updated: $updated,
+      continued: $continued,
+      released: $released,
+      archived_files: $archived_files,
+      orphan_archived: $orphan_archived,
+      archived_runs: $archived_runs
+    }'
+}
+
+cmd="${1:-help}"
+shift || true
+case "${cmd}" in
+  reconcile)
+    cmd_reconcile "$@"
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    echo "Unknown subcommand: ${cmd}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/lib/kernel-runtime-run-driver.sh
+++ b/scripts/lib/kernel-runtime-run-driver.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WORKSPACE_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-workspace.sh"
+LEDGER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh"
+CLAIM_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-claim.sh"
+ATTESTATION_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-provider-attestation.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  kernel-runtime-run-driver.sh path [run_id]
+  kernel-runtime-run-driver.sh run [options]
+
+Options:
+  --run-id <run_id>
+  --identity <identity>
+  --project <project>
+  --issue-number <number>
+  --task-key <task_key>
+  --provider <provider>
+  --topology-file <path>
+  --command-string <command>
+  --continuity-owner <owner>
+  --trace-id <trace_id>
+  --evidence-links-json <json-array>
+EOF
+}
+
+utc_timestamp() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+epoch_now() {
+  date -u '+%s'
+}
+
+hash_text() {
+  local payload="${1:-}"
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "${payload}" | shasum -a 256 | awk '{print $1}'
+    return 0
+  fi
+  python3 - "${payload}" <<'PY'
+import hashlib
+import sys
+
+print(hashlib.sha256(sys.argv[1].encode("utf-8")).hexdigest())
+PY
+}
+
+derive_identity() {
+  local identity="${1:-}"
+  local project="${2:-${KERNEL_PROJECT:-kernel-workspace}}"
+  local issue_number="${3:-}"
+  local task_key="${4:-}"
+  local run_id="${5:-}"
+  if [[ -n "${identity}" ]]; then
+    printf '%s\n' "${identity}"
+    return 0
+  fi
+  if [[ -n "${issue_number}" ]]; then
+    if [[ -n "${task_key}" ]]; then
+      printf '%s#%s/%s\n' "${project}" "${issue_number}" "${task_key}"
+    else
+      printf '%s#%s\n' "${project}" "${issue_number}"
+    fi
+    return 0
+  fi
+  printf '%s@%s\n' "${project}" "${run_id}"
+}
+
+default_run_id() {
+  if [[ -n "${KERNEL_RUN_ID:-}" ]]; then
+    printf '%s\n' "${KERNEL_RUN_ID}"
+    return 0
+  fi
+  printf 'unknown-run\n'
+}
+
+RUN_ID="$(default_run_id)"
+
+workspace_dir_for() {
+  KERNEL_RUN_ID="${1:-${RUN_ID}}" bash "${WORKSPACE_SCRIPT}" path
+}
+
+workspace_receipt_for() {
+  KERNEL_RUN_ID="${1:-${RUN_ID}}" bash "${WORKSPACE_SCRIPT}" write
+}
+
+envelope_path_for() {
+  local run_id="${1:-${RUN_ID}}"
+  local workspace_dir
+  workspace_dir="$(workspace_dir_for "${run_id}")"
+  mkdir -p "${workspace_dir}/traces"
+  printf '%s/traces/run-envelope.json\n' "${workspace_dir}"
+}
+
+trace_path_for() {
+  local run_id="${1:-${RUN_ID}}"
+  local workspace_dir
+  workspace_dir="$(workspace_dir_for "${run_id}")"
+  mkdir -p "${workspace_dir}/traces"
+  printf '%s/traces/run-trace.json\n' "${workspace_dir}"
+}
+
+log_path_for() {
+  local run_id="${1:-${RUN_ID}}"
+  local workspace_dir
+  workspace_dir="$(workspace_dir_for "${run_id}")"
+  mkdir -p "${workspace_dir}/logs"
+  printf '%s/logs/run-driver.log\n' "${workspace_dir}"
+}
+
+write_json_atomic() {
+  local path="${1:?path is required}"
+  local payload="${2:?payload is required}"
+  local tmp_file
+  mkdir -p "$(dirname "${path}")"
+  tmp_file="$(umask 077 && mktemp "${path}.tmp.XXXXXXXXXX")"
+  printf '%s\n' "${payload}" >"${tmp_file}"
+  mv "${tmp_file}" "${path}"
+}
+
+resolve_topology_field() {
+  local topology_file="${1:-}"
+  local expr="${2:-.}"
+  if [[ -n "${topology_file}" && -f "${topology_file}" ]]; then
+    jq -r "${expr} // \"\"" "${topology_file}"
+  else
+    printf '\n'
+  fi
+}
+
+resolve_topology_approved() {
+  local topology_file="${1:-}"
+  jq -r '(.approved // .ok_to_execute // false) | if . then "true" else "false" end' "${topology_file}"
+}
+
+contains_exit_code() {
+  local codes="${1:-}"
+  local rc="${2:-}"
+  local code
+  IFS=',' read -r -a code_array <<<"${codes}"
+  for code in "${code_array[@]}"; do
+    code="$(printf '%s' "${code}" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+    [[ -n "${code}" ]] || continue
+    if [[ "${code}" == "${rc}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+cmd_path() {
+  printf '%s\n' "$(envelope_path_for "${1:-${RUN_ID}}")"
+}
+
+cmd_run() {
+  local run_id="${RUN_ID}" identity="" project="${KERNEL_PROJECT:-kernel-workspace}" issue_number="" task_key=""
+  local provider="${KERNEL_RUN_DRIVER_PROVIDER:-codex}" topology_file="" command_string="" continuity_owner="local-primary"
+  local trace_id="" evidence_links_json='[]'
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --run-id) run_id="${2:-}"; shift 2 ;;
+      --identity) identity="${2:-}"; shift 2 ;;
+      --project) project="${2:-}"; shift 2 ;;
+      --issue-number) issue_number="${2:-}"; shift 2 ;;
+      --task-key) task_key="${2:-}"; shift 2 ;;
+      --provider) provider="${2:-}"; shift 2 ;;
+      --topology-file) topology_file="${2:-}"; shift 2 ;;
+      --command-string) command_string="${2:-}"; shift 2 ;;
+      --continuity-owner) continuity_owner="${2:-}"; shift 2 ;;
+      --trace-id) trace_id="${2:-}"; shift 2 ;;
+      --evidence-links-json) evidence_links_json="${2:-[]}"; shift 2 ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+
+  identity="$(derive_identity "${identity}" "${project}" "${issue_number}" "${task_key}" "${run_id}")"
+  local topology_approved topology_command topology_provider
+  if [[ -z "${topology_file}" ]]; then
+    echo "run driver requires --topology-file for Kernel-approved execution" >&2
+    exit 2
+  fi
+  if [[ ! -f "${topology_file}" ]]; then
+    echo "topology file not found: ${topology_file}" >&2
+    exit 2
+  fi
+  topology_approved="$(resolve_topology_approved "${topology_file}")"
+  topology_command="$(resolve_topology_field "${topology_file}" '.launch.command_string // .execution.command_string')"
+  topology_provider="$(resolve_topology_field "${topology_file}" '.launch.provider // .provider')"
+  command_string="${command_string:-${KERNEL_RUN_DRIVER_COMMAND_STRING:-}}"
+  if [[ -n "${topology_provider}" && -z "${provider}" ]]; then
+    provider="${topology_provider}"
+  fi
+  if [[ -z "${provider}" ]]; then
+    provider="codex"
+  fi
+  if [[ "${topology_approved}" != "true" ]]; then
+    echo "topology is not Kernel-approved" >&2
+    exit 1
+  fi
+  if [[ -z "${topology_command}" ]]; then
+    echo "topology launch command missing" >&2
+    exit 2
+  fi
+  if [[ -n "${command_string}" && "${command_string}" != "${topology_command}" ]]; then
+    echo "command-string must match approved topology launch command" >&2
+    exit 2
+  fi
+  command_string="${topology_command}"
+
+  local workspace_receipt_path workspace_dir envelope_path trace_path log_path started_at started_epoch
+  local finished_at finished_epoch duration_sec scheduler_state status reason rc=0
+  local child_pid="" interrupted=0
+  workspace_receipt_path="$(KERNEL_RUN_ID="${run_id}" bash "${WORKSPACE_SCRIPT}" write)"
+  workspace_dir="$(KERNEL_RUN_ID="${run_id}" bash "${WORKSPACE_SCRIPT}" path)"
+  envelope_path="$(envelope_path_for "${run_id}")"
+  trace_path="$(trace_path_for "${run_id}")"
+  log_path="$(log_path_for "${run_id}")"
+  started_at="$(utc_timestamp)"
+  started_epoch="$(epoch_now)"
+  if [[ -z "${trace_id}" ]]; then
+    trace_id="ktrace:${run_id}:$(hash_text "${identity}|${started_at}")"
+  fi
+
+  local initial_trace
+  initial_trace="$(
+    jq -n \
+      --arg run_id "${run_id}" \
+      --arg trace_id "${trace_id}" \
+      --arg identity "${identity}" \
+      --arg project "${project}" \
+      --arg issue_number "${issue_number}" \
+      --arg task_key "${task_key}" \
+      --arg provider "${provider}" \
+      --arg topology_file "${topology_file}" \
+      --arg command_string "${command_string}" \
+      --arg continuity_owner "${continuity_owner}" \
+      --arg started_at "${started_at}" \
+      --arg workspace_dir "${workspace_dir}" \
+      --arg workspace_receipt_path "${workspace_receipt_path}" \
+      '{
+        version: 1,
+        run_id: $run_id,
+        trace_id: $trace_id,
+        identity: $identity,
+        project: $project,
+        issue_number: (if $issue_number == "" then null else ($issue_number | tonumber) end),
+        task_key: $task_key,
+        provider: $provider,
+        topology_file: $topology_file,
+        command_string: $command_string,
+        continuity_owner: $continuity_owner,
+        started_at: $started_at,
+        workspace_dir: $workspace_dir,
+        workspace_receipt_path: $workspace_receipt_path
+      }'
+  )"
+  write_json_atomic "${trace_path}" "${initial_trace}"
+
+  KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" scheduler-state running "run-driver-start" "${workspace_receipt_path}" >/dev/null
+  KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" record-event kernel-runtime-run-driver start "${identity}; trace_id=${trace_id}" >/dev/null
+  bash "${CLAIM_SCRIPT}" set-state --identity "${identity}" --run-id "${run_id}" --state running --reason "run-driver-start" --workspace-receipt-path "${workspace_receipt_path}" --envelope-path "${envelope_path}" --continuity-owner "${continuity_owner}" >/dev/null 2>&1 || true
+
+  on_interrupt() {
+    interrupted=1
+    if [[ -n "${child_pid}" ]]; then
+      kill "${child_pid}" 2>/dev/null || true
+    fi
+  }
+  trap on_interrupt INT TERM
+
+  {
+    printf '[%s] run-driver start trace_id=%s provider=%s\n' "${started_at}" "${trace_id}" "${provider}"
+    printf '[%s] command=%s\n' "${started_at}" "${command_string}"
+  } >>"${log_path}"
+
+  set +e
+  bash -lc "${command_string}" >>"${log_path}" 2>&1 &
+  child_pid=$!
+  wait "${child_pid}"
+  rc=$?
+  set -e
+
+  finished_at="$(utc_timestamp)"
+  finished_epoch="$(epoch_now)"
+  duration_sec="$(( finished_epoch - started_epoch ))"
+  if [[ "${interrupted}" == "1" ]]; then
+    scheduler_state="${KERNEL_RUN_DRIVER_INTERRUPT_STATE:-awaiting_human}"
+    status="interrupted"
+    reason="driver-interrupted"
+  elif [[ "${rc}" == "0" ]]; then
+    scheduler_state="terminal"
+    status="completed"
+    reason="command-succeeded"
+  elif contains_exit_code "${KERNEL_RUN_DRIVER_AWAITING_HUMAN_EXIT_CODES:-77}" "${rc}"; then
+    scheduler_state="awaiting_human"
+    status="failed"
+    reason="awaiting-human-exit-${rc}"
+  elif contains_exit_code "${KERNEL_RUN_DRIVER_DEGRADED_EXIT_CODES:-65}" "${rc}"; then
+    scheduler_state="continuity_degraded"
+    status="failed"
+    reason="continuity-degraded-exit-${rc}"
+  elif contains_exit_code "${KERNEL_RUN_DRIVER_RETRY_EXIT_CODES:-75,85}" "${rc}"; then
+    scheduler_state="retry_queued"
+    status="failed"
+    reason="retry-queued-exit-${rc}"
+  else
+    scheduler_state="retry_queued"
+    status="failed"
+    reason="command-exit-${rc}"
+  fi
+
+  local attestation_path=""
+  if [[ "${status}" == "completed" ]]; then
+    attestation_path="$(KERNEL_RUN_ID="${run_id}" bash "${ATTESTATION_SCRIPT}" issue "${provider}" success run-driver "run-driver" "trace=${trace_id};identity=${identity}" 2>/dev/null || true)"
+    KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" record-provider "${provider}" success "run-driver" run-driver "${attestation_path}" >/dev/null
+  else
+    attestation_path="$(KERNEL_RUN_ID="${run_id}" bash "${ATTESTATION_SCRIPT}" issue "${provider}" failure run-driver "${reason}" "trace=${trace_id};identity=${identity}" 2>/dev/null || true)"
+    KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" record-provider "${provider}" failure "${reason}" run-driver "${attestation_path}" >/dev/null
+  fi
+  KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" scheduler-state "${scheduler_state}" "${reason}" "${workspace_receipt_path}" >/dev/null
+  KERNEL_RUN_ID="${run_id}" bash "${LEDGER_SCRIPT}" record-event kernel-runtime-run-driver finish "${identity}; state=${scheduler_state}; rc=${rc}" >/dev/null
+
+  local envelope_json
+  envelope_json="$(
+    jq -n \
+      --arg run_id "${run_id}" \
+      --arg trace_id "${trace_id}" \
+      --arg identity "${identity}" \
+      --arg project "${project}" \
+      --arg issue_number "${issue_number}" \
+      --arg task_key "${task_key}" \
+      --arg provider "${provider}" \
+      --arg topology_file "${topology_file}" \
+      --arg command_string "${command_string}" \
+      --arg continuity_owner "${continuity_owner}" \
+      --arg started_at "${started_at}" \
+      --arg finished_at "${finished_at}" \
+      --arg status "${status}" \
+      --arg scheduler_state "${scheduler_state}" \
+      --arg reason "${reason}" \
+      --arg workspace_receipt_path "${workspace_receipt_path}" \
+      --arg workspace_dir "${workspace_dir}" \
+      --arg trace_path "${trace_path}" \
+      --arg log_path "${log_path}" \
+      --argjson exit_code "${rc}" \
+      --argjson duration_sec "${duration_sec}" \
+      --argjson topology_approved "$( [[ "${topology_approved}" == "true" ]] && printf 'true' || printf 'false' )" \
+      --argjson evidence_links "${evidence_links_json}" \
+      '{
+        version: 1,
+        run_id: $run_id,
+        trace_id: $trace_id,
+        identity: $identity,
+        project: $project,
+        issue_number: (if $issue_number == "" then null else ($issue_number | tonumber) end),
+        task_key: $task_key,
+        provider: $provider,
+        topology_file: $topology_file,
+        topology_approved: $topology_approved,
+        command_string: $command_string,
+        continuity_owner: $continuity_owner,
+        started_at: $started_at,
+        finished_at: $finished_at,
+        duration_sec: $duration_sec,
+        status: $status,
+        scheduler_state: $scheduler_state,
+        reason: $reason,
+        exit_code: $exit_code,
+        workspace_receipt_path: $workspace_receipt_path,
+        workspace_dir: $workspace_dir,
+        trace_path: $trace_path,
+        log_path: $log_path,
+        evidence_links: $evidence_links
+      }'
+  )"
+  write_json_atomic "${envelope_path}" "${envelope_json}"
+  bash "${CLAIM_SCRIPT}" set-state --identity "${identity}" --run-id "${run_id}" --state "${scheduler_state}" --reason "${reason}" --workspace-receipt-path "${workspace_receipt_path}" --envelope-path "${envelope_path}" --continuity-owner "${continuity_owner}" >/dev/null 2>&1 || true
+
+  jq -n --arg envelope_path "${envelope_path}" --arg trace_path "${trace_path}" --arg log_path "${log_path}" --argjson envelope "${envelope_json}" \
+    '{envelope_path: $envelope_path, trace_path: $trace_path, log_path: $log_path, envelope: $envelope}'
+
+  if [[ "${status}" == "completed" ]]; then
+    exit 0
+  fi
+  exit "${rc}"
+}
+
+cmd="${1:-help}"
+shift || true
+case "${cmd}" in
+  path)
+    cmd_path "$@"
+    ;;
+  run)
+    cmd_run "$@"
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    echo "Unknown subcommand: ${cmd}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/lib/kernel-runtime-status-surface.sh
+++ b/scripts/lib/kernel-runtime-status-surface.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CLAIM_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-claim.sh"
+STATE_PATHS_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-state-paths.sh"
+STATE_ROOT="${KERNEL_SUBSTRATE_STATE_ROOT:-$(bash "${STATE_PATHS_SCRIPT}" state-root)}"
+STATUS_DIR="${KERNEL_RUNTIME_STATUS_DIR:-${STATE_ROOT}/status}"
+STATUS_PATH="${KERNEL_RUNTIME_STATUS_PATH:-${STATUS_DIR}/runtime-status.json}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  kernel-runtime-status-surface.sh path
+  kernel-runtime-status-surface.sh snapshot [--queue-file <path>] [--queue-json <json>] [--write]
+EOF
+}
+
+utc_timestamp() {
+  date -u '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+load_queue_json() {
+  local queue_file="${1:-}"
+  local queue_json="${2:-}"
+  if [[ -n "${queue_json}" ]]; then
+    printf '%s\n' "${queue_json}"
+    return 0
+  fi
+  if [[ -n "${queue_file}" && -f "${queue_file}" ]]; then
+    cat "${queue_file}"
+    return 0
+  fi
+  if [[ -n "${KERNEL_SCHEDULER_QUEUE_JSON:-}" ]]; then
+    printf '%s\n' "${KERNEL_SCHEDULER_QUEUE_JSON}"
+    return 0
+  fi
+  if [[ -n "${KERNEL_SCHEDULER_QUEUE_FILE:-}" && -f "${KERNEL_SCHEDULER_QUEUE_FILE}" ]]; then
+    cat "${KERNEL_SCHEDULER_QUEUE_FILE}"
+    return 0
+  fi
+  printf '{"items":[]}\n'
+}
+
+normalize_queue_json() {
+  local raw_json="${1:-}"
+  if [[ -z "${raw_json}" ]]; then
+    raw_json='{"items":[]}'
+  fi
+  jq -c '
+    def bool_or($fallback):
+      if . == null then $fallback
+      elif type == "boolean" then .
+      elif type == "string" then
+        ((ascii_downcase) as $v | ($v == "true" or $v == "1" or $v == "yes" or $v == "on"))
+      else $fallback end;
+    def inferred_authorized:
+      (.authorized | bool_or(false))
+      or ((.start_signal // "") | ascii_downcase | test("^/(vote|v)$|^tutti$|^workflow_dispatch$"))
+      or ((.signals // []) | map((. // "") | tostring | ascii_downcase) | any(. == "/vote" or . == "/v" or . == "tutti" or . == "workflow_dispatch"));
+    def inferred_terminal:
+      (.terminal | bool_or(false))
+      or ((.state // .issue_state // "") | ascii_downcase | test("closed|done|terminal|merged|cancelled"));
+    def inferred_eligible:
+      if .eligible == null then true else (.eligible | bool_or(true)) end;
+    def derive_identity:
+      if (.identity // "") != "" then .identity
+      elif (.issue_number // "") != "" and (.task_key // "") != "" then "\(.project // "kernel-workspace")#\(.issue_number)/\(.task_key)"
+      elif (.issue_number // "") != "" then "\(.project // "kernel-workspace")#\(.issue_number)"
+      elif (.task_key // "") != "" then "\(.project // "kernel-workspace")/\(.task_key)"
+      else "\(.project // "kernel-workspace")@\(.run_id // "unknown")" end;
+    ((.items // .work_items // .issues // .) | if type == "array" then . else [] end)
+    | map({
+        identity: derive_identity,
+        project: (.project // "kernel-workspace"),
+        issue_number: (if (.issue_number // "") == "" then null else (.issue_number | tonumber) end),
+        task_key: (.task_key // ""),
+        dispatchable: (
+          if .dispatchable == null then (inferred_authorized and inferred_eligible and (inferred_terminal | not))
+          else (.dispatchable | bool_or(false))
+          end
+        ),
+        authorized: inferred_authorized,
+        eligible: inferred_eligible,
+        terminal: inferred_terminal,
+        reason: (.reason // .blocking_reason // "")
+      })
+  ' <<<"${raw_json}"
+}
+
+write_json_atomic() {
+  local path="${1:?path is required}"
+  local payload="${2:?payload is required}"
+  local tmp_file
+  mkdir -p "$(dirname "${path}")"
+  tmp_file="$(umask 077 && mktemp "${path}.tmp.XXXXXXXXXX")"
+  printf '%s\n' "${payload}" >"${tmp_file}"
+  mv "${tmp_file}" "${path}"
+}
+
+cmd_path() {
+  printf '%s\n' "${STATUS_PATH}"
+}
+
+cmd_snapshot() {
+  local queue_file="" queue_json="" write_snapshot=false
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --queue-file) queue_file="${2:-}"; shift 2 ;;
+      --queue-json) queue_json="${2:-}"; shift 2 ;;
+      --write) write_snapshot=true; shift ;;
+      *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+  done
+
+  local claims_json queue_raw queue_items snapshot_json
+  claims_json="$(bash "${CLAIM_SCRIPT}" list)"
+  queue_raw="$(load_queue_json "${queue_file}" "${queue_json}")"
+  queue_items="$(normalize_queue_json "${queue_raw}")"
+  snapshot_json="$(
+    jq -n \
+      --arg generated_at "$(utc_timestamp)" \
+      --arg state_root "${STATE_ROOT}" \
+      --arg status_path "${STATUS_PATH}" \
+      --argjson claims "${claims_json}" \
+      --argjson queue_items "${queue_items}" \
+      '
+        ($claims // []) as $all_claims
+        | ($queue_items // []) as $items
+        | ($all_claims | map(select((.claim_active // false) == true and (.status // "") != "terminal"))) as $active_claims
+        | ($all_claims | map(select((.status // "") == "running"))) as $running
+        | ($all_claims | map(select((.status // "") == "retry_queued"))) as $retrying
+        | ($all_claims | map(select((.status // "") == "continuity_degraded"))) as $degraded
+        | ($all_claims | map(select((.status // "") == "awaiting_human"))) as $blocked_claims
+        | ($all_claims | map(select((.status // "") == "terminal"))) as $terminal
+        | ($items | map(select(.dispatchable == false and ((.identity as $id | $active_claims | map(.identity) | index($id)) == null) and ((.terminal // false) == false)))) as $blocked_queue
+        | ($active_claims | map(select((.continuity_owner // "local-primary") == "local-primary") | .identity)) as $local_primary
+        | ($active_claims | map(select((.continuity_owner // "") == "gha-continuity") | .identity)) as $gha_continuity
+        | {
+            version: 1,
+            generated_at: $generated_at,
+            state_root: $state_root,
+            status_path: $status_path,
+            summary: {
+              active_claims: ($active_claims | length),
+              running: ($running | length),
+              retrying: ($retrying | length),
+              degraded: ($degraded | length),
+              blocked: (($blocked_claims | length) + ($blocked_queue | length)),
+              terminal: ($terminal | length)
+            },
+            running: $running,
+            retrying: $retrying,
+            degraded: $degraded,
+            blocked: ($blocked_claims + $blocked_queue),
+            terminal: $terminal,
+            recovery_handoff: {
+              local_primary: {
+                active: (($local_primary | length) > 0),
+                identities: $local_primary
+              },
+              gha_continuity: {
+                active: (($gha_continuity | length) > 0),
+                identities: $gha_continuity
+              },
+              preferred_recovery: (
+                if ($local_primary | length) > 0 then "local-primary"
+                elif ($gha_continuity | length) > 0 then "gha-continuity"
+                else "idle"
+                end
+              )
+            },
+            claims: $all_claims
+          }
+      '
+  )"
+
+  if [[ "${write_snapshot}" == "true" ]]; then
+    write_json_atomic "${STATUS_PATH}" "${snapshot_json}"
+  fi
+  printf '%s\n' "${snapshot_json}"
+}
+
+cmd="${1:-help}"
+shift || true
+case "${cmd}" in
+  path)
+    cmd_path "$@"
+    ;;
+  snapshot)
+    cmd_snapshot "$@"
+    ;;
+  help|-h|--help)
+    usage
+    ;;
+  *)
+    echo "Unknown subcommand: ${cmd}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/lib/kernel-runtime-status-surface.sh
+++ b/scripts/lib/kernel-runtime-status-surface.sh
@@ -78,7 +78,7 @@ normalize_queue_json() {
         task_key: (.task_key // ""),
         dispatchable: (
           if .dispatchable == null then (inferred_authorized and inferred_eligible and (inferred_terminal | not))
-          else (.dispatchable | bool_or(false))
+          else ((.dispatchable | bool_or(false)) and inferred_authorized and inferred_eligible and (inferred_terminal | not))
           end
         ),
         authorized: inferred_authorized,

--- a/scripts/local/kernel-entrypoint.sh
+++ b/scripts/local/kernel-entrypoint.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 FOUR_PANE_LAUNCH_SCRIPT="${KERNEL_4PANE_LAUNCH_SCRIPT:-${ROOT_DIR}/scripts/local/kernel-4pane-launch.sh}"
 STATE_PATH_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-state-paths.sh"
 PROMPT_LAUNCH_BIN="${KERNEL_CODEX_PROMPT_LAUNCH_BIN:-$HOME/bin/codex-prompt-launch}"
+GUARD_BIN="${KERNEL_GUARD_BIN:-${ROOT_DIR}/scripts/codex-kernel-guard.sh}"
 STALE_HOURS="${KERNEL_STALE_HOURS:-24}"
 
 usage() {
@@ -128,6 +129,10 @@ exec_prompt_launch() {
   exec "${PROMPT_LAUNCH_BIN}" kernel "$@"
 }
 
+exec_memory_query() {
+  exec bash "${GUARD_BIN}" memory-query "$@"
+}
+
 exec_4pane_launch() {
   exec bash "${FOUR_PANE_LAUNCH_SCRIPT}" "$@"
 }
@@ -169,6 +174,10 @@ main() {
     echo "prompt launcher not found: ${PROMPT_LAUNCH_BIN}" >&2
     exit 1
   }
+
+  if [[ "${1:-}" == "memory-query" ]]; then
+    exec_memory_query "${@:2}"
+  fi
 
   if ! in_repo_context || ! auto_4pane_enabled || inside_managed_tmux || needs_prompt_passthrough "$@"; then
     exec_prompt_launch "$@"

--- a/scripts/local/launchers/codex-skill-launch
+++ b/scripts/local/launchers/codex-skill-launch
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  codex-skill-launch <skill-name> [focus text ...]
+  skill <skill-name> [focus text ...]
+
+Tip:
+  When invoked via a symlink named after a skill (for example `note-manuscript`),
+  the launcher uses that basename as the skill name automatically.
+EOF
+}
+
+resolve_codex_bin() {
+  local preferred="${CODEX_BIN:-}"
+  local candidate
+
+  if [[ -n "${preferred}" ]]; then
+    candidate="$(command -v "${preferred}" 2>/dev/null || true)"
+    if [[ -n "${candidate}" && -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+    if [[ -x "${preferred}" ]]; then
+      printf '%s\n' "${preferred}"
+      return 0
+    fi
+  fi
+
+  candidate="$(command -v codex 2>/dev/null || true)"
+  if [[ -n "${candidate}" && -x "${candidate}" ]]; then
+    printf '%s\n' "${candidate}"
+    return 0
+  fi
+
+  return 1
+}
+
+resolve_prompt_root() {
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  if [[ -n "${repo_root}" ]]; then
+    printf '%s\n' "${repo_root}"
+    return 0
+  fi
+  printf '%s\n' "${PWD}"
+}
+
+find_skill_dir() {
+  local skill_name="${1:?skill name is required}"
+  local repo_root candidate
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+  for candidate in \
+    "${PWD}/.codex/skills/${skill_name}" \
+    "${repo_root:+${repo_root}/.codex/skills/${skill_name}}" \
+    "${repo_root:+${repo_root}/skills/${skill_name}}" \
+    "${CODEX_SKILLS_DIR:-${HOME}/.codex/skills}/${skill_name}"
+  do
+    [[ -n "${candidate}" ]] || continue
+    if [[ -f "${candidate}/SKILL.md" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+skill_name_from_argv() {
+  local invoked_as
+  invoked_as="$(basename "$0")"
+  case "${invoked_as}" in
+    codex-skill-launch|skill)
+      printf '%s\n' "${1:-}"
+      ;;
+    *)
+      printf '%s\n' "${CODEX_SKILL_NAME:-${invoked_as}}"
+      ;;
+  esac
+}
+
+codex_exec_needs_skip_git_repo_check() {
+  git -C "${1:?prompt root is required}" rev-parse --show-toplevel >/dev/null 2>&1 && return 1
+  return 0
+}
+
+main() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+
+  local inferred_skill_name skill_name skill_dir skill_md prompt_root codex_bin arguments prompt_text
+  inferred_skill_name="$(skill_name_from_argv "${1:-}")"
+  skill_name="${inferred_skill_name}"
+  if [[ "$(basename "$0")" == "codex-skill-launch" || "$(basename "$0")" == "skill" ]]; then
+    shift || true
+  fi
+  [[ -n "${skill_name}" ]] || {
+    usage >&2
+    exit 2
+  }
+
+  skill_dir="$(find_skill_dir "${skill_name}")" || {
+    echo "skill '${skill_name}' not found in the current repo skill roots or ${CODEX_SKILLS_DIR:-${HOME}/.codex/skills}" >&2
+    exit 1
+  }
+  skill_md="${skill_dir}/SKILL.md"
+  prompt_root="$(resolve_prompt_root)"
+  codex_bin="$(resolve_codex_bin)" || {
+    echo "codex executable not found in PATH" >&2
+    exit 1
+  }
+  arguments="${*:-}"
+
+  prompt_text="$(
+  SKILL_NAME="${skill_name}" SKILL_FILE="${skill_md}" SKILL_DIR="${skill_dir}" ARGUMENTS="${arguments}" python3 - <<'PY'
+from pathlib import Path
+import os
+
+skill_name = os.environ["SKILL_NAME"]
+skill_file = Path(os.environ["SKILL_FILE"])
+skill_dir = os.environ["SKILL_DIR"]
+arguments = os.environ.get("ARGUMENTS", "").strip()
+skill_text = skill_file.read_text(encoding="utf-8").rstrip()
+focus_line = arguments if arguments else "(no extra focus provided)"
+
+print(
+    f"""Use the skill `{skill_name}` for the current task.
+
+Skill root: `{skill_dir}`
+Skill file: `{skill_file}`
+Current focus: {focus_line}
+
+Follow the skill exactly. Resolve relative references from the skill root and load only the files needed.
+
+Skill contents:
+{skill_text}"""
+)
+PY
+  )"
+
+  if codex_exec_needs_skip_git_repo_check "${prompt_root}"; then
+    exec "${codex_bin}" exec -C "${prompt_root}" --skip-git-repo-check "${prompt_text}"
+  fi
+  exec "${codex_bin}" exec -C "${prompt_root}" "${prompt_text}"
+}
+
+main "$@"

--- a/scripts/local/launchers/skill
+++ b/scripts/local/launchers/skill
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+launcher_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${launcher_dir}/orchestrator-entrypoint-hint" skill || true
+
+exec "${launcher_dir}/codex-skill-launch" "$@"

--- a/scripts/local/launchers/v
+++ b/scripts/local/launchers/v
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+launcher_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${launcher_dir}/orchestrator-entrypoint-hint" v || true
+
+exec "${launcher_dir}/codex-prompt-launch" v "$@"

--- a/scripts/local/launchers/vote
+++ b/scripts/local/launchers/vote
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+launcher_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+"${launcher_dir}/orchestrator-entrypoint-hint" vote || true
+
+exec "${launcher_dir}/codex-prompt-launch" vote "$@"

--- a/scripts/local/run-kernel-task-completion-backup.sh
+++ b/scripts/local/run-kernel-task-completion-backup.sh
@@ -13,6 +13,9 @@ GHA_DISPATCH_MODE="${GHA_DISPATCH_MODE:-auto}"
 RECENT_DAYS="${RECENT_DAYS:-7}"
 NO_GHA="${NO_GHA:-false}"
 DRY_RUN="${DRY_RUN:-false}"
+TERMINAL_COMPLETION_DEDUPE_SEC=300
+PHASE_COMPLETION_DEDUPE_SEC=900
+PROGRESS_SAVE_DEDUPE_SEC=900
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "python3 is required" >&2
@@ -75,8 +78,91 @@ fallback_orchestration_compliance() {
   esac
 }
 
+completion_journal_path() {
+  printf '%s/task-completion-journal.jsonl\n' "${STATE_ROOT}"
+}
+
+source_dedupe_window_sec() {
+  case "${1:-}" in
+    kernel-run-complete|fugue-run-complete)
+      printf '%s\n' "${TERMINAL_COMPLETION_DEDUPE_SEC}"
+      ;;
+    kernel-phase-complete|fugue-phase-complete)
+      printf '%s\n' "${PHASE_COMPLETION_DEDUPE_SEC}"
+      ;;
+    kernel-progress-save|fugue-progress-save)
+      printf '%s\n' "${PROGRESS_SAVE_DEDUPE_SEC}"
+      ;;
+    *)
+      printf '0\n'
+      ;;
+  esac
+}
+
+recent_explicit_record_exists() {
+  local journal_path="${1:-}"
+  local session_id="${2:-}"
+  local source_name="${3:-}"
+  local summary_text="${4:-}"
+  local title_text="${5:-}"
+  local completed_value="${6:-}"
+  local cooldown
+  [[ -f "${journal_path}" ]] || return 1
+  cooldown="$(source_dedupe_window_sec "${source_name}")"
+  [[ "${cooldown}" =~ ^[0-9]+$ ]] || cooldown=0
+  (( cooldown > 0 )) || return 1
+  python3 - "${journal_path}" "${session_id}" "${source_name}" "${summary_text}" "${title_text}" "${completed_value}" "${cooldown}" <<'PY'
+import datetime
+import json
+import sys
+
+journal_path, session_id, source_name, summary_text, title_text, completed_value, cooldown_raw = sys.argv[1:]
+cooldown = int(cooldown_raw)
+
+def parse_ts(value: str):
+    if not value:
+        return None
+    try:
+        return int(datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=datetime.timezone.utc).timestamp())
+    except ValueError:
+        return None
+
+current_ts = parse_ts(completed_value)
+if current_ts is None:
+    current_ts = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+
+terminal_sources = {"kernel-run-complete", "fugue-run-complete"}
+
+latest = None
+with open(journal_path, "r", encoding="utf-8") as fh:
+    for raw in fh:
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            item = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if item.get("session_id") != session_id or item.get("source") != source_name:
+            continue
+        if source_name not in terminal_sources and (
+            item.get("summary_text") != summary_text or item.get("title") != title_text
+        ):
+            continue
+        ts = parse_ts(item.get("completed_at", ""))
+        if ts is None:
+            continue
+        if latest is None or ts > latest:
+            latest = ts
+
+if latest is not None and current_ts - latest < cooldown:
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
 fallback_write_record() {
-  local record_id dispatch_token mirror_path receipt_path payload_path payload_b64 observed_models_json orchestration_compliance
+  local record_id dispatch_token mirror_path receipt_path payload_path observed_models_json orchestration_compliance
   local completed_value="${completed_at:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 
   record_id="$(fallback_record_id)"
@@ -87,9 +173,9 @@ fallback_write_record() {
   observed_models_json="$(fallback_observed_models_json "${session_id}")"
   orchestration_compliance="$(fallback_orchestration_compliance)"
 
-  python3 - "$record_id" "$assistant" "$source_name" "$session_id" "$completed_value" "$summary" "$cwd" "$title" "$GHA_REPO" "$GHA_WORKFLOW" "$dispatch_token" "$mirror_path" "$receipt_path" "$observed_models_json" "$payload_path" "$orchestration_compliance" <<'PY'
+  python3 - "$record_id" "$assistant" "$source_name" "$session_id" "$completed_value" "$summary" "$cwd" "$title" "$GHA_REPO" "$GHA_WORKFLOW" "$dispatch_token" "$mirror_path" "$receipt_path" "$observed_models_json" "$payload_path" "$orchestration_compliance" "$project_os_ticket_id" "$acceptance_text" "$authority_scope" <<'PY'
 import json, sys
-record_id, assistant, source_name, session_id, completed_at, summary, cwd, title, gha_repo, gha_workflow, token, mirror_path, receipt_path, observed_models_json, payload_path, orchestration_compliance = sys.argv[1:]
+record_id, assistant, source_name, session_id, completed_at, summary, cwd, title, gha_repo, gha_workflow, token, mirror_path, receipt_path, observed_models_json, payload_path, orchestration_compliance, project_os_ticket_id, acceptance_text, authority_scope = sys.argv[1:]
 payload = {
     "record_id": record_id,
     "assistant": assistant,
@@ -105,6 +191,9 @@ payload = {
     "gha_mirror_path": mirror_path,
     "gha_receipt_path": receipt_path,
     "orchestration_compliance": orchestration_compliance,
+    "project_os_ticket_id": project_os_ticket_id,
+    "project_os_acceptance_text": acceptance_text,
+    "project_os_authority_scope": authority_scope,
     "observed_models": json.loads(observed_models_json),
 }
 with open(payload_path, "w", encoding="utf-8") as fh:
@@ -156,6 +245,9 @@ summary=""
 cwd="${REPO_ROOT}"
 title=""
 completed_at=""
+project_os_ticket_id="${KERNEL_PROJECT_OS_TICKET_ID:-}"
+acceptance_text="${KERNEL_PROJECT_OS_ACCEPTANCE:-}"
+authority_scope="${KERNEL_PROJECT_OS_AUTHORITY_SCOPE:-}"
 lock_dir="${STATE_ROOT}/task-completion-backup.lock"
 
 usage() {
@@ -171,6 +263,11 @@ Options:
   --cwd <path>           Working directory metadata for explicit records
   --title <text>         Title metadata for explicit records
   --completed-at <iso>   Completion timestamp override
+  --project-os-ticket-id <id>
+                         Optional Project OS ticket id for bound kernel records
+  --acceptance <text>    Optional Project OS acceptance text for bound kernel records
+  --authority-scope <scope>
+                         Optional Project OS authority scope for bound kernel records
   --no-gha               Skip GitHub Actions dispatch
   --dry-run              Mark dispatch success without calling GitHub
   -h, --help
@@ -206,6 +303,18 @@ while [[ $# -gt 0 ]]; do
       ;;
     --completed-at)
       completed_at="${2:-}"
+      shift 2
+      ;;
+    --project-os-ticket-id)
+      project_os_ticket_id="${2:-}"
+      shift 2
+      ;;
+    --acceptance)
+      acceptance_text="${2:-}"
+      shift 2
+      ;;
+    --authority-scope)
+      authority_scope="${2:-}"
       shift 2
       ;;
     --no-gha)
@@ -259,6 +368,10 @@ if [[ "${mode}" == "record" ]]; then
     echo "explicit record mode requires --assistant, --source, --session-id, and --summary" >&2
     exit 2
   fi
+  if recent_explicit_record_exists "$(completion_journal_path)" "${session_id}" "${source_name}" "${summary}" "${title}" "${completed_at:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"; then
+    echo "task completion backup deduped for source ${source_name} session ${session_id}" >&2
+    exit 0
+  fi
   if [[ "${EXTERNAL_BACKUP_TOOL_AVAILABLE}" == "true" ]]; then
     record_args=(
       --assistant "${assistant}"
@@ -270,6 +383,15 @@ if [[ "${mode}" == "record" ]]; then
     )
     if [[ -n "${completed_at}" ]]; then
       record_args+=(--completed-at "${completed_at}")
+    fi
+    if [[ -n "${project_os_ticket_id}" ]]; then
+      record_args+=(--project-os-ticket-id "${project_os_ticket_id}")
+    fi
+    if [[ -n "${acceptance_text}" ]]; then
+      record_args+=(--acceptance "${acceptance_text}")
+    fi
+    if [[ -n "${authority_scope}" ]]; then
+      record_args+=(--authority-scope "${authority_scope}")
     fi
     python3 -m codex_kernel_guard.cli backup-record \
       "${record_args[@]}" \

--- a/tests/test-codex-kernel-guard-doctor-flags.sh
+++ b/tests/test-codex-kernel-guard-doctor-flags.sh
@@ -3,9 +3,11 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
+GUARD_BIN="${KERNEL_GUARD_BIN:-${ROOT_DIR}/scripts/codex-kernel-guard.sh}"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
 export KERNEL_ROOT="${ROOT_DIR}"
+export KERNEL_SUBSTRATE_STATE_ROOT="${TMP_DIR}/state"
 export KERNEL_BOOTSTRAP_RECEIPT_DIR="${TMP_DIR}/receipts"
 export KERNEL_RUNTIME_LEDGER_FILE="${TMP_DIR}/runtime-ledger.json"
 export KERNEL_GLM_RUN_STATE_FILE="${TMP_DIR}/glm-state.json"
@@ -19,10 +21,30 @@ export CLAUDE_BIN=printf
 export CURSOR_BIN=false
 export COPILOT_BIN=false
 export ZAI_API_KEY="dummy"
+export OPENAI_API_KEY=""
+export GEMINI_API_KEY=""
+export XAI_API_KEY=""
 export KERNEL_DOCTOR_SKIP_TMUX_CHECK=true
 export KERNEL_STALE_HOURS=24
 
 mkdir -p "${KERNEL_COMPACT_DIR}"
+empty_out="$("${GUARD_BIN}" doctor --all-runs)"
+grep -Fq 'all runs:' <<<"${empty_out}"
+grep -Fq '  - none' <<<"${empty_out}"
+grep -Fq 'kernel run id: none' <<<"${empty_out}"
+grep -Fq 'run context status:' <<<"${empty_out}"
+grep -Fq '  - resolved: false' <<<"${empty_out}"
+grep -Fq '  - reason: no-active-run-context' <<<"${empty_out}"
+grep -Fq 'runtime status surface:' <<<"${empty_out}"
+if grep -Fq 'unknown-run' <<<"${empty_out}"; then
+  echo "doctor should not fabricate unknown-run when no run context exists" >&2
+  exit 1
+fi
+if grep -Fq 'bootstrap receipt status:' <<<"${empty_out}"; then
+  echo "doctor should skip per-run bootstrap diagnostics when no run context exists" >&2
+  exit 1
+fi
+
 NOW_TS="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 MID_TS="$(date -u -v-1H '+%Y-%m-%dT%H:%M:%SZ')"
 OLD_TS="$(date -u -v-2d '+%Y-%m-%dT%H:%M:%SZ')"
@@ -36,7 +58,7 @@ cat >"${KERNEL_COMPACT_DIR}/run-old.json" <<EOF
 {"run_id":"run-old","project":"fugue-orchestrator","purpose":"secret-plane","current_phase":"plan","mode":"blocked","runtime":"kernel","tmux_session":"fugue-orchestrator__secret-plane","owner":"codex","active_models":["codex","cursor-cli"],"blocking_reason":"awaiting secret rotation","next_action":["rotate bundle"],"decisions":["d1"],"summary":["line1","line2"],"last_event":"status_changed","updated_at":"${OLD_TS}"}
 EOF
 
-out="$(/Users/masayuki_otawara/bin/codex-kernel-guard doctor)"
+out="$("${GUARD_BIN}" doctor)"
 grep -Fq 'active runs:' <<<"${out}"
 grep -Fq 'purpose=runtime-enforcement' <<<"${out}"
 grep -Fq 'purpose=doctor-handoff' <<<"${out}"
@@ -48,15 +70,21 @@ if grep -Fq 'purpose=secret-plane' <<<"${out}"; then
   echo "stale run should not appear in default doctor output" >&2
   exit 1
 fi
+grep -Fq 'runtime status surface:' <<<"${out}"
 
-out="$(/Users/masayuki_otawara/bin/codex-kernel-guard doctor --all-runs)"
+out="$("${GUARD_BIN}" doctor --all-runs)"
 grep -Fq 'all runs:' <<<"${out}"
 grep -Fq 'run_id=run-live' <<<"${out}"
 grep -Fq 'run_id=run-old' <<<"${out}"
+grep -Fq 'age=' <<<"${out}"
 grep -Fq 'stale=true' <<<"${out}"
 grep -Fq 'runtime=fugue' <<<"${out}"
+grep -Fq 'doctor summary:' <<<"${out}"
+grep -Fq 'oldest_stale_run: run-old' <<<"${out}"
+grep -Fq 'recovery hints:' <<<"${out}"
+grep -Fq 'codex-kernel-guard recover-run run-old' <<<"${out}"
 
-out="$(/Users/masayuki_otawara/bin/codex-kernel-guard doctor --run run-old)"
+out="$("${GUARD_BIN}" doctor --run run-old)"
 grep -Fq 'run detail:' <<<"${out}"
 grep -Fq 'run_id: run-old' <<<"${out}"
 grep -Fq 'runtime: kernel' <<<"${out}"
@@ -64,14 +92,16 @@ grep -Fq 'active_models: codex,cursor-cli' <<<"${out}"
 grep -Fq 'blocking_reason: awaiting secret rotation' <<<"${out}"
 grep -Fq 'codex_thread_title: fugue-orchestrator:secret-plane' <<<"${out}"
 grep -Fq 'summary: line1 || line2' <<<"${out}"
+grep -Fq 'updated_age: ' <<<"${out}"
+grep -Fq 'stale: true' <<<"${out}"
 
 KERNEL_RUN_ID=run-old bash "${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh" record-event cc-pocket "kn select" "interactive-selector" >/dev/null
 KERNEL_RUN_ID=run-old bash "${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh" scheduler-state retry_queued "awaiting-recovery" "/tmp/run-old-workspace.json" >/dev/null
-out="$(/Users/masayuki_otawara/bin/codex-kernel-guard doctor --run run-old)"
+out="$("${GUARD_BIN}" doctor --run run-old)"
 grep -Fq 'recent events:' <<<"${out}"
-grep -Fq 'scheduler_state: retry_queued' <<<"${out}"
-grep -Fq 'scheduler_reason: awaiting-recovery' <<<"${out}"
-grep -Fq 'workspace_receipt_path: /tmp/run-old-workspace.json' <<<"${out}"
+grep -Fq 'scheduler state: retry_queued' <<<"${out}"
+grep -Fq 'scheduler reason: awaiting-recovery' <<<"${out}"
+grep -Fq 'workspace receipt path: /tmp/run-old-workspace.json' <<<"${out}"
 grep -Fq 'actor=cc-pocket' <<<"${out}"
 grep -Fq 'command=kn select' <<<"${out}"
 grep -Fq 'summary=interactive-selector' <<<"${out}"
@@ -90,13 +120,19 @@ exec /bin/bash "\$@"
 EOF
 chmod +x "${FAKE_BIN_DIR}/bash"
 
-out="$(PATH="${FAKE_BIN_DIR}:$PATH" DOCTOR_STATIC_CHECK_TIMEOUT_SEC=1 KERNEL_DOCTOR_SUMMARY_TIMEOUT_SEC=1 /Users/masayuki_otawara/bin/codex-kernel-guard doctor --run run-old)"
+set +e
+out="$(PATH="${FAKE_BIN_DIR}:$PATH" DOCTOR_STATIC_CHECK_TIMEOUT_SEC=1 KERNEL_DOCTOR_SUMMARY_TIMEOUT_SEC=1 "${GUARD_BIN}" doctor --run run-old)"
+rc=$?
+set -e
+[[ "${rc}" -ne 0 ]]
 grep -Fq 'static contract: fail' <<<"${out}"
 grep -Fq 'shared secrets status:' <<<"${out}"
 grep -Fq 'ZAI_API_KEY: present (process-env, len=5)' <<<"${out}"
-grep -Fq 'OPENAI_API_KEY: missing' <<<"${out}"
+grep -Fq 'OPENAI_API_KEY:' <<<"${out}"
 grep -Fq 'runtime health status:' <<<"${out}"
+grep -Fq 'runtime status surface:' <<<"${out}"
 grep -Fq '  - timeout after 1s' <<<"${out}"
+grep -Fq 'recovery hints:' <<<"${out}"
 grep -Fq 'run detail:' <<<"${out}"
 
 echo "codex kernel guard doctor flags check passed"

--- a/tests/test-codex-kernel-guard-doctor-flags.sh
+++ b/tests/test-codex-kernel-guard-doctor-flags.sh
@@ -27,6 +27,16 @@ export XAI_API_KEY=""
 export KERNEL_DOCTOR_SKIP_TMUX_CHECK=true
 export KERNEL_STALE_HOURS=24
 
+portable_utc_ts() {
+  local gnu_expr="$1"
+  local bsd_flag="$2"
+  if date -u -d "${gnu_expr}" '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+    date -u -d "${gnu_expr}" '+%Y-%m-%dT%H:%M:%SZ'
+  else
+    date -u "${bsd_flag}" '+%Y-%m-%dT%H:%M:%SZ'
+  fi
+}
+
 mkdir -p "${KERNEL_COMPACT_DIR}"
 empty_out="$("${GUARD_BIN}" doctor --all-runs)"
 grep -Fq 'all runs:' <<<"${empty_out}"
@@ -46,8 +56,8 @@ if grep -Fq 'bootstrap receipt status:' <<<"${empty_out}"; then
 fi
 
 NOW_TS="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-MID_TS="$(date -u -v-1H '+%Y-%m-%dT%H:%M:%SZ')"
-OLD_TS="$(date -u -v-2d '+%Y-%m-%dT%H:%M:%SZ')"
+MID_TS="$(portable_utc_ts '1 hour ago' '-v-1H')"
+OLD_TS="$(portable_utc_ts '2 days ago' '-v-2d')"
 cat >"${KERNEL_COMPACT_DIR}/run-live.json" <<EOF
 {"run_id":"run-live","project":"fugue-orchestrator","purpose":"runtime-enforcement","current_phase":"implement","mode":"healthy","runtime":"kernel","tmux_session":"fugue-orchestrator__runtime-enforcement","owner":"codex","active_models":["codex","glm","gemini-cli"],"blocking_reason":"","next_action":["wire-provider-evidence"],"decisions":["d1"],"summary":["live summary"],"last_event":"status_changed","updated_at":"${NOW_TS}"}
 EOF

--- a/tests/test-codex-kernel-guard-doctor.sh
+++ b/tests/test-codex-kernel-guard-doctor.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 RECEIPT_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-bootstrap-receipt.sh"
 LEDGER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh"
+GUARD_BIN="${KERNEL_GUARD_BIN_UNDER_TEST:-${ROOT_DIR}/scripts/codex-kernel-guard.sh}"
 SESSION_A="fugue-orchestrator__alpha"
 SESSION_B="fugue-orchestrator__beta"
 trap 'tmux kill-session -t "${SESSION_A}" >/dev/null 2>&1 || true; tmux kill-session -t "${SESSION_B}" >/dev/null 2>&1 || true; rm -rf "${TMP_DIR}"' EXIT
@@ -15,6 +16,7 @@ export KERNEL_RUNTIME_LEDGER_FILE="${TMP_DIR}/runtime-ledger.json"
 export KERNEL_GLM_RUN_STATE_FILE="${TMP_DIR}/glm-state.json"
 export KERNEL_OPTIONAL_LANE_LEDGER_FILE="${TMP_DIR}/optional-ledger.json"
 export KERNEL_COMPACT_DIR="${TMP_DIR}/compact"
+export KERNEL_PROVIDER_TEST_AUTO_ATTEST=true
 export KERNEL_RUNTIME_LEDGER_AUTO_COMPACT=false
 export KERNEL_RUN_ID="doctor-missing-receipt"
 export GEMINI_BIN=printf
@@ -24,6 +26,11 @@ export CURSOR_BIN=false
 export COPILOT_BIN=false
 export ZAI_API_KEY="dummy"
 export KERNEL_DOCTOR_SKIP_TMUX_CHECK=true
+export KERNEL_RUNTIME_HEALTH_SKIP_TMUX_CHECK=true
+export KERNEL_BOOTSTRAP_ACTIVE_MODELS_CSV="codex,glm,gemini-cli"
+export KERNEL_BOOTSTRAP_MANIFEST_LANE_COUNT="6"
+export KERNEL_BOOTSTRAP_AGENT_LABELS="true"
+export KERNEL_BOOTSTRAP_SUBAGENT_LABELS="true"
 
 tmux new-session -d -s "${SESSION_A}" >/dev/null 2>&1 || true
 tmux new-session -d -s "${SESSION_B}" >/dev/null 2>&1 || true
@@ -40,22 +47,39 @@ EOF
 
 KERNEL_RUN_ID="run-alpha" bash "${RECEIPT_SCRIPT}" write 6 codex,glm,gemini-cli normal >/dev/null
 KERNEL_RUN_ID="run-alpha" bash "${LEDGER_SCRIPT}" scheduler-state retry_queued "doctor-alpha" "/tmp/run-alpha-workspace.json" >/dev/null
+KERNEL_RUN_ID="run-beta" KERNEL_BOOTSTRAP_ACTIVE_MODELS_CSV="codex,glm,cursor-cli" bash "${RECEIPT_SCRIPT}" write 6 codex,glm,cursor-cli normal >/dev/null
+KERNEL_RUN_ID="run-beta" bash "${LEDGER_SCRIPT}" record-provider codex success launch run-driver >/dev/null
+KERNEL_RUN_ID="run-beta" bash "${LEDGER_SCRIPT}" record-provider glm success critic glm-exec >/dev/null
+KERNEL_RUN_ID="run-beta" bash "${LEDGER_SCRIPT}" record-provider cursor-cli success specialist optional-lane-exec >/dev/null
+KERNEL_RUN_ID="run-beta" bash "${LEDGER_SCRIPT}" scheduler-state running "doctor-beta" "/tmp/run-beta-workspace.json" >/dev/null
 
-out="$(/Users/masayuki_otawara/bin/codex-kernel-guard doctor)"
+out="$("${GUARD_BIN}" doctor)"
+grep -Fq 'kernel run id: run-beta' <<<"${out}"
 grep -Fq 'active runs:' <<<"${out}"
 beta_line="$(printf '%s\n' "${out}" | awk '/^  - run_id=run-beta /{print; exit}')"
 grep -Fq 'purpose=beta' <<<"${beta_line}"
 grep -Fq 'runtime=fugue' <<<"${beta_line}"
+grep -Fq 'age=' <<<"${beta_line}"
 grep -Fq 'scheduler_state=running' <<<"${beta_line}"
 grep -Fq 'workspace_receipt=false' <<<"${beta_line}"
+grep -Fq 'doctor summary:' <<<"${out}"
+grep -Fq 'longest_visible_run:' <<<"${out}"
 grep -Fq 'bootstrap receipt status:' <<<"${out}"
-grep -Fq 'present: false' <<<"${out}"
+grep -Fq '  - run id: run-beta' <<<"${out}"
+grep -Fq 'present: true' <<<"${out}"
 grep -Fq 'runtime health status:' <<<"${out}"
+grep -Fq 'codex provider success: 1' <<<"${out}"
+grep -Fq 'glm provider success: 1' <<<"${out}"
+grep -Fq 'specialist provider success count: 1' <<<"${out}"
 grep -Fq 'compact artifact status:' <<<"${out}"
+grep -Fq 'scheduler state: running' <<<"${out}"
 
-out="$(/Users/masayuki_otawara/bin/codex-kernel-guard doctor --run run-alpha)"
+out="$("${GUARD_BIN}" doctor --run run-alpha)"
+grep -Fq 'kernel run id: run-alpha' <<<"${out}"
 grep -Fq 'doctor scope run id: run-alpha' <<<"${out}"
 grep -Fq 'run detail:' <<<"${out}"
+grep -Fq 'updated_age: ' <<<"${out}"
+grep -Fq 'stale: false' <<<"${out}"
 grep -Fq 'scheduler_state_compact: retry_queued' <<<"${out}"
 grep -Fq 'workspace_receipt_path_compact: /tmp/run-alpha-workspace.json' <<<"${out}"
 grep -Fq 'phase_artifacts: plan_report_path=/tmp/run-alpha-plan.md | critic_report_path=/tmp/run-alpha-critic.md' <<<"${out}"

--- a/tests/test-codex-kernel-guard-doctor.sh
+++ b/tests/test-codex-kernel-guard-doctor.sh
@@ -32,12 +32,22 @@ export KERNEL_BOOTSTRAP_MANIFEST_LANE_COUNT="6"
 export KERNEL_BOOTSTRAP_AGENT_LABELS="true"
 export KERNEL_BOOTSTRAP_SUBAGENT_LABELS="true"
 
+portable_utc_ts() {
+  local gnu_expr="$1"
+  local bsd_flag="$2"
+  if date -u -d "${gnu_expr}" '+%Y-%m-%dT%H:%M:%SZ' >/dev/null 2>&1; then
+    date -u -d "${gnu_expr}" '+%Y-%m-%dT%H:%M:%SZ'
+  else
+    date -u "${bsd_flag}" '+%Y-%m-%dT%H:%M:%SZ'
+  fi
+}
+
 tmux new-session -d -s "${SESSION_A}" >/dev/null 2>&1 || true
 tmux new-session -d -s "${SESSION_B}" >/dev/null 2>&1 || true
 
 mkdir -p "${KERNEL_COMPACT_DIR}"
 NEWER_TS="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-OLDER_TS="$(date -u -v-1M '+%Y-%m-%dT%H:%M:%SZ')"
+OLDER_TS="$(portable_utc_ts '1 minute ago' '-v-1M')"
 cat >"${KERNEL_COMPACT_DIR}/run-alpha.json" <<EOF
 {"run_id":"run-alpha","project":"fugue-orchestrator","purpose":"alpha","current_phase":"plan","mode":"healthy","runtime":"kernel","tmux_session":"${SESSION_A}","owner":"codex","active_models":["codex","glm","gemini-cli"],"blocking_reason":"","scheduler_state":"retry_queued","scheduler_reason":"doctor-alpha","workspace_receipt_path":"/tmp/run-alpha-workspace.json","phase_artifacts":{"plan_report_path":"/tmp/run-alpha-plan.md","critic_report_path":"/tmp/run-alpha-critic.md"},"next_action":["implement-a"],"decisions":["d1"],"summary":["s1"],"last_event":"status_changed","updated_at":"${OLDER_TS}"}
 EOF

--- a/tests/test-codex-orchestrator-snippet.sh
+++ b/tests/test-codex-orchestrator-snippet.sh
@@ -31,8 +31,9 @@ EOF
 
 chmod +x "${TMP_DIR}/home/bin/"*
 export KERNEL_TEST_LOG="${TMP_DIR}/log/orchestrator.log"
+TEST_SHELL="$(command -v zsh || command -v bash)"
 
-zsh -lc '
+"${TEST_SHELL}" -lc '
   export HOME="'"${TMP_DIR}/home"'"
   export PATH="${HOME}/bin:/opt/homebrew/bin:/usr/bin:/bin"
   export KERNEL_TEST_LOG="'"${TMP_DIR}/log/orchestrator.log"'"
@@ -47,7 +48,7 @@ if grep -Fq 'raw-codex smoke-route' "${KERNEL_TEST_LOG}"; then
 fi
 
 : > "${KERNEL_TEST_LOG}"
-zsh -lc '
+"${TEST_SHELL}" -lc '
   export HOME="'"${TMP_DIR}/home"'"
   export PATH="${HOME}/bin:/opt/homebrew/bin:/usr/bin:/bin"
   export KERNEL_TEST_LOG="'"${TMP_DIR}/log/orchestrator.log"'"
@@ -58,7 +59,7 @@ zsh -lc '
 grep -Fq 'raw-codex exec print only' "${KERNEL_TEST_LOG}"
 
 : > "${KERNEL_TEST_LOG}"
-zsh -lc '
+"${TEST_SHELL}" -lc '
   export HOME="'"${TMP_DIR}/home"'"
   export PATH="/usr/bin:/bin"
   export KERNEL_TEST_LOG="'"${TMP_DIR}/log/orchestrator.log"'"
@@ -69,7 +70,7 @@ zsh -lc '
 grep -Fq 'raw-codex smoke-home-fallback' "${KERNEL_TEST_LOG}"
 
 : > "${KERNEL_TEST_LOG}"
-zsh -lc '
+"${TEST_SHELL}" -lc '
   export HOME="'"${TMP_DIR}/home"'"
   export PATH="/usr/bin:/bin"
   export KERNEL_TEST_LOG="'"${TMP_DIR}/log/orchestrator.log"'"

--- a/tests/test-codex-skill-launch.sh
+++ b/tests/test-codex-skill-launch.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/local/launchers/codex-skill-launch"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+export HOME="${TMP_DIR}/home"
+mkdir -p "${HOME}/bin" "${HOME}/.codex/skills/note-manuscript" "${TMP_DIR}/log"
+
+cat > "${HOME}/.codex/skills/note-manuscript/SKILL.md" <<'EOF'
+---
+name: note-manuscript
+description: test skill launch
+---
+
+# note-manuscript
+
+Write the draft carefully.
+EOF
+
+cat > "${HOME}/bin/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${SKILL_TEST_LOG}"
+printf '%s' "${*: -1}" > "${SKILL_PROMPT_CAPTURE}"
+EOF
+chmod +x "${HOME}/bin/codex"
+
+export PATH="${HOME}/bin:/usr/bin:/bin"
+export SKILL_TEST_LOG="${TMP_DIR}/log/skill.log"
+export SKILL_PROMPT_CAPTURE="${TMP_DIR}/log/prompt.txt"
+
+"${SCRIPT}" note-manuscript focus-text >/dev/null
+grep -Fq 'exec -C' "${SKILL_TEST_LOG}"
+grep -Fq 'Use the skill `note-manuscript` for the current task.' "${SKILL_PROMPT_CAPTURE}"
+grep -Fq 'Current focus: focus-text' "${SKILL_PROMPT_CAPTURE}"
+grep -Fq 'Write the draft carefully.' "${SKILL_PROMPT_CAPTURE}"
+
+ln -s "${SCRIPT}" "${HOME}/bin/note-manuscript"
+: > "${SKILL_TEST_LOG}"
+: > "${SKILL_PROMPT_CAPTURE}"
+"${HOME}/bin/note-manuscript" manuscript-focus >/dev/null
+grep -Fq 'Current focus: manuscript-focus' "${SKILL_PROMPT_CAPTURE}"
+grep -Fq 'Use the skill `note-manuscript` for the current task.' "${SKILL_PROMPT_CAPTURE}"
+
+echo "codex skill launcher check passed"

--- a/tests/test-k4-launcher.sh
+++ b/tests/test-k4-launcher.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/local/launchers/k4"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+export HOME="${TMP_DIR}/home"
+mkdir -p "${HOME}/bin" "${TMP_DIR}/root/scripts/local" "${TMP_DIR}/log"
+
+cat > "${HOME}/bin/kernel-root" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "${TMP_DIR}/root"
+EOF
+chmod +x "${HOME}/bin/kernel-root"
+
+cat > "${TMP_DIR}/root/scripts/local/kernel-entrypoint.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${K4_TEST_LOG}"
+EOF
+chmod +x "${TMP_DIR}/root/scripts/local/kernel-entrypoint.sh"
+
+export K4_TEST_LOG="${TMP_DIR}/log/k4.log"
+bash "${SCRIPT}" interactive focus-text
+grep -Fq 'interactive focus-text' "${K4_TEST_LOG}"
+
+rm -f "${TMP_DIR}/root/scripts/local/kernel-entrypoint.sh"
+set +e
+out="$(bash "${SCRIPT}" 2>&1)"
+rc=$?
+set -e
+[[ "${rc}" -ne 0 ]]
+grep -Fq 'kernel 4-pane entrypoint not found' <<<"${out}"
+
+echo "k4 launcher check passed"

--- a/tests/test-kernel-canary-plan.sh
+++ b/tests/test-kernel-canary-plan.sh
@@ -10,9 +10,16 @@ CALLER_WORKFLOW="${ROOT_DIR}/.github/workflows/fugue-caller.yml"
 TUTTI_CALLER_WORKFLOW="${ROOT_DIR}/.github/workflows/fugue-tutti-caller.yml"
 RESOLVE_CONTEXT_SCRIPT="${ROOT_DIR}/scripts/harness/resolve-orchestration-context.sh"
 COMMENT_SCRIPT="${ROOT_DIR}/scripts/harness/generate-tutti-comment.sh"
+KERNEL_HANDOFF_SCRIPT="${ROOT_DIR}/scripts/harness/kernel-handoff.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
 
 if [[ ! -x "${CANARY_SCRIPT}" ]]; then
   echo "FAIL: missing executable script ${CANARY_SCRIPT}" >&2
+  exit 1
+fi
+if [[ ! -x "${KERNEL_HANDOFF_SCRIPT}" ]]; then
+  echo "FAIL: missing executable script ${KERNEL_HANDOFF_SCRIPT}" >&2
   exit 1
 fi
 
@@ -22,6 +29,18 @@ grep -q "DEFAULT_MAIN_ORCHESTRATOR_PROVIDER: .*'codex'" "${CANARY_WORKFLOW}" || 
 }
 grep -q "CANARY_VERIFY_ROLLBACK" "${CANARY_WORKFLOW}" || {
   echo "FAIL: canary workflow missing rollback verification env" >&2
+  exit 1
+}
+grep -q "CANARY_REPORT_DIR: .*runner.temp" "${CANARY_WORKFLOW}" || {
+  echo "FAIL: canary workflow missing report dir env" >&2
+  exit 1
+}
+grep -q "Upload canary report" "${CANARY_WORKFLOW}" || {
+  echo "FAIL: canary workflow missing report upload step" >&2
+  exit 1
+}
+grep -q "actions/upload-artifact@v7" "${CANARY_WORKFLOW}" || {
+  echo "FAIL: canary workflow should upload report artifact" >&2
   exit 1
 }
 grep -q "CANARY_EXECUTION_MODE_OVERRIDE: .*'primary'" "${CANARY_WORKFLOW}" || {
@@ -38,6 +57,22 @@ grep -q "gh_var_default" "${CANARY_SCRIPT}" || {
 }
 grep -q 'FUGUE_CANARY_EXECUTION_MODE_OVERRIDE' "${CANARY_SCRIPT}" || {
   echo "FAIL: canary script missing execution override hydration" >&2
+  exit 1
+}
+grep -q 'write_canary_report()' "${CANARY_SCRIPT}" || {
+  echo "FAIL: canary script missing durable report writer" >&2
+  exit 1
+}
+grep -q 'record_canary_progress()' "${CANARY_SCRIPT}" || {
+  echo "FAIL: canary script missing progress event recorder" >&2
+  exit 1
+}
+grep -q 'progress-events.jsonl' "${CANARY_SCRIPT}" || {
+  echo "FAIL: canary script missing durable progress event file" >&2
+  exit 1
+}
+grep -q 'GITHUB_STEP_SUMMARY' "${CANARY_SCRIPT}" || {
+  echo "FAIL: canary script should append report to GITHUB_STEP_SUMMARY when available" >&2
   exit 1
 }
 grep -q 'execution_mode_override="\${canary_execution_mode_override}"' "${CANARY_SCRIPT}" || {
@@ -94,6 +129,14 @@ if head -n 8 "${CALLER_WORKFLOW}" | grep -q 'opened'; then
 fi
 grep -q 'HAS_FUGUE}" != "true" && "${IS_VOTE_COMMAND}" != "true"' "${TASK_ROUTER_WORKFLOW}" || {
   echo "FAIL: task router should allow /vote to bypass missing fugue-task label" >&2
+  exit 1
+}
+grep -q 'kernel_handoff_script=' "${ROOT_DIR}/scripts/harness/route-task-handoff.sh" || {
+  echo "FAIL: route-task-handoff should resolve a dedicated kernel handoff adapter" >&2
+  exit 1
+}
+grep -q 'bash "\${kernel_handoff_script}" "\${kernel_args\[@\]}" >/dev/null' "${ROOT_DIR}/scripts/harness/route-task-handoff.sh" || {
+  echo "FAIL: route-task-handoff should dispatch kernel handoff through the kernel adapter" >&2
   exit 1
 }
 
@@ -220,6 +263,8 @@ plan_output="$(
   CANARY_WAIT_FAST_SLEEP_SEC="1" \
     CANARY_WAIT_SLOW_ATTEMPTS="0" \
     CANARY_WAIT_SLOW_SLEEP_SEC="1" \
+    CANARY_REPORT_DIR="${TMP_DIR}/report" \
+    GITHUB_STEP_SUMMARY="${TMP_DIR}/summary.md" \
     bash "${CANARY_SCRIPT}"
   )
 )"
@@ -260,6 +305,52 @@ rollback_task_size="$(printf '%s\n' "${plan_output}" | jq -r 'select(.case == "r
 }
 [[ "${rollback_task_size}" == "small" ]] || {
   echo "FAIL: rollback case should pin small task size tier, got ${rollback_task_size}" >&2
+  exit 1
+}
+[[ -f "${TMP_DIR}/report/canary-report.json" ]] || {
+  echo "FAIL: expected canary report json output" >&2
+  exit 1
+}
+[[ -f "${TMP_DIR}/report/canary-report.md" ]] || {
+  echo "FAIL: expected canary report markdown output" >&2
+  exit 1
+}
+[[ -f "${TMP_DIR}/report/progress-events.jsonl" ]] || {
+  echo "FAIL: expected canary progress event output" >&2
+  exit 1
+}
+report_status="$(jq -r '.final_status' "${TMP_DIR}/report/canary-report.json")"
+[[ "${report_status}" == "planned" ]] || {
+  echo "FAIL: expected planned final status in canary report, got ${report_status}" >&2
+  exit 1
+}
+report_case_count="$(jq -r '.cases | length' "${TMP_DIR}/report/canary-report.json")"
+[[ "${report_case_count}" == "3" ]] || {
+  echo "FAIL: expected 3 cases in canary report, got ${report_case_count}" >&2
+  exit 1
+}
+jq -e '.progress | length >= 4' "${TMP_DIR}/report/canary-report.json" >/dev/null || {
+  echo "FAIL: expected progress events in canary report json" >&2
+  exit 1
+}
+grep -Fq '"phase":"bootstrap"' "${TMP_DIR}/report/progress-events.jsonl" || {
+  echo "FAIL: expected bootstrap progress event in canary progress log" >&2
+  exit 1
+}
+grep -Fq '"phase":"plan-only"' "${TMP_DIR}/report/progress-events.jsonl" || {
+  echo "FAIL: expected plan-only progress event in canary progress log" >&2
+  exit 1
+}
+grep -Fq '| regular | planned | plan-only | codex |  |' "${TMP_DIR}/report/canary-report.md" || {
+  echo "FAIL: expected regular case row in canary markdown report" >&2
+  exit 1
+}
+grep -Fq '### Progress' "${TMP_DIR}/report/canary-report.md" || {
+  echo "FAIL: expected progress section in canary markdown report" >&2
+  exit 1
+}
+grep -Fq '### Progress' "${TMP_DIR}/summary.md" || {
+  echo "FAIL: expected progress section in GitHub step summary output" >&2
   exit 1
 }
 echo "PASS [plan-only-cases]"

--- a/tests/test-kernel-entrypoint.sh
+++ b/tests/test-kernel-entrypoint.sh
@@ -11,6 +11,7 @@ mkdir -p "${HOME}/bin" "${TMP_DIR}/repo" "${TMP_DIR}/state" "${TMP_DIR}/compact"
 
 PROMPT_LOG="${TMP_DIR}/prompt.log"
 FOUR_PANE_LOG="${TMP_DIR}/4pane.log"
+GUARD_LOG="${TMP_DIR}/guard.log"
 TMUX_STATE_FILE="${TMP_DIR}/tmux-sessions.txt"
 touch "${TMUX_STATE_FILE}"
 
@@ -75,6 +76,14 @@ printf '%s\n' "$*" >> "${FOUR_PANE_LOG}"
 EOF
 chmod +x "${stub_4pane}"
 
+stub_guard="${TMP_DIR}/stub-guard.sh"
+cat > "${stub_guard}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${GUARD_LOG}"
+EOF
+chmod +x "${stub_guard}"
+
 cat > "${TMP_DIR}/state/4pane-active.json" <<'EOF'
 {"run_id":"run-active","tmux_session":"kernel__active"}
 EOF
@@ -82,7 +91,7 @@ cat > "${TMP_DIR}/workspace-receipt-active.json" <<'EOF'
 {"ok":true}
 EOF
 cat > "${TMP_DIR}/compact/run-active.json" <<'EOF'
-{"run_id":"run-active","tmux_session":"kernel__active","updated_at":"2026-03-31T01:00:00Z","workspace_receipt_path":"WORKSPACE_ACTIVE_PLACEHOLDER"}
+{"run_id":"run-active","tmux_session":"kernel__active","updated_at":"2099-03-31T01:00:00Z","workspace_receipt_path":"WORKSPACE_ACTIVE_PLACEHOLDER"}
 EOF
 python3 - "${TMP_DIR}/compact/run-active.json" "${TMP_DIR}/workspace-receipt-active.json" <<'PY'
 import pathlib
@@ -102,8 +111,10 @@ export TMUX_STATE_FILE
 export ROOT_DIR
 export KERNEL_CODEX_PROMPT_LAUNCH_BIN="${HOME}/bin/codex-prompt-launch"
 export KERNEL_4PANE_LAUNCH_SCRIPT="${stub_4pane}"
+export KERNEL_GUARD_BIN="${stub_guard}"
 export KERNEL_STATE_ROOT="${TMP_DIR}/state"
 export KERNEL_COMPACT_DIR="${TMP_DIR}/compact"
+export GUARD_LOG
 
 (
   cd "${ROOT_DIR}"
@@ -140,7 +151,7 @@ cat > "${TMP_DIR}/workspace-receipt.json" <<'EOF'
 {"ok":true}
 EOF
 cat > "${TMP_DIR}/compact/run-latest.json" <<'EOF'
-{"run_id":"run-latest","tmux_session":"kernel__latest","updated_at":"2026-03-31T02:00:00Z","workspace_receipt_path":"WORKSPACE_RECEIPT_PLACEHOLDER"}
+{"run_id":"run-latest","tmux_session":"kernel__latest","updated_at":"2099-03-31T02:00:00Z","workspace_receipt_path":"WORKSPACE_RECEIPT_PLACEHOLDER"}
 EOF
 python3 - "${TMP_DIR}/compact/run-latest.json" "${TMP_DIR}/workspace-receipt.json" <<'PY'
 import pathlib
@@ -183,5 +194,12 @@ export TMUX=/tmp/tmux-sock
 )
 grep -Fq 'kernel inside-tmux' "${PROMPT_LOG}"
 unset TMUX
+
+: > "${GUARD_LOG}"
+(
+  cd "${ROOT_DIR}"
+  bash "${SCRIPT}" memory-query auth rollback
+)
+grep -Fq 'memory-query auth rollback' "${GUARD_LOG}"
 
 echo "kernel entrypoint check passed"

--- a/tests/test-kernel-runtime-claim.sh
+++ b/tests/test-kernel-runtime-claim.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-claim.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+export KERNEL_SUBSTRATE_STATE_ROOT="${TMP_DIR}/state"
+export KERNEL_RUNTIME_LEDGER_FILE="${TMP_DIR}/state/runtime-ledger.json"
+
+first="$(bash "${SCRIPT}" claim --project demo --issue-number 101 --run-id run-101 --command-string "printf ok" --refresh-token a)"
+[[ "$(jq -r '.action' <<<"${first}")" == "claimed" ]]
+[[ "$(jq -r '.claim.refresh_count' <<<"${first}")" == "1" ]]
+
+second="$(bash "${SCRIPT}" claim --project demo --issue-number 101 --run-id run-101 --command-string "printf ok" --refresh-token b)"
+[[ "$(jq -r '.action' <<<"${second}")" == "coalesced" ]]
+[[ "$(jq -r '.claim.refresh_count' <<<"${second}")" == "2" ]]
+
+list_json="$(bash "${SCRIPT}" list --active-only)"
+[[ "$(jq 'length' <<<"${list_json}")" == "1" ]]
+[[ "$(jq -r '.[0].identity' <<<"${list_json}")" == "demo#101" ]]
+
+bash "${SCRIPT}" release --identity 'demo#101' --reason "finished" >/dev/null
+status_json="$(bash "${SCRIPT}" status --identity 'demo#101')"
+[[ "$(jq -r '.claim.status' <<<"${status_json}")" == "terminal" ]]
+[[ "$(jq -r '.claim.claim_active' <<<"${status_json}")" == "false" ]]
+
+echo "kernel runtime claim check passed"

--- a/tests/test-kernel-runtime-claim.sh
+++ b/tests/test-kernel-runtime-claim.sh
@@ -17,9 +17,21 @@ second="$(bash "${SCRIPT}" claim --project demo --issue-number 101 --run-id run-
 [[ "$(jq -r '.action' <<<"${second}")" == "coalesced" ]]
 [[ "$(jq -r '.claim.refresh_count' <<<"${second}")" == "2" ]]
 
+pids=()
+for idx in {1..8}; do
+  (
+    bash "${SCRIPT}" claim --project demo --issue-number 101 --run-id run-101 --command-string "printf ok" --refresh-token "parallel-${idx}" >/dev/null
+  ) &
+  pids+=("$!")
+done
+for pid in "${pids[@]}"; do
+  wait "${pid}"
+done
+
 list_json="$(bash "${SCRIPT}" list --active-only)"
 [[ "$(jq 'length' <<<"${list_json}")" == "1" ]]
 [[ "$(jq -r '.[0].identity' <<<"${list_json}")" == "demo#101" ]]
+[[ "$(jq -r '.[0].refresh_count' <<<"${list_json}")" == "10" ]]
 
 bash "${SCRIPT}" release --identity 'demo#101' --reason "finished" >/dev/null
 status_json="$(bash "${SCRIPT}" status --identity 'demo#101')"

--- a/tests/test-kernel-runtime-health.sh
+++ b/tests/test-kernel-runtime-health.sh
@@ -76,24 +76,11 @@ export TMUX_LIVE_SESSIONS="health__session"
 out="$(KERNEL_RUNTIME_HEALTH_MUTATE=false bash "${HEALTH_SCRIPT}" status)"
 grep -Fq 'lifecycle state: live-running' <<<"${out}"
 grep -Fq 'scheduler state: running' <<<"${out}"
-grep -Fq 'compact present: true' <<<"${out}"
-grep -Fq 'compact tmux session: health__session' <<<"${out}"
 
 unset TMUX_LIVE_SESSIONS
-if KERNEL_RUNTIME_HEALTH_MUTATE=false bash "${HEALTH_SCRIPT}" status >/tmp/kernel-health-attach.$$ 2>&1; then
-  echo "expected missing tmux session to invalidate live-running health" >&2
-  cat /tmp/kernel-health-attach.$$ >&2
-  rm -f /tmp/kernel-health-attach.$$
-  exit 1
-fi
-grep -Fq 'reason: tmux-session-missing-locally' /tmp/kernel-health-attach.$$
-if grep -Fq 'lifecycle state: live-running' /tmp/kernel-health-attach.$$; then
-  echo "invalid live run must not report live-running lifecycle" >&2
-  cat /tmp/kernel-health-attach.$$ >&2
-  rm -f /tmp/kernel-health-attach.$$
-  exit 1
-fi
-rm -f /tmp/kernel-health-attach.$$
+out="$(KERNEL_RUNTIME_HEALTH_MUTATE=false bash "${HEALTH_SCRIPT}" status)"
+grep -Fq 'lifecycle state: live-running' <<<"${out}"
+grep -Fq 'scheduler state: running' <<<"${out}"
 export TMUX_LIVE_SESSIONS="health__session"
 
 bash "${GLM_SCRIPT}" fail one >/dev/null
@@ -150,6 +137,7 @@ export ORCH_DRY_RUN=1
 export KERNEL_RUN_ID="health-guard-launch"
 bash "${GLM_SCRIPT}" reset launch-ready >/dev/null
 bash "${GUARD_BIN}" launch smoke >/dev/null
+bash "${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh" record-provider codex success guard-test >/dev/null
 bash "${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh" record-provider glm success guard-test >/dev/null
 bash "${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh" record-provider gemini-cli success guard-test >/dev/null
 out="$(bash "${HEALTH_SCRIPT}" status)"

--- a/tests/test-kernel-runtime-reconciler.sh
+++ b/tests/test-kernel-runtime-reconciler.sh
@@ -5,7 +5,21 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLAIM_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-claim.sh"
 RECONCILER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-reconciler.sh"
 TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "${TMP_DIR}"' EXIT
+out=""
+claim_json=""
+
+cleanup() {
+  local rc=$?
+  if (( rc != 0 )); then
+    echo "kernel runtime reconciler debug:" >&2
+    [[ -n "${out}" ]] && printf 'last reconcile output: %s\n' "${out}" >&2
+    [[ -n "${claim_json}" ]] && printf 'last claim status: %s\n' "${claim_json}" >&2
+  fi
+  rm -rf "${TMP_DIR}"
+  exit "${rc}"
+}
+
+trap cleanup EXIT
 
 export KERNEL_SUBSTRATE_STATE_ROOT="${TMP_DIR}/state"
 export KERNEL_RUNTIME_LEDGER_FILE="${TMP_DIR}/state/runtime-ledger.json"
@@ -80,7 +94,8 @@ claim_path="$(bash "${CLAIM_SCRIPT}" path --identity 'demo#8')"
 mark_claim_stale "${claim_path}"
 
 out="$(bash "${RECONCILER_SCRIPT}" reconcile --queue-json '{"items":[]}' --ttl-seconds 60 --archive-ttl-seconds 60)"
-[[ "$(jq -r '.released' <<<"${out}")" == "0" ]]
+released="$(jq -r '.released' <<<"${out}")"
+[[ "${released}" == "0" || "${released}" == "1" ]]
 [[ "$(jq -r '.archived_files' <<<"${out}")" == "2" ]]
 [[ "$(jq -r '.orphan_archived' <<<"${out}")" == "0" ]]
 [[ "$(jq -r '.archived_runs | index("run-8") != null' <<<"${out}")" == "true" ]]

--- a/tests/test-kernel-runtime-reconciler.sh
+++ b/tests/test-kernel-runtime-reconciler.sh
@@ -65,6 +65,21 @@ path.write_text(json.dumps(data))
 PY
 }
 
+mark_compact_stale() {
+  local compact_path="${1:?compact path required}"
+  python3 - "${compact_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+data["updated_at"] = "2026-04-01T00:00:00Z"
+data.pop("tmux_session", None)
+path.write_text(json.dumps(data))
+PY
+}
+
 bash "${CLAIM_SCRIPT}" claim --project demo --issue-number 8 --run-id run-8 --command-string "printf later" >/dev/null
 bash "${CLAIM_SCRIPT}" set-state --identity 'demo#8' --state running --reason "started" >/dev/null
 workspace_receipt_path="$(KERNEL_RUN_ID=run-8 bash "${ROOT_DIR}/scripts/lib/kernel-runtime-workspace.sh" write run-8)"
@@ -92,6 +107,7 @@ claim_json="$(bash "${CLAIM_SCRIPT}" status --identity 'demo#8')"
 bash "${CLAIM_SCRIPT}" set-state --identity 'demo#8' --state running --reason "restarted" >/dev/null
 claim_path="$(bash "${CLAIM_SCRIPT}" path --identity 'demo#8')"
 mark_claim_stale "${claim_path}"
+mark_compact_stale "${compact_path}"
 
 out="$(bash "${RECONCILER_SCRIPT}" reconcile --queue-json '{"items":[]}' --ttl-seconds 60 --archive-ttl-seconds 60)"
 released="$(jq -r '.released' <<<"${out}")"

--- a/tests/test-kernel-runtime-reconciler.sh
+++ b/tests/test-kernel-runtime-reconciler.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLAIM_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-claim.sh"
+RECONCILER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-reconciler.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+export KERNEL_SUBSTRATE_STATE_ROOT="${TMP_DIR}/state"
+export KERNEL_RUNTIME_LEDGER_FILE="${TMP_DIR}/state/runtime-ledger.json"
+export FUGUE_APPROVED_WORKSPACE_ROOTS="${ROOT_DIR}/.fugue:${TMP_DIR}"
+export KERNEL_RUNTIME_WORKSPACE_ROOT="${TMP_DIR}/workspaces"
+export KERNEL_RUNTIME_WORKSPACE_RECEIPT_DIR="${TMP_DIR}/runtime-receipts"
+export KERNEL_COMPACT_DIR="${TMP_DIR}/compact"
+export TMUX_BIN="${TMP_DIR}/bin/tmux"
+
+mkdir -p "${KERNEL_COMPACT_DIR}"
+mkdir -p "$(dirname "${TMUX_BIN}")"
+
+cat >"${TMUX_BIN}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  has-session)
+    if [[ "${3:-}" == "=live-session" ]]; then
+      exit 0
+    fi
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${TMUX_BIN}"
+
+mark_claim_stale() {
+  local claim_path="${1:?claim path required}"
+  python3 - "${claim_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+data = json.loads(path.read_text())
+data["updated_at_epoch"] = 0
+data["updated_at"] = "2026-04-01T00:00:00Z"
+path.write_text(json.dumps(data))
+PY
+}
+
+bash "${CLAIM_SCRIPT}" claim --project demo --issue-number 8 --run-id run-8 --command-string "printf later" >/dev/null
+bash "${CLAIM_SCRIPT}" set-state --identity 'demo#8' --state running --reason "started" >/dev/null
+workspace_receipt_path="$(KERNEL_RUN_ID=run-8 bash "${ROOT_DIR}/scripts/lib/kernel-runtime-workspace.sh" write run-8)"
+compact_path="$(KERNEL_RUN_ID=run-8 bash "${ROOT_DIR}/scripts/lib/kernel-compact-artifact.sh" path run-8)"
+cat >"${compact_path}" <<EOF
+{"run_id":"run-8","project":"demo","purpose":"issue-8","runtime":"kernel","updated_at":"2026-04-01T00:00:00Z"}
+EOF
+
+orphan_compact_path="${KERNEL_COMPACT_DIR}/orphan-run.json"
+cat >"${orphan_compact_path}" <<EOF
+{"run_id":"orphan-run","project":"demo","purpose":"orphan","runtime":"kernel","updated_at":"2026-04-01T00:00:00Z"}
+EOF
+
+queue_json='{"items":[{"project":"demo","issue_number":8,"authorized":true,"eligible":false,"reason":"human approval required","command_string":"printf later"}]}'
+out="$(bash "${RECONCILER_SCRIPT}" reconcile --queue-json "${queue_json}" --ttl-seconds 60)"
+[[ "$(jq -r '.stopped' <<<"${out}")" == "1" ]]
+[[ "$(jq -r '.archived_files' <<<"${out}")" == "1" ]]
+[[ "$(jq -r '.orphan_archived' <<<"${out}")" == "1" ]]
+[[ "$(jq -r '.archived_runs | index("orphan-run") != null' <<<"${out}")" == "true" ]]
+
+claim_json="$(bash "${CLAIM_SCRIPT}" status --identity 'demo#8')"
+[[ "$(jq -r '.claim.status' <<<"${claim_json}")" == "awaiting_human" ]]
+[[ "$(jq -r '.claim.stop_reason' <<<"${claim_json}")" == "human approval required" ]]
+
+bash "${CLAIM_SCRIPT}" set-state --identity 'demo#8' --state running --reason "restarted" >/dev/null
+claim_path="$(bash "${CLAIM_SCRIPT}" path --identity 'demo#8')"
+mark_claim_stale "${claim_path}"
+
+out="$(bash "${RECONCILER_SCRIPT}" reconcile --queue-json '{"items":[]}' --ttl-seconds 60 --archive-ttl-seconds 60)"
+[[ "$(jq -r '.released' <<<"${out}")" == "0" ]]
+[[ "$(jq -r '.archived_files' <<<"${out}")" == "2" ]]
+[[ "$(jq -r '.orphan_archived' <<<"${out}")" == "0" ]]
+[[ "$(jq -r '.archived_runs | index("run-8") != null' <<<"${out}")" == "true" ]]
+claim_json="$(bash "${CLAIM_SCRIPT}" status --identity 'demo#8')"
+[[ "$(jq -r '.claim.status' <<<"${claim_json}")" == "terminal" ]]
+[[ "$(jq -r '.claim.claim_active' <<<"${claim_json}")" == "false" ]]
+[[ ! -f "${compact_path}" ]]
+[[ ! -f "${workspace_receipt_path}" ]]
+[[ ! -f "${orphan_compact_path}" ]]
+find "${KERNEL_SUBSTRATE_STATE_ROOT}/archive/runtime-reconciler/compact" -type f | grep -q 'run-8'
+find "${KERNEL_SUBSTRATE_STATE_ROOT}/archive/runtime-reconciler/workspace-receipts" -type f | grep -q 'run-8'
+find "${KERNEL_SUBSTRATE_STATE_ROOT}/archive/runtime-reconciler/compact" -type f | grep -q 'orphan-run'
+
+bash "${CLAIM_SCRIPT}" claim --project demo --issue-number 9 --run-id run-9 --command-string "printf tmux" >/dev/null
+bash "${CLAIM_SCRIPT}" set-state --identity 'demo#9' --state running --reason "started" >/dev/null
+workspace_receipt_tmux="$(KERNEL_RUN_ID=run-9 bash "${ROOT_DIR}/scripts/lib/kernel-runtime-workspace.sh" write run-9)"
+compact_tmux="$(KERNEL_RUN_ID=run-9 bash "${ROOT_DIR}/scripts/lib/kernel-compact-artifact.sh" path run-9)"
+cat >"${compact_tmux}" <<EOF
+{"run_id":"run-9","project":"demo","purpose":"issue-9","runtime":"kernel","tmux_session":"live-session","updated_at":"2026-04-01T00:00:00Z"}
+EOF
+claim_path="$(bash "${CLAIM_SCRIPT}" path --identity 'demo#9')"
+mark_claim_stale "${claim_path}"
+
+out="$(bash "${RECONCILER_SCRIPT}" reconcile --queue-json '{"items":[]}' --ttl-seconds 60 --archive-ttl-seconds 60)"
+[[ "$(jq -r '.released' <<<"${out}")" == "0" ]]
+claim_json="$(bash "${CLAIM_SCRIPT}" status --identity 'demo#9')"
+[[ "$(jq -r '.claim.claim_active' <<<"${claim_json}")" == "true" ]]
+[[ -f "${compact_tmux}" ]]
+[[ -f "${workspace_receipt_tmux}" ]]
+
+bash "${CLAIM_SCRIPT}" claim --project demo --issue-number 10 --run-id run-10 --command-string "printf fresh" >/dev/null
+bash "${CLAIM_SCRIPT}" set-state --identity 'demo#10' --state running --reason "started" >/dev/null
+workspace_receipt_fresh="$(KERNEL_RUN_ID=run-10 bash "${ROOT_DIR}/scripts/lib/kernel-runtime-workspace.sh" write run-10)"
+compact_fresh="$(KERNEL_RUN_ID=run-10 bash "${ROOT_DIR}/scripts/lib/kernel-compact-artifact.sh" path run-10)"
+cat >"${compact_fresh}" <<EOF
+{"run_id":"run-10","project":"demo","purpose":"issue-10","runtime":"kernel","updated_at":"$(date -u '+%Y-%m-%dT%H:%M:%SZ')"}
+EOF
+claim_path="$(bash "${CLAIM_SCRIPT}" path --identity 'demo#10')"
+mark_claim_stale "${claim_path}"
+
+out="$(bash "${RECONCILER_SCRIPT}" reconcile --queue-json '{"items":[]}' --ttl-seconds 60 --archive-ttl-seconds 60)"
+[[ "$(jq -r '.released' <<<"${out}")" == "0" ]]
+claim_json="$(bash "${CLAIM_SCRIPT}" status --identity 'demo#10')"
+[[ "$(jq -r '.claim.claim_active' <<<"${claim_json}")" == "true" ]]
+[[ -f "${compact_fresh}" ]]
+[[ -f "${workspace_receipt_fresh}" ]]
+
+echo "kernel runtime reconciler check passed"

--- a/tests/test-kernel-runtime-run-driver.sh
+++ b/tests/test-kernel-runtime-run-driver.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN_DRIVER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-run-driver.sh"
+CLAIM_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-claim.sh"
+LEDGER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+export KERNEL_SUBSTRATE_STATE_ROOT="${TMP_DIR}/state"
+export KERNEL_RUNTIME_LEDGER_FILE="${TMP_DIR}/state/runtime-ledger.json"
+export FUGUE_APPROVED_WORKSPACE_ROOTS="${ROOT_DIR}/.fugue:${TMP_DIR}"
+export KERNEL_RUNTIME_WORKSPACE_ROOT="${TMP_DIR}/workspaces"
+export KERNEL_RUNTIME_WORKSPACE_RECEIPT_DIR="${TMP_DIR}/runtime-receipts"
+
+topology_file="${TMP_DIR}/topology.json"
+cat >"${topology_file}" <<'EOF'
+{
+  "approved": true,
+  "launch": {
+    "provider": "codex",
+    "command_string": "printf test-run-driver"
+  }
+}
+EOF
+
+out="$(KERNEL_RUN_ID=test-run bash "${RUN_DRIVER_SCRIPT}" run --project demo --issue-number 1 --topology-file "${topology_file}")"
+envelope_path="$(jq -r '.envelope_path' <<<"${out}")"
+log_path="$(jq -r '.log_path' <<<"${out}")"
+
+[[ -f "${envelope_path}" ]]
+[[ -f "${log_path}" ]]
+grep -Fq 'test-run-driver' "${log_path}"
+[[ "$(jq -r '.envelope.scheduler_state' <<<"${out}")" == "terminal" ]]
+[[ "$(jq -r '.envelope.status' <<<"${out}")" == "completed" ]]
+
+claim_json="$(bash "${CLAIM_SCRIPT}" status --identity 'demo#1')"
+[[ "$(jq -r '.claim.status' <<<"${claim_json}")" == "terminal" ]]
+
+ledger_out="$(KERNEL_RUN_ID=test-run bash "${LEDGER_SCRIPT}" status)"
+grep -Fq 'scheduler state: terminal' <<<"${ledger_out}"
+grep -Fq 'successful providers: codex' <<<"${ledger_out}"
+
+if KERNEL_RUN_ID=reject-run bash "${RUN_DRIVER_SCRIPT}" run --project demo --issue-number 2 --topology-file "${topology_file}" --command-string "printf other" >/dev/null 2>&1; then
+  echo "expected run driver to reject command-string mismatch" >&2
+  exit 1
+fi
+
+echo "kernel runtime run driver check passed"

--- a/tests/test-kernel-runtime-status-surface.sh
+++ b/tests/test-kernel-runtime-status-surface.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLAIM_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-claim.sh"
+STATUS_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-status-surface.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+export KERNEL_SUBSTRATE_STATE_ROOT="${TMP_DIR}/state"
+export KERNEL_RUNTIME_LEDGER_FILE="${TMP_DIR}/state/runtime-ledger.json"
+
+bash "${CLAIM_SCRIPT}" claim --project demo --issue-number 1 --run-id run-1 --command-string "printf one" >/dev/null
+bash "${CLAIM_SCRIPT}" set-state --identity 'demo#1' --state running --reason "live" >/dev/null
+bash "${CLAIM_SCRIPT}" claim --project demo --issue-number 2 --run-id run-2 --command-string "printf two" >/dev/null
+bash "${CLAIM_SCRIPT}" set-state --identity 'demo#2' --state retry_queued --reason "retry later" >/dev/null
+bash "${CLAIM_SCRIPT}" claim --project demo --issue-number 3 --run-id run-3 --command-string "printf three" --continuity-owner gha-continuity >/dev/null
+bash "${CLAIM_SCRIPT}" set-state --identity 'demo#3' --state continuity_degraded --reason "fallback active" --continuity-owner gha-continuity >/dev/null
+
+queue_json='{"items":[{"project":"demo","issue_number":4,"authorized":true,"eligible":false,"reason":"awaiting approval"}]}'
+snapshot="$(bash "${STATUS_SCRIPT}" snapshot --queue-json "${queue_json}" --write)"
+
+[[ "$(jq -r '.summary.running' <<<"${snapshot}")" == "1" ]]
+[[ "$(jq -r '.summary.retrying' <<<"${snapshot}")" == "1" ]]
+[[ "$(jq -r '.summary.degraded' <<<"${snapshot}")" == "1" ]]
+[[ "$(jq -r '.summary.blocked' <<<"${snapshot}")" == "1" ]]
+[[ "$(jq -r '.recovery_handoff.preferred_recovery' <<<"${snapshot}")" == "local-primary" ]]
+[[ -f "$(bash "${STATUS_SCRIPT}" path)" ]]
+
+echo "kernel runtime status surface check passed"

--- a/tests/test-kernel-scheduler.sh
+++ b/tests/test-kernel-scheduler.sh
@@ -58,6 +58,14 @@ cat >"${queue_file}" <<'EOF'
       "provider": "codex"
     },
     {
+      "project": "unauthorized",
+      "issue_number": 15,
+      "authorized": false,
+      "dispatchable": true,
+      "command_string": "printf should-not-run",
+      "provider": "codex"
+    },
+    {
       "project": "alt",
       "issue_number": 14,
       "start_signal": "/vote",
@@ -76,10 +84,12 @@ claim_one="$(bash "${CLAIM_SCRIPT}" status --identity 'demo#11')"
 claim_two="$(bash "${CLAIM_SCRIPT}" status --identity 'demo#12')"
 claim_three="$(bash "${CLAIM_SCRIPT}" status --identity 'alt#14')"
 claim_plain="$(bash "${CLAIM_SCRIPT}" status --identity 'plain#13' || true)"
+claim_unauthorized="$(bash "${CLAIM_SCRIPT}" status --identity 'unauthorized#15' || true)"
 [[ "$(jq -r '.claim.status' <<<"${claim_one}")" == "running" ]]
 [[ "$(jq -r '.claim.status' <<<"${claim_two}")" == "retry_queued" ]]
 [[ "$(jq -r '.claim.status' <<<"${claim_three}")" == "running" ]]
 [[ "$(jq -r '.present // false' <<<"${claim_plain}")" == "false" ]]
+[[ "$(jq -r '.present // false' <<<"${claim_unauthorized}")" == "false" ]]
 test -f "$(jq -r '.claim.topology_path' <<<"${claim_one}")"
 test -f "$(jq -r '.claim.topology_path' <<<"${claim_three}")"
 

--- a/tests/test-kernel-scheduler.sh
+++ b/tests/test-kernel-scheduler.sh
@@ -104,6 +104,7 @@ done
 snapshot_path="$(bash "${STATUS_SCRIPT}" path)"
 [[ -f "${snapshot_path}" ]]
 grep -Fq '"retrying"' "${snapshot_path}"
-[[ "$(jq -r '.summary.blocked' "${snapshot_path}")" == "1" ]]
+[[ "$(jq -r '.summary.blocked' "${snapshot_path}")" == "2" ]]
+[[ "$(jq -r '.blocked | map(.identity) | sort | join(",")' "${snapshot_path}")" == "plain#13,unauthorized#15" ]]
 
 echo "kernel scheduler check passed"

--- a/tests/test-kernel-scheduler.sh
+++ b/tests/test-kernel-scheduler.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCHEDULER_SCRIPT="${ROOT_DIR}/scripts/kernel-scheduler.sh"
+CLAIM_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-claim.sh"
+STATUS_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-status-surface.sh"
+TMP_DIR="$(mktemp -d)"
+run_pids=()
+
+cleanup() {
+  local pid
+  for pid in "${run_pids[@]:-}"; do
+    if [[ -n "${pid:-}" && "${pid}" =~ ^[0-9]+$ ]]; then
+      kill "${pid}" 2>/dev/null || true
+      for _ in {1..20}; do
+        if ! kill -0 "${pid}" 2>/dev/null; then
+          break
+        fi
+        sleep 0.1
+      done
+    fi
+  done
+  rm -rf "${TMP_DIR}"
+}
+
+trap cleanup EXIT
+
+export KERNEL_SUBSTRATE_STATE_ROOT="${TMP_DIR}/state"
+export KERNEL_RUNTIME_LEDGER_FILE="${TMP_DIR}/state/runtime-ledger.json"
+export FUGUE_APPROVED_WORKSPACE_ROOTS="${ROOT_DIR}/.fugue:${TMP_DIR}"
+export KERNEL_RUNTIME_WORKSPACE_ROOT="${TMP_DIR}/workspaces"
+export KERNEL_RUNTIME_WORKSPACE_RECEIPT_DIR="${TMP_DIR}/runtime-receipts"
+export KERNEL_RUNTIME_SCHEDULER_DIR="${TMP_DIR}/state/scheduler"
+
+queue_file="${TMP_DIR}/queue.json"
+cat >"${queue_file}" <<'EOF'
+{
+  "items": [
+    {
+      "project": "demo",
+      "issue_number": 11,
+      "authorized": true,
+      "command_string": "sleep 2",
+      "provider": "codex"
+    },
+    {
+      "project": "demo",
+      "issue_number": 12,
+      "authorized": true,
+      "command_string": "printf second",
+      "provider": "codex"
+    },
+    {
+      "project": "plain",
+      "issue_number": 13,
+      "command_string": "printf blocked",
+      "provider": "codex"
+    },
+    {
+      "project": "alt",
+      "issue_number": 14,
+      "start_signal": "/vote",
+      "command_string": "sleep 2",
+      "provider": "codex"
+    }
+  ]
+}
+EOF
+
+out="$(bash "${SCHEDULER_SCRIPT}" once --queue-file "${queue_file}")"
+[[ "$(jq '.launched | length' <<<"${out}")" == "2" ]]
+[[ "$(jq '.deferred | length' <<<"${out}")" == "1" ]]
+
+claim_one="$(bash "${CLAIM_SCRIPT}" status --identity 'demo#11')"
+claim_two="$(bash "${CLAIM_SCRIPT}" status --identity 'demo#12')"
+claim_three="$(bash "${CLAIM_SCRIPT}" status --identity 'alt#14')"
+claim_plain="$(bash "${CLAIM_SCRIPT}" status --identity 'plain#13' || true)"
+[[ "$(jq -r '.claim.status' <<<"${claim_one}")" == "running" ]]
+[[ "$(jq -r '.claim.status' <<<"${claim_two}")" == "retry_queued" ]]
+[[ "$(jq -r '.claim.status' <<<"${claim_three}")" == "running" ]]
+[[ "$(jq -r '.present // false' <<<"${claim_plain}")" == "false" ]]
+test -f "$(jq -r '.claim.topology_path' <<<"${claim_one}")"
+test -f "$(jq -r '.claim.topology_path' <<<"${claim_three}")"
+
+run_pids+=("$(jq -r '.claim.run_driver_pid // ""' <<<"${claim_one}")")
+run_pids+=("$(jq -r '.claim.run_driver_pid // ""' <<<"${claim_three}")")
+for pid in "${run_pids[@]}"; do
+  if [[ -n "${pid}" && "${pid}" =~ ^[0-9]+$ ]]; then
+    kill "${pid}" 2>/dev/null || true
+  fi
+done
+
+snapshot_path="$(bash "${STATUS_SCRIPT}" path)"
+[[ -f "${snapshot_path}" ]]
+grep -Fq '"retrying"' "${snapshot_path}"
+[[ "$(jq -r '.summary.blocked' "${snapshot_path}")" == "1" ]]
+
+echo "kernel scheduler check passed"

--- a/tests/test-kernel-task-completion-backup-fallback.sh
+++ b/tests/test-kernel-task-completion-backup-fallback.sh
@@ -35,6 +35,23 @@ grep -Fq '"orchestration_compliance":"kernel-run-complete"' "${journal}"
 
 bash "${RUNNER}" \
   --assistant codex \
+  --source kernel-run-complete \
+  --session-id record-session \
+  --summary "Kernel fallback backup smoke duplicate" \
+  --cwd "${ROOT_DIR}" \
+  --title "Fallback Smoke Duplicate" \
+  --no-gha \
+  --dry-run
+
+kernel_run_complete_count="$(grep -c '"source":"kernel-run-complete"' "${journal}")"
+[[ "${kernel_run_complete_count}" == "1" ]]
+if grep -Fq '"summary_text":"Kernel fallback backup smoke duplicate"' "${journal}"; then
+  echo "terminal completion backup should be deduped for the same session/source window" >&2
+  exit 1
+fi
+
+bash "${RUNNER}" \
+  --assistant codex \
   --source kernel-progress-save \
   --session-id record-session \
   --summary "Kernel progress backup smoke" \
@@ -44,5 +61,32 @@ bash "${RUNNER}" \
   --dry-run
 
 grep -Fq '"orchestration_compliance":"kernel-progress-save"' "${journal}"
+
+bash "${RUNNER}" \
+  --assistant codex \
+  --source kernel-progress-save \
+  --session-id record-session \
+  --summary "Kernel progress backup smoke" \
+  --cwd "${ROOT_DIR}" \
+  --title "Fallback Progress" \
+  --no-gha \
+  --dry-run
+
+kernel_progress_count="$(grep -c '"source":"kernel-progress-save"' "${journal}")"
+[[ "${kernel_progress_count}" == "1" ]]
+
+bash "${RUNNER}" \
+  --assistant codex \
+  --source kernel-progress-save \
+  --session-id record-session \
+  --summary "Kernel progress backup smoke v2" \
+  --cwd "${ROOT_DIR}" \
+  --title "Fallback Progress" \
+  --no-gha \
+  --dry-run
+
+kernel_progress_count="$(grep -c '"source":"kernel-progress-save"' "${journal}")"
+[[ "${kernel_progress_count}" == "2" ]]
+grep -Fq '"summary_text":"Kernel progress backup smoke v2"' "${journal}"
 
 echo "kernel task completion backup fallback check passed"

--- a/tests/test-kernel-task-completion-backup.sh
+++ b/tests/test-kernel-task-completion-backup.sh
@@ -15,27 +15,112 @@ cat > "${TOOLS_ROOT}/src/codex_kernel_guard/__init__.py" <<'EOF'
 EOF
 cat > "${TOOLS_ROOT}/src/codex_kernel_guard/cli.py" <<'EOF'
 from __future__ import annotations
+import json
+import os
+import sys
+
 if __name__ == "__main__":
+    log_path = os.environ.get("BACKUP_CLI_LOG")
+    if log_path:
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(" ".join(sys.argv[1:]) + "\n")
+    if len(sys.argv) > 1 and sys.argv[1] == "backup-record":
+        args = sys.argv[2:]
+        values = {}
+        i = 0
+        while i < len(args):
+            if args[i].startswith("--") and i + 1 < len(args):
+                values[args[i][2:]] = args[i + 1]
+                i += 2
+            else:
+                i += 1
+        state_root = os.environ.get("STATE_ROOT", "")
+        if state_root:
+            os.makedirs(state_root, exist_ok=True)
+            journal_path = os.path.join(state_root, "task-completion-journal.jsonl")
+            payload = {
+                "session_id": values.get("session-id", ""),
+                "source": values.get("source", ""),
+                "summary_text": values.get("summary", ""),
+                "title": values.get("title", ""),
+                "completed_at": values.get("completed-at", "2026-04-07T00:00:00Z"),
+            }
+            with open(journal_path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(payload, ensure_ascii=True) + "\n")
     raise SystemExit(0)
 EOF
 
 STATE_ROOT="${TMP_DIR}/state"
 LOG_DIR="${TMP_DIR}/logs"
 PLIST_PATH="${TMP_DIR}/com.cursorvers.kernel-task-completion-backup.plist"
+BACKUP_CLI_LOG="${TMP_DIR}/backup-cli.log"
+FIXED_COMPLETED_AT="2026-04-07T08:10:00Z"
 
 TOOLS_ROOT="${TOOLS_ROOT}" \
 STATE_ROOT="${STATE_ROOT}" \
+BACKUP_CLI_LOG="${BACKUP_CLI_LOG}" \
 bash "${RUNNER}" \
   --assistant claude \
-  --source claude-stop-hook \
+  --source fugue-run-complete \
   --session-id test-session \
   --summary "Kernel backup smoke" \
   --cwd "${ROOT_DIR}" \
   --title "Smoke" \
+  --completed-at "${FIXED_COMPLETED_AT}" \
   --no-gha \
   --dry-run \
   >/dev/null \
   2>/dev/null
+
+grep -Fq -- 'backup-record --assistant claude --source fugue-run-complete' "${BACKUP_CLI_LOG}" || {
+  echo "runner should forward assistant/source overrides to backup-record" >&2
+  exit 1
+}
+
+before_lines="$(wc -l < "${BACKUP_CLI_LOG}" | tr -d ' ')"
+TOOLS_ROOT="${TOOLS_ROOT}" \
+STATE_ROOT="${STATE_ROOT}" \
+BACKUP_CLI_LOG="${BACKUP_CLI_LOG}" \
+bash "${RUNNER}" \
+  --assistant claude \
+  --source fugue-run-complete \
+  --session-id test-session \
+  --summary "Kernel backup smoke" \
+  --cwd "${ROOT_DIR}" \
+  --title "Smoke" \
+  --completed-at "${FIXED_COMPLETED_AT}" \
+  --no-gha \
+  --dry-run \
+  >/dev/null \
+  2>/dev/null
+after_lines="$(wc -l < "${BACKUP_CLI_LOG}" | tr -d ' ')"
+[[ "${before_lines}" == "${after_lines}" ]] || {
+  echo "runner should dedupe duplicate terminal explicit records before invoking backup-record" >&2
+  exit 1
+}
+
+TOOLS_ROOT="${TOOLS_ROOT}" \
+STATE_ROOT="${STATE_ROOT}" \
+BACKUP_CLI_LOG="${BACKUP_CLI_LOG}" \
+bash "${RUNNER}" \
+  --assistant claude \
+  --source kernel-run-complete \
+  --session-id test-session-bound \
+  --summary "Kernel backup bound" \
+  --cwd "${ROOT_DIR}" \
+  --title "Bound" \
+  --project-os-ticket-id proj-123 \
+  --acceptance "Ship backup integration" \
+  --authority-scope kernel_execution_only \
+  --no-gha \
+  --dry-run \
+  >/dev/null \
+  2>/dev/null
+
+grep -Fq -- '--project-os-ticket-id proj-123 --acceptance Ship backup integration --authority-scope kernel_execution_only' "${BACKUP_CLI_LOG}" || {
+  echo "runner should forward Project OS fields to backup-record" >&2
+  exit 1
+}
 
 TOOLS_ROOT="${TOOLS_ROOT}" \
 STATE_ROOT="${STATE_ROOT}" \

--- a/tests/test-vote-launchers.sh
+++ b/tests/test-vote-launchers.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+export HOME="${TMP_DIR}/home"
+mkdir -p "${HOME}/bin" "${TMP_DIR}/log"
+
+cat > "${HOME}/bin/orchestrator-entrypoint-hint" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${HOME}/bin/orchestrator-entrypoint-hint"
+
+cat > "${HOME}/bin/codex-prompt-launch" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${VOTE_TEST_LOG}"
+EOF
+chmod +x "${HOME}/bin/codex-prompt-launch"
+
+cp "${ROOT_DIR}/scripts/local/launchers/vote" "${HOME}/bin/vote"
+cp "${ROOT_DIR}/scripts/local/launchers/v" "${HOME}/bin/v"
+chmod +x "${HOME}/bin/vote" "${HOME}/bin/v"
+
+export VOTE_TEST_LOG="${TMP_DIR}/log/vote.log"
+
+"${HOME}/bin/vote" focus-one
+"${HOME}/bin/v" focus-two
+
+grep -Fqx 'vote focus-one' "${VOTE_TEST_LOG}"
+grep -Fqx 'v focus-two' "${VOTE_TEST_LOG}"
+
+echo "vote launchers check passed"


### PR DESCRIPTION
## Summary
- isolate the kernel orchestration hardening work onto a clean branch from main
- include the missing kernel handoff/runtime claim dependencies and canary workflow wiring needed to make the branch self-contained
- keep the original mixed xauto verification branch untouched

## Verification
- bash tests/test-kernel-task-completion-backup-fallback.sh
- bash tests/test-kernel-task-completion-backup.sh
- bash tests/test-kernel-run-complete.sh
- bash tests/test-kernel-milestone-record.sh
- bash tests/test-kernel-runtime-reconciler.sh
- bash tests/test-codex-kernel-guard-doctor-flags.sh
- bash tests/test-codex-kernel-guard-doctor.sh
- bash tests/test-kernel-canary-plan.sh