### PR TITLE
fix: restore watchdog recovery paths

### DIFF
--- a/.github/workflows/fugue-watchdog.yml
+++ b/.github/workflows/fugue-watchdog.yml
@@ -261,9 +261,11 @@ jobs:
           LAST_TIME="$(echo "${RUNS_JSON}" | jq -r '.workflow_runs[0].created_at // empty')"
 
           if [[ -z "${LAST_TIME}" ]]; then
-            echo "stale=true" >> "${GITHUB_OUTPUT}"
-            echo "hours_since=9999" >> "${GITHUB_OUTPUT}"
-            echo "minutes_since=999999" >> "${GITHUB_OUTPUT}"
+            {
+              echo "stale=true"
+              echo "hours_since=9999"
+              echo "minutes_since=999999"
+            } >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
@@ -296,9 +298,11 @@ jobs:
           LAST_TIME="$(echo "${RUNS_JSON}" | jq -r '.workflow_runs[0].created_at // empty')"
 
           if [[ -z "${LAST_TIME}" ]]; then
-            echo "stale=true" >> "${GITHUB_OUTPUT}"
-            echo "hours_since=9999" >> "${GITHUB_OUTPUT}"
-            echo "minutes_since=999999" >> "${GITHUB_OUTPUT}"
+            {
+              echo "stale=true"
+              echo "hours_since=9999"
+              echo "minutes_since=999999"
+            } >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
@@ -423,7 +427,7 @@ jobs:
           fi
           if gh variable list --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             watchdog_alert_persist="true"
-            watchdog_alert_state="$(gh api "repos/${GITHUB_REPOSITORY}/actions/variables/FUGUE_WATCHDOG_ALERT_STATE" --jq '.value' 2>/dev/null || printf '{}')"
+            watchdog_alert_state="$(gh variable get FUGUE_WATCHDOG_ALERT_STATE --repo "${GITHUB_REPOSITORY}" --json value -q '.value' 2>/dev/null || printf '{}')"
           fi
 
           policy_json="$(
@@ -464,12 +468,14 @@ jobs:
               --previous-state-json "${watchdog_alert_state}" \
               --format json
           )"
+          policy_json="$(printf '%s' "${policy_json}" | jq -c .)"
 
           should_alert="$(printf '%s' "${policy_json}" | jq -r '.should_alert')"
           force_line_alert="$(printf '%s' "${policy_json}" | jq -r '.force_line_alert')"
           msg="$(printf '%s' "${policy_json}" | jq -r '.message')"
           state_update_required="$(printf '%s' "${policy_json}" | jq -r '.state_update_required')"
-          next_state_json="$(printf '%s' "${policy_json}" | jq -c '.next_state')"
+          next_state_json="$(printf '%s' "${policy_json}" | jq -c '.next_state // {} | if type == "object" then . else {} end')"
+          next_state_b64="$(printf '%s' "${next_state_json}" | base64 | tr -d '\n')"
           due_reasons_csv="$(printf '%s' "${policy_json}" | jq -r 'if (.due_reasons | length) == 0 then "" else (.due_reasons | join(",")) end')"
           persist_state="$(printf '%s' "${policy_json}" | jq -r '.persist_state')"
 
@@ -479,7 +485,7 @@ jobs:
             echo "watchdog_alert_due_reasons=${due_reasons_csv}"
             echo "watchdog_alert_persist=${persist_state}"
             echo "watchdog_alert_state_update_required=${state_update_required}"
-            echo "watchdog_alert_next_state_json=${next_state_json}"
+            echo "watchdog_alert_next_state_b64=${next_state_b64}"
             echo "message<<EOF"
             echo "${msg}"
             echo "EOF"
@@ -547,7 +553,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           OPS_TOKEN: ${{ secrets.FUGUE_OPS_PAT || secrets.TARGET_REPO_PAT || '' }}
-          NEXT_STATE_JSON: ${{ steps.decide.outputs.watchdog_alert_next_state_json }}
+          NEXT_STATE_B64: ${{ steps.decide.outputs.watchdog_alert_next_state_b64 }}
           DISCORD_SENT: ${{ steps.discord_alert.outputs.sent }}
         run: |
           set -euo pipefail
@@ -563,6 +569,7 @@ jobs:
             exit 0
           fi
 
+          NEXT_STATE_JSON="$(printf '%s' "${NEXT_STATE_B64:-}" | base64 -d | jq -c 'if type == "object" then . else {} end')"
           gh variable set FUGUE_WATCHDOG_ALERT_STATE \
             --repo "${GITHUB_REPOSITORY}" \
             --body "${NEXT_STATE_JSON}" >/dev/null
@@ -624,7 +631,7 @@ jobs:
           fi
           if gh variable list --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             reconcile_claim_persist="true"
-            reconcile_claim_state="$(gh api "repos/${GITHUB_REPOSITORY}/actions/variables/FUGUE_RECONCILE_CLAIM_STATE" --jq '.value' 2>/dev/null || printf '{}')"
+            reconcile_claim_state="$(gh variable get FUGUE_RECONCILE_CLAIM_STATE --repo "${GITHUB_REPOSITORY}" --json value -q '.value' 2>/dev/null || printf '{}')"
           fi
 
           eval "$(
