### PR TITLE
Harden watchdog reconcile state persistence

### DIFF
--- a/.github/workflows/fugue-watchdog.yml
+++ b/.github/workflows/fugue-watchdog.yml
@@ -701,13 +701,23 @@ jobs:
           fi
 
           decoded_next_state="$(printf '%s' "${NEXT_STATE_B64:-}" | base64 -d 2>/dev/null || printf '{}')"
-          NEXT_STATE_JSON="$(printf '%s' "${decoded_next_state:-{}}" | jq -c '
-            (if type == "object" then . else {} end)
-            | .claims = ((.claims // {}) | if type == "object" then . else {} end)
-          ')"
+          state_raw="${decoded_next_state:-}"
+          if [[ -z "${state_raw}" ]]; then
+            state_raw='{}'
+          fi
+          failed_raw="${FAILED_ISSUE_NUMBERS_JSON:-}"
+          if [[ -z "${failed_raw}" ]]; then
+            failed_raw='[]'
+          fi
           persist_json="$(jq -cn \
-            --argjson state "${NEXT_STATE_JSON}" \
-            --argjson failed "${FAILED_ISSUE_NUMBERS_JSON}" '
+            --arg state_raw "${state_raw}" \
+            --arg failed_raw "${failed_raw}" '
+              ($state_raw | fromjson? // {}) as $state_raw_json
+              | ($failed_raw | fromjson? // []) as $failed_raw_json
+              | ($state_raw_json | if type == "object" then . else {} end
+                  | .claims = ((.claims // {}) | if type == "object" then . else {} end)) as $state
+              | ($failed_raw_json | if type == "array" then . else [] end) as $failed
+              |
               reduce $failed[] as $issue ($state; .claims |= (del(.[($issue|tostring)])))
             ')"
 

--- a/tests/test-watchdog-reconcile-workflow.sh
+++ b/tests/test-watchdog-reconcile-workflow.sh
@@ -39,5 +39,45 @@ grep -Fq 'next_state_b64=' "${WORKFLOW}" || {
   echo "FAIL: watchdog workflow should pass reconcile claim state through base64 GITHUB_OUTPUT" >&2
   exit 1
 }
+grep -Fq 'fromjson? // {}' "${WORKFLOW}" || {
+  echo "FAIL: watchdog workflow should parse persisted reconcile state defensively" >&2
+  exit 1
+}
+grep -Fq 'fromjson? // []' "${WORKFLOW}" || {
+  echo "FAIL: watchdog workflow should parse failed dispatch list defensively" >&2
+  exit 1
+}
+
+next_state_json='{"claims":{"681":{"issue_number":681,"claimed_at":1776317846,"expires_at":1776319646,"source":"watchdog-reconcile","status":"claimed"},"682":{"issue_number":682,"claimed_at":1776317846,"expires_at":1776319646,"source":"watchdog-reconcile","status":"claimed"}}}'
+NEXT_STATE_B64="$(printf '%s' "${next_state_json}" | base64 | tr -d '\n')"
+FAILED_ISSUE_NUMBERS_JSON='[682]'
+decoded_next_state="$(printf '%s' "${NEXT_STATE_B64:-}" | base64 -d 2>/dev/null || printf '%s' "${NEXT_STATE_B64:-}" | base64 -D 2>/dev/null || printf '{}')"
+state_raw="${decoded_next_state:-}"
+if [[ -z "${state_raw}" ]]; then
+  state_raw='{}'
+fi
+failed_raw="${FAILED_ISSUE_NUMBERS_JSON:-}"
+if [[ -z "${failed_raw}" ]]; then
+  failed_raw='[]'
+fi
+persist_json="$(jq -cn \
+  --arg state_raw "${state_raw}" \
+  --arg failed_raw "${failed_raw}" '
+    ($state_raw | fromjson? // {}) as $state_raw_json
+    | ($failed_raw | fromjson? // []) as $failed_raw_json
+    | ($state_raw_json | if type == "object" then . else {} end
+        | .claims = ((.claims // {}) | if type == "object" then . else {} end)) as $state
+    | ($failed_raw_json | if type == "array" then . else [] end) as $failed
+    |
+    reduce $failed[] as $issue ($state; .claims |= (del(.[($issue|tostring)])))
+  ')"
+[[ "$(printf '%s' "${persist_json}" | jq -r '.claims["681"].status')" == "claimed" ]] || {
+  echo "FAIL: watchdog workflow persist simulation should retain successful claims" >&2
+  exit 1
+}
+[[ "$(printf '%s' "${persist_json}" | jq -r '.claims["682"] // empty')" == "" ]] || {
+  echo "FAIL: watchdog workflow persist simulation should drop failed claims" >&2
+  exit 1
+}
 
 echo "PASS [watchdog-reconcile-workflow]"


### PR DESCRIPTION
## Summary
- parse persisted reconcile state and failed-dispatch lists defensively from raw JSON strings
- avoid Bash default-expansion appending a stray brace to decoded state
- add a workflow-level regression simulation for retaining successful claims and dropping failed claims

## Validation
- actionlint .github/workflows/fugue-watchdog.yml
- bash tests/test-watchdog-reconcile-workflow.sh
- bash tests/test-watchdog-reconcile-claim-policy.sh
- git diff --check