### PR TITLE
Add Kernel memory handoff packets

### DIFF
--- a/scripts/codex-kernel-guard.sh
+++ b/scripts/codex-kernel-guard.sh
@@ -72,7 +72,8 @@ Usage:
   codex-kernel-guard.sh doctor --run <run_id>
   codex-kernel-guard.sh recover-run <run_id>
   codex-kernel-guard.sh attach-context <run_id> <reference_path> [label]
-  codex-kernel-guard.sh memory-query [--limit N] [--run <run_id>] [--format <text|json>] <query>
+  codex-kernel-guard.sh memory-query [search [--limit N] [--run <run_id>] [--format <text|json>] <query>]
+  codex-kernel-guard.sh memory-query packet [--run <run_id> | <query>] [--format <text|json>]
   codex-kernel-guard.sh phase-check <phase> [--uiux]
   codex-kernel-guard.sh phase-complete <phase> [--uiux]
   codex-kernel-guard.sh run-complete --summary <text> [--title <text>] [--uiux] [--no-gha] [--dry-run]
@@ -1118,6 +1119,9 @@ cmd_adopt_run() {
 
 cmd_memory_query() {
   ensure_default_env
+  if [[ $# -gt 0 && ( "$1" == "search" || "$1" == "packet" ) ]]; then
+    exec bash "${MEMORY_QUERY_SCRIPT}" "$@"
+  fi
   exec bash "${MEMORY_QUERY_SCRIPT}" search "$@"
 }
 

--- a/scripts/lib/kernel-codex-thread.sh
+++ b/scripts/lib/kernel-codex-thread.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPACT_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-compact-artifact.sh"
+MEMORY_QUERY_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-memory-query.sh"
 CODEX_BIN="${CODEX_BIN:-/opt/homebrew/bin/codex}"
 
 usage() {
@@ -46,7 +47,7 @@ cmd_title() {
 
 cmd_prompt() {
   local run_id="${1:-${RUN_ID}}"
-  local json title summary next_action phase mode runtime
+  local json title summary next_action phase mode runtime handoff_packet
   json="$(compact_json "${run_id}")"
   title="$(jq -r '.codex_thread_title // (.project + ":" + .purpose)' <<<"${json}")"
   summary="$(jq -r '(.summary // []) | join(" || ")' <<<"${json}")"
@@ -54,6 +55,10 @@ cmd_prompt() {
   phase="$(jq -r '.current_phase // "unknown"' <<<"${json}")"
   mode="$(jq -r '.mode // "unknown"' <<<"${json}")"
   runtime="$(jq -r '.runtime // "kernel"' <<<"${json}")"
+  handoff_packet=""
+  if [[ -f "${MEMORY_QUERY_SCRIPT}" ]]; then
+    handoff_packet="$(bash "${MEMORY_QUERY_SCRIPT}" packet --run "${run_id}" --format text 2>/dev/null || true)"
+  fi
   cat <<EOF
 Kernel thread: ${title}
 Continue Kernel run ${run_id}.
@@ -62,6 +67,7 @@ Mode: ${mode}
 Runtime: ${runtime}
 Next action: ${next_action}
 Summary: ${summary}
+${handoff_packet}
 Resume this run as its dedicated Codex thread and continue under the repository Kernel contract.
 EOF
 }

--- a/scripts/lib/kernel-compact-artifact.sh
+++ b/scripts/lib/kernel-compact-artifact.sh
@@ -39,6 +39,7 @@ usage() {
   cat <<'EOF'
 Usage:
   kernel-compact-artifact.sh path [run_id]
+  kernel-compact-artifact.sh packet-path [run_id]
   kernel-compact-artifact.sh update <event> [summary]
   kernel-compact-artifact.sh status [run_id]
 EOF
@@ -54,6 +55,12 @@ artifact_path_for() {
   local run_id="$1"
   mkdir -p "${COMPACT_DIR}"
   printf '%s/%s.json\n' "${COMPACT_DIR}" "$(printf '%s' "${run_id}" | tr '/:' '__')"
+}
+
+packet_path_for() {
+  local run_id="$1"
+  mkdir -p "${COMPACT_DIR}"
+  printf '%s/%s.handoff.json\n' "${COMPACT_DIR}" "$(printf '%s' "${run_id}" | tr '/:' '__')"
 }
 
 default_session_short_id() {
@@ -376,14 +383,60 @@ resolve_phase_artifacts_json() {
     '
 }
 
+resolve_context_reference_json() {
+  local existing_json="${1:-}"
+  local existing_context_reference='{}'
+  local path="${KERNEL_CONTEXT_REFERENCE_PATH:-}"
+  local kind="${KERNEL_CONTEXT_REFERENCE_KIND:-}"
+  local label="${KERNEL_CONTEXT_REFERENCE_LABEL:-}"
+  if [[ -n "${existing_json}" ]]; then
+    existing_context_reference="$(jq -c '.context_reference // {}' <<<"${existing_json}")"
+  fi
+  jq -cn \
+    --argjson existing_context_reference "${existing_context_reference}" \
+    --arg path "${path}" \
+    --arg kind "${kind}" \
+    --arg label "${label}" \
+    '
+      $existing_context_reference
+      + (if $path == "" then {} else {path: $path} end)
+      + (if $kind == "" then {} else {kind: $kind} end)
+      + (if $label == "" then {} else {label: $label} end)
+    '
+}
+
+phase_artifact_focus_key() {
+  case "${1:-}" in
+    plan)
+      printf 'plan_report_path\n'
+      ;;
+    critique)
+      printf 'critic_report_path\n'
+      ;;
+    implement|implementation)
+      printf 'implementation_report_path\n'
+      ;;
+    verify|verification)
+      printf 'verification_report_path\n'
+      ;;
+    *)
+      printf '\n'
+      ;;
+  esac
+}
+
 cmd_path() {
   printf '%s\n' "$(artifact_path_for "${1:-${RUN_ID}}")"
+}
+
+cmd_packet_path() {
+  printf '%s\n' "$(packet_path_for "${1:-${RUN_ID}}")"
 }
 
 cmd_update() {
   local event="${1:-}"
   local summary_input="${2:-${KERNEL_SUMMARY:-}}"
-  local path tmp_file existing_json existing_project existing_purpose
+  local path packet_path tmp_file packet_tmp_file existing_json existing_project existing_purpose
   local tmux_session phase project purpose owner blocking_reason codex_thread_title
   local mode runtime active_models_json decisions_json next_actions_json phase_artifacts_json ledger_compact receipt_compact
   local existing_mode existing_blocking_reason existing_scheduler_state existing_scheduler_reason
@@ -391,6 +444,8 @@ cmd_update() {
   local lifecycle_state
   local session_fingerprint
   local summary normalized_summary
+  local context_reference_json preserve_summary preserve_last_event last_event updated_at
+  local handoff_packet_json handoff_packet_sha256 handoff_focus_key handoff_focus_path
 
   [[ -n "${event}" ]] || {
     echo "event is required" >&2
@@ -536,7 +591,11 @@ cmd_update() {
     active_models_json='[]'
   fi
 
-  if [[ -z "${summary_input}" ]]; then
+  preserve_summary="${KERNEL_COMPACT_PRESERVE_SUMMARY:-false}"
+  preserve_last_event="${KERNEL_COMPACT_PRESERVE_LAST_EVENT:-false}"
+  if bool_env "${preserve_summary}" && [[ -n "${existing_json}" ]]; then
+    summary="$(jq -r '(.summary // []) | join("\n")' <<<"${existing_json}")"
+  elif [[ -z "${summary_input}" ]]; then
     summary="event=${event}; mode=${mode}; phase=${phase}; next=$(jq -r '.[0] // ""' <<<"${next_actions_json}")"
   else
     summary="${summary_input}"
@@ -544,11 +603,63 @@ cmd_update() {
   if [[ -z "${summary}" && -n "${existing_json}" ]]; then
     summary="$(jq -r '(.summary // []) | join("\n")' <<<"${existing_json}")"
   fi
+  if bool_env "${preserve_last_event}" && [[ -n "${existing_json}" ]]; then
+    last_event="$(jq -r '.last_event // ""' <<<"${existing_json}")"
+  else
+    last_event="${event}"
+  fi
   normalized_summary="$(normalize_summary "${summary}")"
   phase_artifacts_json="$(resolve_phase_artifacts_json "${existing_json}")"
+  context_reference_json="$(resolve_context_reference_json "${existing_json}")"
+  updated_at="$(utc_timestamp)"
+  handoff_focus_key="$(phase_artifact_focus_key "${phase}")"
+  handoff_focus_path=""
+  if [[ -n "${handoff_focus_key}" ]]; then
+    handoff_focus_path="$(jq -r --arg key "${handoff_focus_key}" '.[$key] // ""' <<<"${phase_artifacts_json}")"
+  fi
 
   acquire_lock "compact artifact"
   tmp_file="${path}.tmp.$$.$RANDOM"
+  packet_path="$(packet_path_for "${RUN_ID}")"
+  packet_tmp_file="${packet_path}.tmp.$$.$RANDOM"
+  handoff_packet_json="$(jq -cn \
+    --arg kind "kernel-handoff-packet" \
+    --argjson version 1 \
+    --arg run_id "${RUN_ID}" \
+    --arg project "${project}" \
+    --arg purpose "${purpose}" \
+    --arg phase "${phase}" \
+    --arg mode "${mode}" \
+    --arg runtime "${runtime}" \
+    --arg lifecycle_state "${lifecycle_state}" \
+    --arg updated_at "${updated_at}" \
+    --arg next_action "$(jq -r '.[0] // ""' <<<"${next_actions_json}")" \
+    --arg handoff_focus_key "${handoff_focus_key}" \
+    --arg handoff_focus_path "${handoff_focus_path}" \
+    --argjson summary "$(jq -cn --arg summary "${normalized_summary}" '$summary | split("\n") | map(select(length > 0)) | .[:3]')" \
+    --argjson decisions "${decisions_json}" \
+    --argjson context_reference "${context_reference_json}" \
+    '
+      {
+        kind: $kind,
+        version: $version,
+        run_id: $run_id,
+        project: $project,
+        purpose: $purpose,
+        current_phase: $phase,
+        mode: $mode,
+        runtime: $runtime,
+        lifecycle_state: $lifecycle_state,
+        updated_at: $updated_at,
+        next_action: $next_action,
+        summary: $summary,
+        decisions: $decisions
+      }
+      + (if $handoff_focus_key == "" then {} else {phase_artifact_focus: {key: $handoff_focus_key, path: $handoff_focus_path}} end)
+      + (if ($context_reference | length) == 0 then {} else {context_reference: $context_reference} end)
+    ')"
+  printf '%s\n' "${handoff_packet_json}" >"${packet_tmp_file}"
+  handoff_packet_sha256="$(hash_payload "${handoff_packet_json}")"
   jq -n \
     --arg run_id "${RUN_ID}" \
     --arg project "${project}" \
@@ -566,13 +677,16 @@ cmd_update() {
     --arg lifecycle_state "${lifecycle_state}" \
     --arg workspace_receipt_path "${workspace_receipt_path}" \
     --arg consensus_receipt_path "${consensus_receipt_path_value}" \
+    --arg handoff_packet_path "${packet_path}" \
+    --arg handoff_packet_sha256 "${handoff_packet_sha256}" \
     --arg event "${event}" \
-    --arg updated_at "$(utc_timestamp)" \
+    --arg updated_at "${updated_at}" \
     --arg summary "${normalized_summary}" \
     --argjson active_models "${active_models_json}" \
     --argjson decisions "${decisions_json}" \
     --argjson next_action "${next_actions_json}" \
     --argjson phase_artifacts "${phase_artifacts_json}" \
+    --argjson context_reference "${context_reference_json}" \
     '
       {
         run_id: $run_id,
@@ -592,6 +706,8 @@ cmd_update() {
         scheduler_reason: $scheduler_reason,
         workspace_receipt_path: $workspace_receipt_path,
         consensus_receipt_path: $consensus_receipt_path,
+        handoff_packet_path: $handoff_packet_path,
+        handoff_packet_sha256: $handoff_packet_sha256,
         next_action: $next_action,
         decisions: $decisions,
         phase_artifacts: $phase_artifacts,
@@ -599,7 +715,13 @@ cmd_update() {
         last_event: $event,
         updated_at: $updated_at
       }
+      + (if ($context_reference | length) == 0 then {} else {context_reference: $context_reference} end)
     ' >"${tmp_file}"
+  if [[ -n "${last_event}" ]]; then
+    jq --arg last_event "${last_event}" '.last_event = $last_event' "${tmp_file}" >"${tmp_file}.last"
+    mv "${tmp_file}.last" "${tmp_file}"
+  fi
+  mv "${packet_tmp_file}" "${packet_path}"
   mv "${tmp_file}" "${path}"
   sync_tmux_session_metadata "${RUN_ID}" "${tmux_session}" "${project}" "${purpose}" "${runtime}" "${session_fingerprint}"
   cleanup_lock
@@ -638,6 +760,9 @@ cmd_status() {
     "  - scheduler reason: \(.scheduler_reason // "")",
     "  - workspace receipt path: \(.workspace_receipt_path // "")",
     "  - consensus receipt path: \(.consensus_receipt_path // "")",
+    "  - handoff packet path: \(.handoff_packet_path // "")",
+    "  - handoff packet sha256: \(.handoff_packet_sha256 // "")",
+    "  - context reference: \(if ((.context_reference // {}) | length) == 0 then "none" else (((.context_reference.label // .context_reference.kind // "context") + " -> " + (.context_reference.path // ""))) end)",
     "  - phase artifacts: \(if ((.phase_artifacts // {}) | length) == 0 then "none" else ((.phase_artifacts // {}) | keys | join(" | ")) end)",
     "  - next action: \(.next_action | join(" | "))",
     "  - decisions: \(.decisions | join(" | "))",
@@ -652,6 +777,10 @@ case "${cmd}" in
   path)
     shift || true
     cmd_path "$@"
+    ;;
+  packet-path)
+    shift || true
+    cmd_packet_path "$@"
     ;;
   update)
     shift || true

--- a/scripts/lib/kernel-memory-query.sh
+++ b/scripts/lib/kernel-memory-query.sh
@@ -10,18 +10,26 @@ usage() {
   cat <<'EOF'
 Usage:
   kernel-memory-query.sh search [--limit N] [--run <run_id>] [--format <text|json>] <query>
+  kernel-memory-query.sh packet [--run <run_id> | <query>] [--format <text|json>]
 EOF
 }
 
 compact_files() {
   [[ -d "${COMPACT_DIR}" ]] || return 0
-  find "${COMPACT_DIR}" -maxdepth 1 -type f -name '*.json' | sort
+  find "${COMPACT_DIR}" -maxdepth 1 -type f -name '*.json' ! -name '*.handoff.json' | sort
+}
+
+normalize_query() {
+  local value="${1:-}"
+  value="$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')"
+  value="$(printf '%s' "${value}" | sed -E 's/[^a-z0-9]+/ /g; s/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]{2,}/ /g')"
+  printf '%s\n' "${value}"
 }
 
 valid_docs_json() {
   local run_filter="${1:-}"
-  local json path run_id
   local docs=""
+  local path json run_id
 
   while IFS= read -r path; do
     [[ -n "${path}" ]] || continue
@@ -29,7 +37,7 @@ valid_docs_json() {
     [[ -n "${json}" ]] || continue
     jq -e 'type == "object"' <<<"${json}" >/dev/null 2>&1 || continue
     if [[ -n "${run_filter}" ]]; then
-      run_id="$(jq -r '.run_id // ""' <<<"${json}" 2>/dev/null || true)"
+      run_id="$(jq -r '.run_id // ""' <<<"${json}")"
       [[ "${run_id}" == "${run_filter}" ]] || continue
     fi
     json="$(jq -cn --arg path "${path}" --argjson doc "${json}" '$doc + {compact_path: $path}')"
@@ -47,20 +55,11 @@ valid_docs_json() {
   printf '%s\n' "${docs}" | jq -cs '.'
 }
 
-normalize_query() {
-  local value="${1:-}"
-  value="$(printf '%s' "${value}" | tr '[:upper:]' '[:lower:]')"
-  value="$(printf '%s' "${value}" | sed -E 's/[^a-z0-9]+/ /g; s/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]{2,}/ /g')"
-  printf '%s\n' "${value}"
-}
-
 cmd_search_json() {
   local query="${1:?query is required}"
   local limit="${2:-5}"
   local run_filter="${3:-}"
-  local normalized_query
-  local normalized_tokens
-  local docs_json
+  local normalized_query normalized_tokens docs_json
 
   normalized_query="$(normalize_query "${query}")"
   normalized_tokens="$(printf '%s\n' "${normalized_query}" | awk '{count=0; for (i=1; i<=NF; i++) if (length($i) > 1) count++; print count}')"
@@ -129,6 +128,7 @@ cmd_search_json() {
               $phase_artifact_keys,
               .workspace_receipt_path,
               .consensus_receipt_path,
+              .handoff_packet_path,
               $context_reference.path,
               $context_reference.label
             ] | map(norm) | join(" ")) as $haystack
@@ -146,7 +146,10 @@ cmd_search_json() {
               project: (.project // ""),
               purpose: (.purpose // ""),
               phase: phase_value,
+              current_phase: phase_value,
               mode: (.mode // ""),
+              runtime: (.runtime // ""),
+              lifecycle_state: (.lifecycle_state // ""),
               updated_at: (.updated_at // ""),
               score: $score,
               match_stage: (if $exact then "exact" elif $phrase then "phrase" else "token" end),
@@ -158,8 +161,9 @@ cmd_search_json() {
               compact_path: (.compact_path // ""),
               workspace_receipt_path: (.workspace_receipt_path // ""),
               consensus_receipt_path: (.consensus_receipt_path // ""),
-              context_reference_path: ($context_reference.path // ""),
-              context_reference_label: ($context_reference.label // "")
+              handoff_packet_path: (.handoff_packet_path // ""),
+              handoff_packet_sha256: (.handoff_packet_sha256 // ""),
+              context_reference: $context_reference
             }
         ] as $matches
       | {
@@ -201,8 +205,161 @@ cmd_search() {
   jq -r '
     .results
     | to_entries[]
-    | "  - result \(.key + 1): run=\(.value.run_id) | stage=\(.value.match_stage) | score=\(.value.score) | project=\(.value.project) | purpose=\(.value.purpose) | phase=\(.value.phase) | updated_at=\(.value.updated_at) | summary=\((.value.summary // []) | join(" || "))"
+    | "  - result \(.key + 1): run=\(.value.run_id) | stage=\(.value.match_stage) | score=\(.value.score) | project=\(.value.project) | purpose=\(.value.purpose) | phase=\(.value.current_phase) | updated_at=\(.value.updated_at) | summary=\((.value.summary // []) | join(" || "))"
   ' <<<"${json}"
+}
+
+compact_json_for_run() {
+  local run_id="${1:?run id is required}"
+  local docs_json
+  docs_json="$(valid_docs_json "${run_id}")"
+  jq -c '.[0] // {}' <<<"${docs_json}"
+}
+
+packet_json_from_doc() {
+  local doc_json="${1:?doc json is required}"
+  local packet_path packet_json
+  packet_path="$(jq -r '.handoff_packet_path // ""' <<<"${doc_json}")"
+  if [[ -n "${packet_path}" && -f "${packet_path}" ]]; then
+    packet_json="$(jq -c '.' "${packet_path}" 2>/dev/null || true)"
+    if [[ -n "${packet_json}" ]]; then
+      jq -cn \
+        --argjson packet "${packet_json}" \
+        --arg compact_path "$(jq -r '.compact_path // ""' <<<"${doc_json}")" \
+        --arg handoff_packet_path "${packet_path}" \
+        --arg handoff_packet_sha256 "$(jq -r '.handoff_packet_sha256 // ""' <<<"${doc_json}")" \
+        '$packet + {
+          source_compact_path: $compact_path,
+          handoff_packet_path: $handoff_packet_path,
+          handoff_packet_sha256: $handoff_packet_sha256
+        }'
+      return 0
+    fi
+  fi
+
+  jq -cn \
+    --arg kind "kernel-handoff-packet" \
+    --argjson version 1 \
+    --arg run_id "$(jq -r '.run_id // ""' <<<"${doc_json}")" \
+    --arg project "$(jq -r '.project // ""' <<<"${doc_json}")" \
+    --arg purpose "$(jq -r '.purpose // ""' <<<"${doc_json}")" \
+    --arg phase "$(jq -r '.current_phase // ""' <<<"${doc_json}")" \
+    --arg mode "$(jq -r '.mode // ""' <<<"${doc_json}")" \
+    --arg runtime "$(jq -r '.runtime // ""' <<<"${doc_json}")" \
+    --arg lifecycle_state "$(jq -r '.lifecycle_state // ""' <<<"${doc_json}")" \
+    --arg updated_at "$(jq -r '.updated_at // ""' <<<"${doc_json}")" \
+    --arg next_action "$(jq -r '(.next_action // [])[0] // ""' <<<"${doc_json}")" \
+    --arg compact_path "$(jq -r '.compact_path // ""' <<<"${doc_json}")" \
+    --arg handoff_packet_path "$(jq -r '.handoff_packet_path // ""' <<<"${doc_json}")" \
+    --arg handoff_packet_sha256 "$(jq -r '.handoff_packet_sha256 // ""' <<<"${doc_json}")" \
+    --argjson summary "$(jq -c '.summary // []' <<<"${doc_json}")" \
+    --argjson decisions "$(jq -c '.decisions // []' <<<"${doc_json}")" \
+    --argjson context_reference "$(jq -c '.context_reference // {}' <<<"${doc_json}")" \
+    '{
+      kind: $kind,
+      version: $version,
+      run_id: $run_id,
+      project: $project,
+      purpose: $purpose,
+      current_phase: $phase,
+      mode: $mode,
+      runtime: $runtime,
+      lifecycle_state: $lifecycle_state,
+      updated_at: $updated_at,
+      next_action: $next_action,
+      summary: $summary,
+      decisions: $decisions,
+      source_compact_path: $compact_path,
+      handoff_packet_path: $handoff_packet_path,
+      handoff_packet_sha256: $handoff_packet_sha256
+    }
+    + (if ($context_reference | length) == 0 then {} else {context_reference: $context_reference} end)'
+}
+
+render_packet_text() {
+  local packet_json="${1:?packet json is required}"
+  jq -r '
+    "Kernel handoff packet:",
+    "  - run id: \(.run_id)",
+    "  - project: \(.project)",
+    "  - purpose: \(.purpose)",
+    "  - phase: \(.current_phase)",
+    "  - mode: \(.mode)",
+    "  - runtime: \(.runtime)",
+    "  - lifecycle state: \(.lifecycle_state // "unknown")",
+    "  - next action: \(.next_action // "")",
+    "  - summary: \((.summary // []) | join(" || "))",
+    "  - decisions: \((.decisions // []) | join(" | "))",
+    "  - context reference: \(if ((.context_reference // {}) | length) == 0 then "none" else (((.context_reference.label // .context_reference.kind // "context") + " -> " + (.context_reference.path // ""))) end)",
+    "  - packet path: \(.handoff_packet_path // "")",
+    "  - compact path: \(.source_compact_path // "")"
+  ' <<<"${packet_json}"
+}
+
+cmd_packet() {
+  local format="text"
+  local run_filter=""
+  local query=""
+  local doc_json packet_json search_json
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --format)
+        format="${2:-}"
+        case "${format}" in
+          text|json) ;;
+          *)
+            echo "--format must be text or json" >&2
+            exit 2
+            ;;
+        esac
+        shift 2
+        ;;
+      --run)
+        run_filter="${2:-}"
+        [[ -n "${run_filter}" ]] || {
+          echo "--run requires a run id" >&2
+          exit 2
+        }
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        query="${1:-}"
+        shift
+        if [[ $# -gt 0 ]]; then
+          query="${query} $*"
+        fi
+        break
+        ;;
+    esac
+  done
+
+  if [[ -n "${run_filter}" ]]; then
+    doc_json="$(compact_json_for_run "${run_filter}")"
+  else
+    [[ -n "${query}" ]] || {
+      echo "packet requires --run <run_id> or a query" >&2
+      exit 2
+    }
+    search_json="$(cmd_search_json "${query}" 1 "")"
+    doc_json="$(jq -c '.results[0] // {}' <<<"${search_json}")"
+  fi
+
+  [[ "${doc_json}" != "{}" ]] || {
+    echo "no matching run found" >&2
+    exit 1
+  }
+
+  packet_json="$(packet_json_from_doc "${doc_json}")"
+  if [[ "${format}" == "json" ]]; then
+    printf '%s\n' "${packet_json}"
+    return 0
+  fi
+  render_packet_text "${packet_json}"
 }
 
 cmd="${1:-help}"
@@ -247,12 +404,12 @@ case "${cmd}" in
           exit 0
           ;;
         *)
-          if [[ -z "${query}" ]]; then
-            query="$1"
-          else
-            query="${query} $1"
-          fi
+          query="${1:-}"
           shift
+          if [[ $# -gt 0 ]]; then
+            query="${query} $*"
+          fi
+          break
           ;;
       esac
     done
@@ -261,6 +418,10 @@ case "${cmd}" in
       exit 2
     }
     cmd_search "${format}" "${query}" "${limit}" "${run_filter}"
+    ;;
+  packet)
+    shift || true
+    cmd_packet "$@"
     ;;
   help|-h|--help)
     usage

--- a/scripts/local/kernel-handoff-summary.sh
+++ b/scripts/local/kernel-handoff-summary.sh
@@ -44,7 +44,20 @@ while [[ $# -gt 0 ]]; do
 done
 
 latest_compact_path() {
-  ls -t "${COMPACT_DIR}"/*.json 2>/dev/null | head -n 1 || true
+  find "${COMPACT_DIR}" -maxdepth 1 -type f -name '*.json' ! -name '*.handoff.json' -print 2>/dev/null \
+    | while IFS= read -r path; do
+        printf '%s\t%s\n' "$(file_mtime_epoch "${path}")" "${path}"
+      done \
+    | sort -rn \
+    | head -n 1 \
+    | cut -f2-
+}
+
+file_mtime_epoch() {
+  local path="${1:?path is required}"
+  stat -f '%m' "${path}" 2>/dev/null \
+    || stat -c '%Y' "${path}" 2>/dev/null \
+    || printf '0\n'
 }
 
 compact_path_for_run() {
@@ -145,6 +158,8 @@ printf '  - active models: %s\n' "${active_models:-none}"
 printf '  - lifecycle state: %s\n' "$(jq -r '.lifecycle_state // "unknown"' <<<"${compact_json}")"
 printf '  - scheduler state: %s\n' "$(jq -r '.scheduler_state // "unknown"' <<<"${compact_json}")"
 printf '  - scheduler reason: %s\n' "$(jq -r '.scheduler_reason // ""' <<<"${compact_json}")"
+printf '  - handoff packet path: %s\n' "$(jq -r '.handoff_packet_path // ""' <<<"${compact_json}")"
+printf '  - context reference: %s\n' "$(jq -r 'if ((.context_reference // {}) | length) == 0 then "none" else ((.context_reference.label // .context_reference.kind // "context") + " -> " + (.context_reference.path // "")) end' <<<"${compact_json}")"
 printf '  - next action: %s\n' "${next_action}"
 printf '  - phase artifact focus: %s=%s\n' "${focus_key:-none}" "${phase_artifact_focus}"
 printf '  - decisions: %s\n' "${decisions:-none}"

--- a/tests/test-kernel-codex-thread.sh
+++ b/tests/test-kernel-codex-thread.sh
@@ -25,9 +25,20 @@ export KERNEL_BOOTSTRAP_MANIFEST_LANE_COUNT="6"
 export KERNEL_BOOTSTRAP_AGENT_LABELS="true"
 export KERNEL_BOOTSTRAP_SUBAGENT_LABELS="true"
 
+context_reference_path="${TMP_DIR}/context.json"
+cat >"${context_reference_path}" <<'EOF'
+{
+  "kind": "social-post",
+  "post_id": "11"
+}
+EOF
+
 bash "${RECEIPT_SCRIPT}" write 6 codex,glm,gemini-cli normal >/dev/null
 bash "${LEDGER_SCRIPT}" transition healthy "bootstrap-valid" >/dev/null
-bash "${COMPACT_SCRIPT}" update manual_snapshot "Thread-aware recovery ready" >/dev/null
+KERNEL_CONTEXT_REFERENCE_PATH="${context_reference_path}" \
+KERNEL_CONTEXT_REFERENCE_KIND="social-post" \
+KERNEL_CONTEXT_REFERENCE_LABEL="social-post #11" \
+  bash "${COMPACT_SCRIPT}" update manual_snapshot "Thread-aware recovery ready" >/dev/null
 
 title="$(bash "${THREAD_SCRIPT}" title)"
 [[ "${title}" == "fugue-orchestrator:thread separation" ]]
@@ -37,5 +48,7 @@ grep -Fq 'Kernel thread: fugue-orchestrator:thread separation' <<<"${prompt}"
 grep -Fq 'Continue Kernel run thread-test.' <<<"${prompt}"
 grep -Fq 'Runtime: fugue' <<<"${prompt}"
 grep -Fq 'Next action: resume-threaded-implementation' <<<"${prompt}"
+grep -Fq 'Kernel handoff packet:' <<<"${prompt}"
+grep -Fq "context reference: social-post #11 -> ${context_reference_path}" <<<"${prompt}"
 
 echo "kernel codex thread check passed"

--- a/tests/test-kernel-compact-artifact.sh
+++ b/tests/test-kernel-compact-artifact.sh
@@ -32,11 +32,26 @@ export KERNEL_BOOTSTRAP_MANIFEST_LANE_COUNT="6"
 export KERNEL_BOOTSTRAP_AGENT_LABELS="true"
 export KERNEL_BOOTSTRAP_SUBAGENT_LABELS="true"
 
+context_reference_path="${TMP_DIR}/social-context.json"
+cat >"${context_reference_path}" <<'EOF'
+{
+  "kind": "social-post",
+  "post_id": "42",
+  "summary": ["Bounded external context"]
+}
+EOF
+
 KERNEL_TASK_SIZE_TIER="medium" bash "${CONSENSUS_SCRIPT}" record approved vote "compact receipt consensus" >/dev/null
 bash "${RECEIPT_SCRIPT}" write 6 codex,glm,gemini-cli normal >/dev/null
 bash "${LEDGER_SCRIPT}" transition healthy "bootstrap-valid" >/dev/null
 bash "${LEDGER_SCRIPT}" scheduler-state running "live-running" "/tmp/compact-test-workspace.json" >/dev/null
 bash "${COMPACT_SCRIPT}" update manual_snapshot "bootstrap-valid" >/dev/null
+KERNEL_COMPACT_PRESERVE_SUMMARY="true" \
+KERNEL_COMPACT_PRESERVE_LAST_EVENT="true" \
+KERNEL_CONTEXT_REFERENCE_PATH="${context_reference_path}" \
+KERNEL_CONTEXT_REFERENCE_KIND="social-post" \
+KERNEL_CONTEXT_REFERENCE_LABEL="social-post #42" \
+  bash "${COMPACT_SCRIPT}" update manual_snapshot "attach context" >/dev/null
 
 out="$(bash "${COMPACT_SCRIPT}" status)"
 grep -Fq 'present: true' <<<"${out}"
@@ -52,15 +67,24 @@ grep -Fq 'scheduler state: running' <<<"${out}"
 grep -Fq 'scheduler reason: live-running' <<<"${out}"
 grep -Fq 'workspace receipt path: /tmp/compact-test-workspace.json' <<<"${out}"
 grep -Fq "consensus receipt path: ${TMP_DIR}/state/consensus-receipts/compact-test.json" <<<"${out}"
+grep -Fq "handoff packet path: ${KERNEL_COMPACT_DIR}/compact-test.handoff.json" <<<"${out}"
+grep -Fq "context reference: social-post #42 -> ${context_reference_path}" <<<"${out}"
 grep -Fq 'phase artifacts: critic_report_path | plan_report_path' <<<"${out}"
 grep -Fq 'next action: implement-loader' <<<"${out}"
 grep -Fq 'decisions: use-keychain | mirror-github | keep-fugue-untouched' <<<"${out}"
 plan_report_path="$(jq -r '.phase_artifacts.plan_report_path' "${KERNEL_COMPACT_DIR}/compact-test.json")"
 critic_report_path="$(jq -r '.phase_artifacts.critic_report_path' "${KERNEL_COMPACT_DIR}/compact-test.json")"
 lifecycle_state="$(jq -r '.lifecycle_state' "${KERNEL_COMPACT_DIR}/compact-test.json")"
+handoff_packet_path="$(jq -r '.handoff_packet_path' "${KERNEL_COMPACT_DIR}/compact-test.json")"
+context_reference_json="$(jq -c '.context_reference // {}' "${KERNEL_COMPACT_DIR}/compact-test.json")"
 [[ "${plan_report_path}" == "/tmp/kernel-plan.md" ]]
 [[ "${critic_report_path}" == "/tmp/kernel-critic.md" ]]
 [[ "${lifecycle_state}" == "live-running" ]]
+[[ "${handoff_packet_path}" == "${KERNEL_COMPACT_DIR}/compact-test.handoff.json" ]]
+[[ -f "${handoff_packet_path}" ]]
+[[ "${context_reference_json}" == *"${context_reference_path}"* ]]
+grep -Fq '"run_id":"compact-test"' "${handoff_packet_path}"
+grep -Fq '"label":"social-post #42"' "${handoff_packet_path}"
 
 out="$(KERNEL_SUMMARY=$'line1\nline2\nline3\nline4' bash "${COMPACT_SCRIPT}" update manual_snapshot)"
 grep -Fq 'summary: line1 || line2 || line3' <<<"${out}"

--- a/tests/test-kernel-handoff-summary.sh
+++ b/tests/test-kernel-handoff-summary.sh
@@ -24,6 +24,12 @@ cat >"${KERNEL_COMPACT_DIR}/run-one.json" <<'EOF'
   "lifecycle_state": "live-running",
   "scheduler_state": "running",
   "scheduler_reason": "live-running",
+  "handoff_packet_path": "/tmp/run-one.handoff.json",
+  "context_reference": {
+    "kind": "social-post",
+    "label": "social-post #88",
+    "path": "/tmp/run-one-context.json"
+  },
   "next_action": ["verify-implementation"],
   "decisions": ["keep-kernel-sovereign", "bounded-handoff"],
   "phase_artifacts": {
@@ -76,10 +82,21 @@ cat >"${KERNEL_COMPACT_DIR}/run-two.json" <<'EOF'
 }
 EOF
 
+sleep 1
+cat >"${KERNEL_COMPACT_DIR}/run-two.handoff.json" <<'EOF'
+{
+  "kind": "kernel-handoff-packet",
+  "run_id": "run-two",
+  "summary": ["newer packet should not be selected as compact"]
+}
+EOF
+
 out="$(bash "${SCRIPT}" --run-id run-one)"
 grep -Fq 'run id: run-one' <<<"${out}"
 grep -Fq 'phase: implementation' <<<"${out}"
 grep -Fq 'lifecycle state: live-running' <<<"${out}"
+grep -Fq 'handoff packet path: /tmp/run-one.handoff.json' <<<"${out}"
+grep -Fq 'context reference: social-post #88 -> /tmp/run-one-context.json' <<<"${out}"
 grep -Fq 'phase artifact focus: implementation_report_path=/tmp/run-one-implementation.md' <<<"${out}"
 grep -Fq 'workspace receipt path: '"${workspace_receipt}" <<<"${out}"
 grep -Fq 'runtime ledger path: /tmp/kernel/runtime-ledger.json' <<<"${out}"
@@ -95,5 +112,6 @@ grep -Fq 'workspace receipt path: ' <<<"${out}"
 
 out="$(bash "${SCRIPT}")"
 grep -Fq 'run id: run-two' <<<"${out}"
+grep -Fq 'phase: plan' <<<"${out}"
 
 echo "kernel handoff summary check passed"

--- a/tests/test-kernel-memory-query.sh
+++ b/tests/test-kernel-memory-query.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPACT_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-compact-artifact.sh"
+MEMORY_QUERY_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-memory-query.sh"
+LEDGER_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-runtime-ledger.sh"
+RECEIPT_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-bootstrap-receipt.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+export KERNEL_RUN_ID="memory-run"
+export KERNEL_COMPACT_DIR="${TMP_DIR}/compact"
+export KERNEL_RUNTIME_LEDGER_FILE="${TMP_DIR}/runtime-ledger.json"
+export KERNEL_BOOTSTRAP_RECEIPT_DIR="${TMP_DIR}/receipts"
+export KERNEL_PROJECT="fugue-orchestrator"
+export KERNEL_PURPOSE="shared-memory"
+export KERNEL_PHASE="implement"
+export KERNEL_OWNER="codex"
+export KERNEL_TMUX_SESSION="fugue-orchestrator__shared-memory"
+export KERNEL_RUNTIME="kernel"
+export KERNEL_DECISIONS="bounded-handoff|repo-native-first"
+export KERNEL_NEXT_ACTIONS="resume-codex-thread"
+export KERNEL_BOOTSTRAP_ACTIVE_MODELS_CSV="codex,glm,gemini-cli"
+export KERNEL_BOOTSTRAP_MANIFEST_LANE_COUNT="6"
+export KERNEL_BOOTSTRAP_AGENT_LABELS="true"
+export KERNEL_BOOTSTRAP_SUBAGENT_LABELS="true"
+
+context_reference_path="${TMP_DIR}/context.json"
+cat >"${context_reference_path}" <<'EOF'
+{
+  "kind": "social-post",
+  "post_id": "77"
+}
+EOF
+
+bash "${RECEIPT_SCRIPT}" write 6 codex,glm,gemini-cli normal >/dev/null
+bash "${LEDGER_SCRIPT}" transition healthy "bootstrap-valid" >/dev/null
+KERNEL_CONTEXT_REFERENCE_PATH="${context_reference_path}" \
+KERNEL_CONTEXT_REFERENCE_KIND="social-post" \
+KERNEL_CONTEXT_REFERENCE_LABEL="social-post #77" \
+  bash "${COMPACT_SCRIPT}" update manual_snapshot "repo-native bounded handoff" >/dev/null
+
+out="$(bash "${MEMORY_QUERY_SCRIPT}" search --format text "bounded handoff")"
+grep -Fq 'matched runs: 1' <<<"${out}"
+grep -Fq 'run=memory-run' <<<"${out}"
+
+search_json="$(bash "${MEMORY_QUERY_SCRIPT}" search --format json "bounded handoff")"
+[[ "$(jq -r '.results[0].phase' <<<"${search_json}")" == "implement" ]]
+[[ "$(jq -r '.results[0].current_phase' <<<"${search_json}")" == "implement" ]]
+
+packet_json="$(bash "${MEMORY_QUERY_SCRIPT}" packet --run memory-run --format json)"
+grep -Fq '"run_id":"memory-run"' <<<"${packet_json}"
+grep -Fq '"purpose":"shared-memory"' <<<"${packet_json}"
+grep -Fq '"path":"'"${context_reference_path}"'"' <<<"${packet_json}"
+
+packet_text="$(bash "${MEMORY_QUERY_SCRIPT}" packet "repo native" --format text)"
+grep -Fq 'Kernel handoff packet:' <<<"${packet_text}"
+grep -Fq 'run id: memory-run' <<<"${packet_text}"
+grep -Fq "context reference: social-post #77 -> ${context_reference_path}" <<<"${packet_text}"
+
+packet_text_unquoted="$(bash "${MEMORY_QUERY_SCRIPT}" packet repo native --format text)"
+grep -Fq 'Kernel handoff packet:' <<<"${packet_text_unquoted}"
+grep -Fq 'run id: memory-run' <<<"${packet_text_unquoted}"
+
+sentinel="${TMP_DIR}/query-sentinel"
+printf 'keep\n' >"${sentinel}"
+set +e
+bash "${MEMORY_QUERY_SCRIPT}" packet 'repo"; rm -f '"${sentinel}"'; echo "native' --format text >/dev/null 2>&1
+malicious_status=$?
+set -e
+[[ "${malicious_status}" -ne 0 ]]
+[[ -f "${sentinel}" ]]
+
+echo "kernel memory query check passed"


### PR DESCRIPTION
## Summary
- add bounded Kernel handoff packet sidecars to compact artifacts
- expose packet lookup through kernel-memory-query and Codex thread prompts
- preserve existing memory-search compatibility, including phase/current_phase fields and workspace receipt search

## Multi-agent review
- Codex: implementation and local integration validation
- GLM-5.1: code review; fixed Linux stat compatibility and JSON phase backward compatibility
- Gemini CLI: architecture review approved Kernel/FUGUE separation and Claude-free design
- Copilot CLI: read-only review; added malicious query regression coverage
- /vote: Claude-free consensus returned CONDITIONAL, requiring CI pass

## Tests
- bash -n scripts/lib/kernel-memory-query.sh scripts/lib/kernel-compact-artifact.sh scripts/lib/kernel-codex-thread.sh scripts/local/kernel-handoff-summary.sh scripts/codex-kernel-guard.sh
- bash tests/test-kernel-compact-artifact.sh
- bash tests/test-kernel-memory-query.sh
- bash tests/test-kernel-codex-thread.sh
- bash tests/test-kernel-handoff-summary.sh
- bash tests/test-kernel-runtime-health.sh
- bash tests/test-kernel-run-recovery.sh
- bash tests/test-kernel-recovery-console.sh
- bash tests/test-watchdog-alert-policy.sh
- bash tests/test-watchdog-reconcile-claim-policy.sh
- git diff --cached --check