@@ -636,13 +643,14 @@ jobs:
               --ttl-seconds 1800 \
               --format env
           )"
+          next_state_b64="$(printf '%s' "${next_state_json}" | base64 | tr -d '\n')"
 
           {
             echo "dispatch_issue_numbers_json=${dispatch_issue_numbers_json}"
             echo "dispatch_count=${dispatch_count}"
             echo "state_update_required=${state_update_required}"
             echo "persist_state=${persist_state}"
-            echo "next_state_json=${next_state_json}"
+            echo "next_state_b64=${next_state_b64}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Trigger caller for claimable issues
@@ -682,7 +690,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           OPS_TOKEN: ${{ secrets.FUGUE_OPS_PAT || secrets.TARGET_REPO_PAT || '' }}
-          NEXT_STATE_JSON: ${{ steps.claims.outputs.next_state_json || '{}' }}
+          NEXT_STATE_B64: ${{ steps.claims.outputs.next_state_b64 || '' }}
           FAILED_ISSUE_NUMBERS_JSON: ${{ steps.dispatch.outputs.failed_issue_numbers_json || '[]' }}
         run: |
           set -euo pipefail
@@ -692,6 +700,11 @@ jobs:
             export GH_TOKEN
           fi
 
+          decoded_next_state="$(printf '%s' "${NEXT_STATE_B64:-}" | base64 -d 2>/dev/null || printf '{}')"
+          NEXT_STATE_JSON="$(printf '%s' "${decoded_next_state:-{}}" | jq -c '
+            (if type == "object" then . else {} end)
+            | .claims = ((.claims // {}) | if type == "object" then . else {} end)
+          ')"
           persist_json="$(jq -cn \
             --argjson state "${NEXT_STATE_JSON}" \
             --argjson failed "${FAILED_ISSUE_NUMBERS_JSON}" '

--- a/.github/workflows/kernel-recovery-console.yml
+++ b/.github/workflows/kernel-recovery-console.yml
@@ -14,6 +14,7 @@ on:
           - continuity-canary
           - rollback-canary
           - reroute-issue
+          - manus-diagnose
       issue_number:
         description: "Issue number for reroute-issue"
         required: false

--- a/README.md
+++ b/README.md
@@ -248,8 +248,8 @@ export ANTHROPIC_API_KEY="your-anthropic-key" # optional (Claude assist lane)
 
 # 3.7 Orchestrator切替シミュレーション（ローカル・非破壊）
 # ./scripts/sim-orchestrator-switch.sh | column -t -s $'\t'
-# NOTE: シミュレーションは `FUGUE_SIM_CODEX_SPARK_ONLY=true`（既定）で codex-main/codex multi-agent を `gpt-5.3-codex-spark` に統一し高速化します。
-# NOTE: `gpt-5-codex` との厳密差分検証が必要な場合のみ `FUGUE_SIM_CODEX_SPARK_ONLY=false` を指定してください。
+# NOTE: シミュレーションは `FUGUE_SIM_CODEX_SPARK_ONLY=false`（既定）で codex-main と GLM/role lanes の多様性を維持します。
+# NOTE: 短時間の高速検証を優先する場合のみ `FUGUE_SIM_CODEX_SPARK_ONLY=true` で `gpt-5.3-codex-spark` に統一します。
 # NOTE: lane構成のSSOTは `scripts/lib/build-agent-matrix.sh` です。
 # NOTE: ドリフト検知は `./scripts/check-agent-matrix-parity.sh` で実行できます。
 

--- a/docs/agents/simulation-runbook.md
+++ b/docs/agents/simulation-runbook.md
@@ -10,7 +10,7 @@ scripts/sim-orchestrator-switch.sh
 ```
 
 Simulation common rule:
-- `FUGUE_SIM_CODEX_SPARK_ONLY=true` (default) forces simulation to run `codex-main` and codex multi-agent lanes on `gpt-5.3-codex-spark` for faster turnaround.
-- Set `FUGUE_SIM_CODEX_SPARK_ONLY=false` only when main-model parity testing against `gpt-5.4` is explicitly required.
+- `FUGUE_SIM_CODEX_SPARK_ONLY=false` (default) keeps main-model and role-lane diversity so codex-spark rate limits do not stop simulation.
+- Set `FUGUE_SIM_CODEX_SPARK_ONLY=true` only for short, speed-first checks that can tolerate codex-spark quota exhaustion.
 
 Use live rehearsal only when needed and clean up synthetic issues after verification.

--- a/docs/kernel-recovery-runbook.md
+++ b/docs/kernel-recovery-runbook.md
@@ -82,8 +82,8 @@ Required input:
 
 Behavior:
 
-- if the issue already has `tutti` or `processing`, dispatch `fugue-tutti-caller`
-- if the issue has `fugue-task` but not `tutti`, dispatch `fugue-task-router`
+- if the issue has `tutti`, `processing`, or `fugue-task`, dispatch `fugue-caller` with an explicit `issues`/`tutti` replay
+- if the issue lacks `fugue-task`, no recovery dispatch is performed
 
 Recommended inputs:
 
@@ -91,13 +91,28 @@ Recommended inputs:
 - `handoff_target=fugue-bridge` when forcing legacy rollback
 - `subscription_offline_policy_override=continuity`
 
+### `manus-diagnose`
+
+Use when Manus should be checked as a standby recovery lane without spending Manus quota.
+
+Behavior:
+
+- checks whether the Manus client and key resolution path are available
+- writes a diagnosis and recommendations to the workflow summary
+- does not start a live Manus task by default
+
+Recommended input:
+
+- `mode=manus-diagnose`
+
 ## Mobile Recovery Sequence
 
 1. Run `status`
 2. Run `mobile-progress` if you want a phone-friendly thread update
 3. If local runner is unhealthy, run `continuity-canary`
 4. If legacy rollback must remain available, run `rollback-canary`
-5. If a real issue is stuck, run `reroute-issue`
+5. If Manus may be needed as a standby repair lane, run `manus-diagnose`
+6. If a real issue is stuck, run `reroute-issue`
 
 ## Recovery Guarantees
 

--- a/docs/kernel/interfaces/contracts.md
+++ b/docs/kernel/interfaces/contracts.md
@@ -59,8 +59,9 @@ If `GLM` fails:
 
 ### Simulation
 
-- `codex-spark only`
-- if unavailable, `codex-subagent` substitution requires explicit human approval
+- use one codex-spark lane when available
+- keep GLM / main Codex / role-specialist lanes available so codex-spark rate limits do not block simulation
+- require human approval only when the lane count drops below the critical minimum or a paid live provider must be started
 
 ### Implementation / Verification
 

--- a/docs/requirements-codex-main-claude-assist.md
+++ b/docs/requirements-codex-main-claude-assist.md
@@ -157,7 +157,7 @@ Required/optional repo variables:
 - `FUGUE_GEMINI_FALLBACK_MODEL` (optional, default `gemini-3-flash`; Gemini specialist fallback model)
 - `FUGUE_XAI_MODEL` (optional, default `grok-4`; xAI specialist primary model)
 - Runtime model normalization is enforced by `scripts/lib/model-policy.sh` (stale values are auto-corrected to supported latest-track families).
-- `FUGUE_SIM_CODEX_SPARK_ONLY` (`true|false`, default `true`; deterministic simulation common rule to pin both codex-main and codex multi-agent lanes to codex-spark for faster verification)
+- `FUGUE_SIM_CODEX_SPARK_ONLY` (`true|false`, default `false`; optional speed override to pin both codex-main and codex multi-agent lanes to codex-spark for short verification runs)
 - `FUGUE_SIM_CODEX_SPARK_MODEL` (optional, default `gpt-5.3-codex-spark`; spark-family model used when simulation spark-only rule is active)
 - `FUGUE_IMPLEMENT_REFINEMENT_CYCLES` (`1-5`, default `3`; enforce pre-implementation refinement loops)
 - `FUGUE_IMPLEMENT_DIALOGUE_ROUNDS` (`1-5`, default `2`; implementation collaboration rounds)

--- a/scripts/harness/manus-recovery-diagnose.js
+++ b/scripts/harness/manus-recovery-diagnose.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+
+const MANUS_CLIENT_PATH = "/Users/masayuki/.codex/skills/slide/scripts/manus-api-client.js";
+
+function argValue(args, name, fallback = "") {
+  const idx = args.indexOf(name);
+  if (idx < 0) return fallback;
+  return args[idx + 1] || fallback;
+}
+
+function boolEnv(name, fallback = false) {
+  const raw = String(process.env[name] || "").trim().toLowerCase();
+  if (!raw) return fallback;
+  return ["1", "true", "yes", "on"].includes(raw);
+}
+
+function resolveManusAccess() {
+  if (!fs.existsSync(MANUS_CLIENT_PATH)) {
+    return {
+      apiKeyAvailable: false,
+      clientAvailable: false,
+      reason: "manus-client-missing",
+    };
+  }
+  try {
+    const client = require(MANUS_CLIENT_PATH);
+    const key = typeof client.resolveApiKey === "function" ? client.resolveApiKey() : "";
+    return {
+      apiKeyAvailable: Boolean(key),
+      clientAvailable: true,
+      reason: key ? "key-resolved" : "key-missing",
+    };
+  } catch (err) {
+    return {
+      apiKeyAvailable: false,
+      clientAvailable: false,
+      reason: `client-load-failed: ${String(err && err.message ? err.message : err).slice(0, 120)}`,
+    };
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const repo = argValue(args, "--repo", process.env.GITHUB_REPOSITORY || "");
+  const issueNumber = argValue(args, "--issue-number", process.env.RECOVERY_ISSUE_NUMBER || "");
+  const runUrl = argValue(args, "--run-url", "");
+  const execute = args.includes("--execute") || boolEnv("RECOVERY_MANUS_EXECUTE", false);
+  const access = resolveManusAccess();
+
+  const recommendations = [];
+  if (!access.clientAvailable) {
+    recommendations.push("restore-or-install-manus-slide-client-before-routing-live-repair");
+  }
+  if (!access.apiKeyAvailable) {
+    recommendations.push("resolve-manus-api-key-before-spending-repair-budget");
+  }
+  recommendations.push("prefer-github-actions-and-kernel-recovery-for-deterministic-repairs");
+  recommendations.push("use-manus-only-for-novel-diagnosis-or-artifact-synthesis-after-local-tests-fail");
+  recommendations.push("keep-manus-live-execution-manual-until-diagnosis-receipts-are-stable");
+
+  const receipt = {
+    success: true,
+    provider: "manus",
+    mode: "diagnose",
+    execute,
+    liveExecutionStarted: false,
+    clientAvailable: access.clientAvailable,
+    apiKeyAvailable: access.apiKeyAvailable,
+    accessReason: access.reason,
+    input: {
+      repo,
+      issueNumber,
+      runUrl,
+    },
+    recommendations,
+    nextAction: access.apiKeyAvailable
+      ? "keep-manus-standby-and-run-deterministic-kernel-gha-recovery-first"
+      : "fix-manus-key-resolution-before-enabling-any-live-manus-repair",
+  };
+
+  if (execute) {
+    receipt.success = false;
+    receipt.nextAction = "manual-approval-required-for-live-manus-repair";
+    receipt.recommendations.unshift("live-manus-repair-is-intentionally-disabled-in-diagnose-mode");
+  }
+
+  process.stdout.write(`${JSON.stringify(receipt)}\n`);
+  process.exit(receipt.success ? 0 : 2);
+}
+
+main();

--- a/scripts/harness/publish-decision-journal.sh
+++ b/scripts/harness/publish-decision-journal.sh
@@ -47,7 +47,7 @@ ensure_status_issue() {
 }
 
 list_changed_files() {
-  if [[ -n "${before_sha}" && ! "${before_sha}" =~ ^0+$ ]]; then
+  if [[ -n "${before_sha}" && ! "${before_sha}" =~ ^0+$ ]] && git cat-file -e "${before_sha}^{commit}" 2>/dev/null; then
     git diff --name-only "${before_sha}" "${sha}" -- \
       docs/ \
       apps/happy-web/ \

--- a/scripts/harness/run-recovery-console.sh
+++ b/scripts/harness/run-recovery-console.sh
@@ -370,6 +370,41 @@ reroute_issue() {
   append_summary "- no recovery dispatch performed: issue is not labeled \`fugue-task\`"
 }
 
+manus_diagnose() {
+  local receipt run_url api_key_available client_available access_reason next_action live_started
+  run_url="$(current_run_url)"
+
+  append_summary "## Manus Recovery Diagnosis"
+  append_summary ""
+  append_summary "- repository: \`${repo}\`"
+  append_summary "- issue: \`${issue_number:-none}\`"
+  append_summary "- live execution: \`disabled\`"
+  append_summary ""
+
+  receipt="$(
+    node "${SCRIPT_DIR}/manus-recovery-diagnose.js" \
+      --repo "${repo}" \
+      --issue-number "${issue_number}" \
+      --run-url "${run_url}"
+  )"
+  client_available="$(printf '%s' "${receipt}" | jq -r '.clientAvailable')"
+  api_key_available="$(printf '%s' "${receipt}" | jq -r '.apiKeyAvailable')"
+  access_reason="$(printf '%s' "${receipt}" | jq -r '.accessReason')"
+  live_started="$(printf '%s' "${receipt}" | jq -r '.liveExecutionStarted')"
+  next_action="$(printf '%s' "${receipt}" | jq -r '.nextAction')"
+
+  append_summary "- manus client available: \`${client_available}\`"
+  append_summary "- manus api key available: \`${api_key_available}\`"
+  append_summary "- access reason: \`${access_reason}\`"
+  append_summary "- live manus task started: \`${live_started}\`"
+  append_summary "- next action: \`${next_action}\`"
+  append_summary ""
+  append_summary "### Recommendations"
+  while IFS= read -r line; do
+    append_summary "- ${line}"
+  done < <(printf '%s' "${receipt}" | jq -r '.recommendations[]')
+}
+
 case "${mode}" in
   status)
     summarize_status
@@ -385,6 +420,9 @@ case "${mode}" in
     ;;
   reroute-issue)
     reroute_issue
+    ;;
+  manus-diagnose)
+    manus_diagnose
     ;;
   *)
     echo "Unknown RECOVERY_MODE: ${mode}" >&2

--- a/scripts/lib/kernel-compact-artifact.sh
+++ b/scripts/lib/kernel-compact-artifact.sh
@@ -25,6 +25,16 @@ default_run_id() {
 
 RUN_ID="$(default_run_id)"
 
+project_from_run_id() {
+  local run_id="${1:-${RUN_ID}}"
+  awk -F: 'NF >= 6 && $1 == "adhoc" && $3 != "" {print $3}' <<<"${run_id}"
+}
+
+purpose_from_run_id() {
+  local run_id="${1:-${RUN_ID}}"
+  awk -F: 'NF >= 6 && $1 == "adhoc" && $4 != "" {print $4}' <<<"${run_id}"
+}
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -156,6 +166,8 @@ resolve_tmux_session() {
 resolve_codex_thread_title() {
   local existing_json="${1:-}"
   local existing_title=""
+  local existing_project=""
+  local existing_purpose=""
   local session_short_id
   if [[ -n "${existing_json}" ]]; then
     existing_title="$(jq -r '.codex_thread_title // ""' <<<"${existing_json}")"
@@ -163,7 +175,15 @@ resolve_codex_thread_title() {
       printf '%s\n' "${existing_title}"
       return 0
     fi
-    jq -r '(.project // "kernel-workspace") + ":" + (.purpose // "unspecified")' <<<"${existing_json}"
+    existing_project="$(jq -r '.project // ""' <<<"${existing_json}")"
+    existing_purpose="$(jq -r '.purpose // ""' <<<"${existing_json}")"
+    if [[ -z "${existing_project}" ]]; then
+      existing_project="$(project_from_run_id "${RUN_ID}")"
+    fi
+    if [[ -z "${existing_purpose}" ]]; then
+      existing_purpose="$(purpose_from_run_id "${RUN_ID}")"
+    fi
+    printf '%s:%s\n' "${existing_project:-${KERNEL_PROJECT:-kernel-workspace}}" "${existing_purpose:-${KERNEL_PURPOSE:-unspecified}}"
     return 0
   fi
   session_short_id="$(default_session_short_id)"
@@ -234,6 +254,10 @@ consensus_receipt_path() {
 normalize_summary() {
   local raw="${1:-}"
   printf '%s\n' "${raw}" | awk 'NF {print}' | sed -n '1,3p'
+}
+
+bool_env() {
+  [[ "${1:-false}" == "true" ]]
 }
 
 json_array_from_pipe_csv() {
@@ -327,6 +351,10 @@ resolve_phase_artifacts_json() {
   if [[ -n "${existing_json}" ]]; then
     existing_phase_artifacts="$(jq -c '.phase_artifacts // {}' <<<"${existing_json}")"
   fi
+  if bool_env "${KERNEL_COMPACT_PRESERVE_PHASE_ARTIFACTS:-false}"; then
+    printf '%s\n' "${existing_phase_artifacts}"
+    return 0
+  fi
   jq -cn \
     --argjson existing_phase_artifacts "${existing_phase_artifacts}" \
     --arg research_report_path "${research_report_path}" \
@@ -376,10 +404,16 @@ cmd_update() {
     IFS=$'\t' read -r _ep _eu < <(jq -r '[(.project // ""), (.purpose // "")] | @tsv' <<<"${existing_json}")
     existing_project="${_ep}"
     existing_purpose="${_eu}"
+    if [[ -z "${existing_project}" ]]; then
+      existing_project="$(project_from_run_id "${RUN_ID}")"
+    fi
+    if [[ -z "${existing_purpose}" ]]; then
+      existing_purpose="$(purpose_from_run_id "${RUN_ID}")"
+    fi
   else
     existing_json=""
-    existing_project=""
-    existing_purpose=""
+    existing_project="$(project_from_run_id "${RUN_ID}")"
+    existing_purpose="$(purpose_from_run_id "${RUN_ID}")"
   fi
   existing_mode="${KERNEL_MODE:-}"
   existing_blocking_reason=""

--- a/scripts/lib/kernel-run-recovery.sh
+++ b/scripts/lib/kernel-run-recovery.sh
@@ -177,8 +177,8 @@ refresh_compact_artifact() {
       ((.next_action // []) | join("|")),
       ((.decisions // []) | join("|")),
       (.runtime // "kernel"),
-      (.project // "kernel-workspace"),
-      (.purpose // "unspecified"),
+      (.project // ""),
+      (.purpose // ""),
       (.current_phase // "unknown"),
       (.mode // "unknown"),
       (.tmux_session // ""),
@@ -200,6 +200,9 @@ refresh_compact_artifact() {
   KERNEL_NEXT_ACTIONS="${next_actions}" \
   KERNEL_DECISIONS="${decisions}" \
   KERNEL_SUMMARY="${summary}" \
+  KERNEL_COMPACT_PRESERVE_SUMMARY=true \
+  KERNEL_COMPACT_PRESERVE_LAST_EVENT=true \
+  KERNEL_COMPACT_PRESERVE_PHASE_ARTIFACTS=true \
     bash "${COMPACT_SCRIPT}" update recovered_session >/dev/null
 }
 
@@ -288,8 +291,8 @@ cmd_recover() {
       (.tmux_session // ""),
       (.session_fingerprint // ""),
       (.runtime // "kernel"),
-      (.project // "kernel-workspace"),
-      (.purpose // "unspecified")
+      (.project // ""),
+      (.purpose // "")
     ' <<<"${json}"
   )
   session_state="$(ensure_session "${run_id}" "${tmux_session}" "${session_fingerprint}")"

--- a/scripts/lib/watchdog-alert-policy.sh
+++ b/scripts/lib/watchdog-alert-policy.sh
@@ -114,6 +114,27 @@ normalize_state() {
   esac
 }
 
+normalize_state_json() {
+  local raw="${1:-}"
+  local normalized
+  if [[ -z "${raw}" ]]; then
+    raw='{}'
+  fi
+  normalized="$(
+    printf '%s\n' "${raw}" | jq -cs '
+      (map(select(type == "object")) | first // {})
+      | .reason_buckets = (
+          (.reason_buckets // {})
+          | if type == "object" then . else {} end
+        )
+    ' 2>/dev/null
+  )" || normalized='{"reason_buckets":{}}'
+  if [[ -z "${normalized}" ]]; then
+    normalized='{"reason_buckets":{}}'
+  fi
+  printf '%s' "${normalized}"
+}
+
 reason_key() {
   local reason="$1"
   printf '%s' "${reason}" | sed 's/[^A-Za-z0-9._-]/_/g'
@@ -252,14 +273,8 @@ fi
 now_epoch="$(normalize_int "${now_epoch}" "$(date -u +%s)")"
 prev_epoch="$((now_epoch - tick_seconds))"
 
-if ! jq -e . >/dev/null 2>&1 <<<"${previous_state_json}"; then
-  previous_state_json='{}'
-fi
-if ! jq -e '.reason_buckets? // {} | type == "object"' >/dev/null 2>&1 <<<"${previous_state_json}"; then
-  previous_state_json='{}'
-fi
-
-state_json="$(jq -c '.reason_buckets = (.reason_buckets // {})' <<<"${previous_state_json}")"
+previous_state_json="$(normalize_state_json "${previous_state_json}")"
+state_json="${previous_state_json}"
 updated_state_json="${state_json}"
 state_update_required="false"
 
@@ -311,8 +326,8 @@ maybe_mark_stale_reason() {
     return
   fi
 
-  active_reasons+=("${reason}")
   if (( minutes < 180 )); then
+    active_reasons+=("${reason}")
     return
   fi
 
@@ -321,6 +336,7 @@ maybe_mark_stale_reason() {
     return
   fi
 
+  active_reasons+=("${reason}")
   if is_initial_or_repeat_window "${minutes}" 180 360; then
     due_reasons+=("${reason}")
   fi
@@ -439,6 +455,7 @@ bucket_180_now="$((now_epoch / 10800))"
 bucket_180_prev="$((prev_epoch / 10800))"
 bucket_360_now="$((now_epoch / 21600))"
 bucket_360_prev="$((prev_epoch / 21600))"
+updated_state_json="$(normalize_state_json "${updated_state_json}")"
 
 if [[ "${format}" == "env" ]]; then
   message_base64="$(printf '%s' "${message}" | base64 | tr -d '\n')"

--- a/scripts/lib/watchdog-reconcile-claim-policy.sh
+++ b/scripts/lib/watchdog-reconcile-claim-policy.sh
@@ -44,6 +44,42 @@ normalize_int() {
   fi
 }
 
+normalize_pending_json() {
+  local raw="${1:-[]}"
+  local normalized
+  normalized="$(
+    printf '%s\n' "${raw}" | jq -cs '
+      (map(select(type == "array")) | first // [])
+      | map(select(type == "number" or type == "string"))
+    ' 2>/dev/null
+  )" || normalized='[]'
+  if [[ -z "${normalized}" ]]; then
+    normalized='[]'
+  fi
+  printf '%s' "${normalized}"
+}
+
+normalize_claim_state_json() {
+  local raw="${1:-}"
+  local normalized
+  if [[ -z "${raw}" ]]; then
+    raw='{}'
+  fi
+  normalized="$(
+    printf '%s\n' "${raw}" | jq -cs '
+      (map(select(type == "object")) | first // {})
+      | .claims = (
+          (.claims // {})
+          | if type == "object" then . else {} end
+        )
+    ' 2>/dev/null
+  )" || normalized='{"claims":{}}'
+  if [[ -z "${normalized}" ]]; then
+    normalized='{"claims":{}}'
+  fi
+  printf '%s' "${normalized}"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --pending-json) pending_json="${2:-"[]"}"; shift 2 ;;
@@ -67,6 +103,8 @@ if [[ "${format}" != "json" && "${format}" != "env" ]]; then
   echo "Error: --format must be json|env" >&2
   exit 2
 fi
+pending_json="$(normalize_pending_json "${pending_json}")"
+previous_state_json="$(normalize_claim_state_json "${previous_state_json}")"
 
 policy_json="$(
   jq -cn \

--- a/scripts/sim-orchestrator-switch.sh
+++ b/scripts/sim-orchestrator-switch.sh
@@ -49,7 +49,7 @@ fi
 codex_main_model_default="$(echo "${FUGUE_CODEX_MAIN_MODEL:-gpt-5.4}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
 codex_multi_agent_model_default="$(echo "${FUGUE_CODEX_MULTI_AGENT_MODEL:-gpt-5.3-codex-spark}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
 claude_opus_model_default="$(echo "${FUGUE_CLAUDE_OPUS_MODEL:-claude-sonnet-4-6}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-sim_codex_spark_only="$(echo "${FUGUE_SIM_CODEX_SPARK_ONLY:-true}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+sim_codex_spark_only="$(echo "${FUGUE_SIM_CODEX_SPARK_ONLY:-false}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
 if [[ "${sim_codex_spark_only}" != "false" ]]; then
   sim_codex_spark_only="true"
 fi
@@ -74,8 +74,8 @@ if [[ -x "${model_policy_script}" ]]; then
   codex_multi_agent_model_default="${codex_multi_agent_model}"
   claude_opus_model_default="${claude_model}"
 fi
-# Simulation common rule: keep simulation iterations fast by using codex-spark only
-# unless explicitly disabled.
+# Simulation override: pin both Codex simulation lanes to codex-spark only when
+# explicitly requested. The default keeps main-model and GLM fallback diversity.
 if [[ "${sim_codex_spark_only}" == "true" ]]; then
   codex_main_model_default="${sim_codex_spark_model}"
   codex_multi_agent_model_default="${sim_codex_spark_model}"

--- a/tests/test-kernel-recovery-console.sh
+++ b/tests/test-kernel-recovery-console.sh
@@ -11,6 +11,10 @@ grep -q -- '- mobile-progress' "${WORKFLOW}" || {
   echo "FAIL: kernel-recovery-console workflow missing mobile-progress mode" >&2
   exit 1
 }
+grep -q -- '- manus-diagnose' "${WORKFLOW}" || {
+  echo "FAIL: kernel-recovery-console workflow missing manus-diagnose mode" >&2
+  exit 1
+}
 grep -q 'name: kernel-mobile-progress' "${MOBILE_WORKFLOW}" || {
   echo "FAIL: missing kernel-mobile-progress workflow" >&2
   exit 1
@@ -25,6 +29,14 @@ grep -q 'mobile_progress()' "${SCRIPT}" || {
 }
 grep -q 'ensure_status_issue()' "${SCRIPT}" || {
   echo "FAIL: recovery console script missing status-thread helper" >&2
+  exit 1
+}
+grep -q 'manus_diagnose()' "${SCRIPT}" || {
+  echo "FAIL: recovery console script missing manus_diagnose helper" >&2
+  exit 1
+}
+grep -q 'manus-recovery-diagnose.js' "${SCRIPT}" || {
+  echo "FAIL: manus-diagnose mode should call the Manus diagnosis helper" >&2
   exit 1
 }
 grep -q 'gh issue comment "${status_issue}"' "${SCRIPT}" || {
@@ -110,6 +122,23 @@ grep -q -- '-f trigger_event_name=issues' "${FAKE_GH_LOG}" || {
 }
 grep -q -- '-f trigger_label_name=tutti' "${FAKE_GH_LOG}" || {
   echo "FAIL: reroute-issue runtime should replay explicit tutti label trigger" >&2
+  exit 1
+}
+
+PATH="${FAKE_BIN}:${PATH}" \
+FAKE_GH_LOG="${FAKE_GH_LOG}" \
+GITHUB_REPOSITORY="cursorvers/fugue-orchestrator" \
+GITHUB_STEP_SUMMARY="${FAKE_SUMMARY}" \
+RECOVERY_MODE="manus-diagnose" \
+RECOVERY_ISSUE_NUMBER="123" \
+bash "${SCRIPT}" >/dev/null
+
+grep -q 'Manus Recovery Diagnosis' "${FAKE_SUMMARY}" || {
+  echo "FAIL: manus-diagnose should append a recovery diagnosis summary" >&2
+  exit 1
+}
+grep -q 'live manus task started: `false`' "${FAKE_SUMMARY}" || {
+  echo "FAIL: manus-diagnose must not start a live Manus task by default" >&2
   exit 1
 }
 

--- a/tests/test-watchdog-alert-policy.sh
+++ b/tests/test-watchdog-alert-policy.sh
@@ -223,6 +223,76 @@ assert_field "workflow-dispatch-force-reason" "due_reasons_csv" "manual-force-li
   --now-epoch 11400 \
   --force-line-alert true
 
+total=$((total + 1))
+json_output="$(
+  bash "${SCRIPT}" \
+    --event-name schedule \
+    --persist-state true \
+    --previous-state-json '{not-json' \
+    --now-epoch 11400 \
+    --openai-ok false \
+    --pending-count 2 \
+    --format json
+)" || {
+  echo "FAIL [invalid-previous-state-json-is-normalized]: script exited with error"
+  failed=$((failed + 1))
+  json_output=""
+}
+if [[ -n "${json_output}" ]] && jq -e '.next_state.reason_buckets | type == "object"' >/dev/null <<<"${json_output}"; then
+  echo "PASS [invalid-previous-state-json-is-normalized]"
+  passed=$((passed + 1))
+elif [[ -n "${json_output}" ]]; then
+  echo "FAIL [invalid-previous-state-json-is-normalized]: next_state.reason_buckets is not an object"
+  failed=$((failed + 1))
+fi
+
+total=$((total + 1))
+json_output="$(
+  bash "${SCRIPT}" \
+    --event-name workflow_dispatch \
+    --persist-state true \
+    --previous-state-json '{"message":"Not Found","reason_buckets":{}}{}' \
+    --now-epoch 11400 \
+    --openai-ok true \
+    --zai-ok true \
+    --format json
+)" || {
+  echo "FAIL [concatenated-previous-state-json-is-normalized]: script exited with error"
+  failed=$((failed + 1))
+  json_output=""
+}
+if [[ -n "${json_output}" ]] && jq -e '.next_state.reason_buckets | type == "object"' >/dev/null <<<"${json_output}"; then
+  echo "PASS [concatenated-previous-state-json-is-normalized]"
+  passed=$((passed + 1))
+elif [[ -n "${json_output}" ]]; then
+  echo "FAIL [concatenated-previous-state-json-is-normalized]: next_state.reason_buckets is not an object"
+  failed=$((failed + 1))
+fi
+
+total=$((total + 1))
+json_output="$(
+  bash "${SCRIPT}" \
+    --event-name schedule \
+    --persist-state true \
+    --previous-state-json '{}' \
+    --now-epoch 20000 \
+    --openai-ok true \
+    --zai-ok true \
+    --mainframe-stale true \
+    --mainframe-hours 3 \
+    --mainframe-minutes 186 \
+    --mainframe-pending-count 3 \
+    --format json
+)"
+mainframe_active_count="$(jq -r '[.active_reasons[] | select(. == "mainframe-stale")] | length' <<<"${json_output}")"
+if [[ "${mainframe_active_count}" == "1" ]]; then
+  echo "PASS [persisted-stale-active-reason-is-not-duplicated]"
+  passed=$((passed + 1))
+else
+  echo "FAIL [persisted-stale-active-reason-is-not-duplicated]: count=${mainframe_active_count}"
+  failed=$((failed + 1))
+fi
+
 echo ""
 echo "=== Results: ${passed}/${total} passed, ${failed} failed ==="
 

--- a/tests/test-watchdog-alert-routing.sh
+++ b/tests/test-watchdog-alert-routing.sh
@@ -67,4 +67,19 @@ grep -Fq 'Discord system webhook did not confirm delivery' "${WORKFLOW}" || {
   exit 1
 }
 
+grep -Fq 'watchdog_alert_next_state_b64=' "${WORKFLOW}" || {
+  echo "FAIL: fugue-watchdog should pass persisted alert state through base64 GITHUB_OUTPUT" >&2
+  exit 1
+}
+
+grep -Fq 'base64 -d | jq -c' "${WORKFLOW}" || {
+  echo "FAIL: fugue-watchdog should decode and validate persisted alert state before gh variable set" >&2
+  exit 1
+}
+
+if grep -Fq 'watchdog_alert_next_state_json=' "${WORKFLOW}"; then
+  echo "FAIL: fugue-watchdog must not write raw JSON state directly to GITHUB_OUTPUT" >&2
+  exit 1
+fi
+
 echo "PASS [watchdog-alert-routing]"

--- a/tests/test-watchdog-reconcile-claim-policy.sh
+++ b/tests/test-watchdog-reconcile-claim-policy.sh
@@ -46,6 +46,8 @@ assert_case "suppresses-unexpired-claim" '[101,102]' '{"claims":{"101":{"issue_n
 assert_case "reclaims-stale-claim" '[101]' '{"claims":{"101":{"issue_number":101,"claimed_at":100,"expires_at":150,"source":"watchdog-reconcile","status":"claimed"}}}' '[101]' '1'
 assert_case "releases-non-pending-claims" '[102]' '{"claims":{"101":{"issue_number":101,"claimed_at":180,"expires_at":240,"source":"watchdog-reconcile","status":"claimed"}}}' '[102]' '1'
 assert_case "releases-all-claims-when-pending-empty" '[]' '{"claims":{"101":{"issue_number":101,"claimed_at":180,"expires_at":240,"source":"watchdog-reconcile","status":"claimed"}}}' '[]' '0'
+assert_case "normalizes-concatenated-missing-variable-state" '[]' '{"message":"Not Found","claims":{}}{}' '[]' '0'
+assert_case "normalizes-invalid-pending-json" '[not-json' '{"claims":{"101":{"issue_number":101,"claimed_at":180,"expires_at":240,"source":"watchdog-reconcile","status":"claimed"}}}' '[]' '0'
 
 echo ""
-echo "=== Results: 5/5 passed, 0 failed ==="
+echo "=== Results: 7/7 passed, 0 failed ==="

--- a/tests/test-watchdog-reconcile-workflow.sh
+++ b/tests/test-watchdog-reconcile-workflow.sh
@@ -31,5 +31,13 @@ grep -Fq 'gh variable set FUGUE_RECONCILE_CLAIM_STATE' "${WORKFLOW}" || {
   echo "FAIL: watchdog workflow missing reconcile claim state persistence" >&2
   exit 1
 }
+grep -Fq 'gh variable get FUGUE_RECONCILE_CLAIM_STATE' "${WORKFLOW}" || {
+  echo "FAIL: watchdog workflow should read reconcile claim state without concatenating gh api 404 JSON" >&2
+  exit 1
+}
+grep -Fq 'next_state_b64=' "${WORKFLOW}" || {
+  echo "FAIL: watchdog workflow should pass reconcile claim state through base64 GITHUB_OUTPUT" >&2
+  exit 1
+}
 
 echo "PASS [watchdog-reconcile-workflow]"


### PR DESCRIPTION
## Summary
- harden fugue-watchdog alert and reconcile state handling against missing/invalid GitHub variables
- add Kernel recovery compact artifact preservation fixes and Manus diagnose mode without live Manus spend
- make codex-spark simulation pinning opt-in and keep GLM/main-model diversity by default
- make decision journal tolerate force-push before SHAs that are absent from shallow checkout

## Validation
- bash tests/test-watchdog-alert-policy.sh
- bash tests/test-watchdog-reconcile-claim-policy.sh
- bash tests/test-watchdog-alert-routing.sh
- bash tests/test-watchdog-reconcile-workflow.sh
- bash tests/test-kernel-run-recovery.sh
- bash tests/test-kernel-recovery-console.sh
- bash tests/test-kernel-runtime-health.sh
- actionlint .github/workflows/fugue-watchdog.yml .github/workflows/kernel-recovery-console.yml .github/workflows/kernel-mobile-progress.yml
- FUGUE_SIM_CODEX_SPARK_ONLY=false bash scripts/sim-orchestrator-switch.sh