### PR TITLE
Add x-auto quoted-author recovery foundation

### DIFF
--- a/scripts/local/integrations/xauto-blocked-recovery.sh
+++ b/scripts/local/integrations/xauto-blocked-recovery.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="execute"
+DRAFT_RESULT_INPUT=""
+REGISTRY_INPUT=""
+EXTRACT_MODE="${X_AUTO_DRAFT_BLOCKED_RECOVERY_EXTRACT_MODE:-heuristic}"
+GENERATE_MODE="${X_AUTO_DRAFT_BLOCKED_RECOVERY_GENERATE_MODE:-heuristic}"
+ONLY_REASON="${X_AUTO_DRAFT_BLOCKED_RECOVERY_ONLY_REASON:-missing-non-x-primary-source}"
+MAX_CANDIDATES="${X_AUTO_MAX_CANDIDATES:-3}"
+MIN_CHARS="${X_AUTO_MIN_CHARS:-800}"
+RUN_DIR=""
+RECENT_DRAFTS_INPUT="${X_AUTO_DRAFT_RECENT_INPUT:-}"
+RECOVERY_POSTS_SEED_DIR="${X_AUTO_DRAFT_BLOCKED_RECOVERY_POSTS_SEED_DIR:-}"
+FROM_DATE="${X_AUTO_DRAFT_FROM_DATE:-}"
+TO_DATE="${X_AUTO_DRAFT_TO_DATE:-}"
+HANDLE="${X_AUTO_DRAFT_HANDLE:-cursorvers}"
+PYTHON_BIN="${X_AUTO_PYTHON:-python3}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_GENERATOR="${X_AUTO_DRAFT_LOCAL_GENERATOR:-${SCRIPT_DIR}/xauto_generate_drafts_from_registry.py}"
+SYNC_HELPER="${SCRIPT_DIR}/xauto_quoted_author_sync.py"
+
+usage() {
+  cat <<'EOF'
+Usage: xauto-blocked-recovery.sh [options]
+
+Options:
+  --mode <smoke|execute>            Mode passed through to recovery metadata
+  --draft-result-input <path>       Initial xauto_generate_drafts_from_registry result JSON
+  --registry-input <path>           Original registry seed input JSON
+  --extract-mode <mode>             auto|xai|heuristic for recovery extraction
+  --generate-mode <mode>            auto|xai|heuristic for rerun generation
+  --only-reason <reason>            Block reason to target (default: missing-non-x-primary-source)
+  --max-candidates <n>              Candidate limit for rerun
+  --min-chars <n>                   Minimum chars for rerun
+  --run-dir <path>                  Optional run directory for artifacts
+  --recent-drafts-input <path>      Optional recent draft JSON for similarity guard
+  --recovery-posts-seed-dir <path>  Directory of post JSON seeds used to recover primary sources
+  --from-date <YYYY-MM-DD>          Optional date range passthrough
+  --to-date <YYYY-MM-DD>            Optional date range passthrough
+  -h, --help                        Show help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode) MODE="${2:-}"; shift 2 ;;
+    --draft-result-input) DRAFT_RESULT_INPUT="${2:-}"; shift 2 ;;
+    --registry-input) REGISTRY_INPUT="${2:-}"; shift 2 ;;
+    --extract-mode) EXTRACT_MODE="${2:-}"; shift 2 ;;
+    --generate-mode) GENERATE_MODE="${2:-}"; shift 2 ;;
+    --only-reason) ONLY_REASON="${2:-}"; shift 2 ;;
+    --max-candidates) MAX_CANDIDATES="${2:-}"; shift 2 ;;
+    --min-chars) MIN_CHARS="${2:-}"; shift 2 ;;
+    --run-dir) RUN_DIR="${2:-}"; shift 2 ;;
+    --recent-drafts-input) RECENT_DRAFTS_INPUT="${2:-}"; shift 2 ;;
+    --recovery-posts-seed-dir) RECOVERY_POSTS_SEED_DIR="${2:-}"; shift 2 ;;
+    --from-date) FROM_DATE="${2:-}"; shift 2 ;;
+    --to-date) TO_DATE="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ "${MODE}" == "smoke" || "${MODE}" == "execute" ]] || { echo "mode must be smoke|execute" >&2; exit 2; }
+[[ -f "${DRAFT_RESULT_INPUT}" ]] || { echo "missing draft result input: ${DRAFT_RESULT_INPUT}" >&2; exit 1; }
+[[ -f "${REGISTRY_INPUT}" ]] || { echo "missing registry input: ${REGISTRY_INPUT}" >&2; exit 1; }
+[[ -f "${LOCAL_GENERATOR}" ]] || { echo "missing local generator: ${LOCAL_GENERATOR}" >&2; exit 1; }
+[[ -f "${SYNC_HELPER}" ]] || { echo "missing sync helper: ${SYNC_HELPER}" >&2; exit 1; }
+command -v "${PYTHON_BIN}" >/dev/null 2>&1 || { echo "missing python: ${PYTHON_BIN}" >&2; exit 1; }
+if [[ -n "${RECOVERY_POSTS_SEED_DIR}" ]]; then
+  [[ -d "${RECOVERY_POSTS_SEED_DIR}" ]] || { echo "missing recovery posts seed dir: ${RECOVERY_POSTS_SEED_DIR}" >&2; exit 1; }
+fi
+if [[ -n "${RECENT_DRAFTS_INPUT}" ]]; then
+  [[ -f "${RECENT_DRAFTS_INPUT}" ]] || { echo "missing recent drafts input: ${RECENT_DRAFTS_INPUT}" >&2; exit 1; }
+fi
+
+if [[ -n "${RUN_DIR}" ]]; then
+  mkdir -p "${RUN_DIR}"
+else
+  RUN_DIR="$(mktemp -d)"
+fi
+
+MERGED_REGISTRY_PATH="${RUN_DIR}/xauto-blocked-recovery.registry.json"
+RECOVERY_META_PATH="${RUN_DIR}/xauto-blocked-recovery.recovery.json"
+RERUN_RESULT_PATH="${RUN_DIR}/xauto-blocked-recovery.result.json"
+
+RECOVERY_JSON="$("${PYTHON_BIN}" - "${DRAFT_RESULT_INPUT}" "${REGISTRY_INPUT}" "${ONLY_REASON}" "${RECOVERY_POSTS_SEED_DIR}" "${MERGED_REGISTRY_PATH}" "${HANDLE}" "${SCRIPT_DIR}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+draft_result_path = Path(sys.argv[1])
+registry_input_path = Path(sys.argv[2])
+only_reason = sys.argv[3]
+recovery_seed_dir = Path(sys.argv[4]) if sys.argv[4] else None
+merged_registry_path = Path(sys.argv[5])
+self_handle = sys.argv[6]
+script_dir = Path(sys.argv[7])
+
+sys.path.insert(0, str(script_dir))
+import xauto_quoted_author_sync as sync_helper  # noqa: E402
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def dump_json(path: Path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, ensure_ascii=False, indent=2)
+
+
+def normalize_registry(payload):
+    if isinstance(payload, list):
+        return payload, "list"
+    if isinstance(payload, dict) and isinstance(payload.get("records"), list):
+        return payload["records"], "records-object"
+    raise RuntimeError("registry input must be a list or {records:[...]}")
+
+
+def restore_registry(records, shape):
+    if shape == "list":
+        return records
+    return {"records": records}
+
+
+def collect_targets(result_payload):
+    targets = []
+    for item in result_payload.get("blocked", []) or []:
+        if str(item.get("blocked_reason_canonical", "")).strip() != only_reason:
+            continue
+        targets.append(
+            {
+                "draft_id": str(item.get("draft_id", "")).strip(),
+                "source_url": str(item.get("source_url", "")).strip(),
+                "author_handle": str(item.get("quoted_author_handle", "")).strip().lower(),
+            }
+        )
+    if not targets:
+        for item in ((result_payload.get("closeout") or {}).get("backfill_targets", []) or []):
+            source_url = str(item.get("source_url", "")).strip()
+            author_handle = str(item.get("quoted_author_handle", "")).strip().lower()
+            if source_url or author_handle:
+                targets.append(
+                    {
+                        "draft_id": str(item.get("draft_id", "")).strip(),
+                        "source_url": source_url,
+                        "author_handle": author_handle,
+                    }
+                )
+    deduped = []
+    seen = set()
+    for target in targets:
+        key = (target["source_url"], target["author_handle"])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(target)
+    return deduped
+
+
+def build_recovered_records(seed_dir: Path | None):
+    by_source = {}
+    by_author = {}
+    used_files = []
+    if not seed_dir or not seed_dir.exists():
+        return by_source, by_author, used_files
+    for seed_file in sorted(seed_dir.glob("*.json")):
+        posts = sync_helper.load_posts_from_seed(str(seed_file))
+        records = sync_helper.postprocess_records(sync_helper.heuristic_extract(posts, self_handle), posts)
+        if not records:
+            continue
+        used_files.append(seed_file.name)
+        for record in records:
+            source_url = str(record.get("source_url", "")).strip()
+            author_handle = str(record.get("author_handle", "")).strip().lower()
+            primary_url = str((record.get("metadata") or {}).get("primary_source_url", "")).strip()
+            if source_url and primary_url and source_url not in by_source:
+                by_source[source_url] = record
+            if author_handle and primary_url and author_handle not in by_author:
+                by_author[author_handle] = record
+    return by_source, by_author, used_files
+
+
+result_payload = load_json(draft_result_path)
+registry_payload = load_json(registry_input_path)
+registry_records, registry_shape = normalize_registry(registry_payload)
+targets = collect_targets(result_payload)
+recovered_by_source, recovered_by_author, used_files = build_recovered_records(recovery_seed_dir)
+
+patched_count = 0
+recovered_count = 0
+recovery_notes = []
+records = [dict(item) for item in registry_records]
+
+for target in targets:
+    recovered = None
+    if target["source_url"]:
+      recovered = recovered_by_source.get(target["source_url"])
+    if recovered is None and target["author_handle"]:
+      recovered = recovered_by_author.get(target["author_handle"])
+    if recovered is None:
+      recovery_notes.append({"target": target, "status": "unresolved"})
+      continue
+
+    recovered_meta = dict(recovered.get("metadata") or {})
+    primary_url = str(recovered_meta.get("primary_source_url", "")).strip()
+    if not primary_url:
+      recovery_notes.append({"target": target, "status": "missing-primary-source"})
+      continue
+
+    match_index = None
+    for idx, record in enumerate(records):
+      source_url = str(record.get("source_url", "")).strip()
+      author_handle = str(record.get("author_handle", "")).strip().lower()
+      if target["source_url"] and source_url == target["source_url"]:
+        match_index = idx
+        break
+      if target["author_handle"] and author_handle == target["author_handle"]:
+        match_index = idx
+        break
+
+    if match_index is None:
+      records.append(recovered)
+      patched_count += 1
+      recovered_count += 1
+      recovery_notes.append({"target": target, "status": "appended", "primary_source_url": primary_url})
+      continue
+
+    record = dict(records[match_index])
+    metadata = dict(record.get("metadata") or {})
+    metadata["primary_source_url"] = primary_url
+    metadata["primary_source_confidence"] = recovered_meta.get("primary_source_confidence", 0.8)
+    metadata["primary_source_strategy"] = recovered_meta.get("primary_source_strategy", "author-conversation")
+    if recovered_meta.get("source_hash"):
+      metadata["source_hash"] = recovered_meta["source_hash"]
+    if recovered_meta.get("event_hash"):
+      metadata["event_hash"] = recovered_meta["event_hash"]
+    if recovered_meta.get("confidence") is not None:
+      metadata["confidence"] = recovered_meta.get("confidence")
+    record["metadata"] = metadata
+    records[match_index] = record
+    patched_count += 1
+    recovered_count += 1
+    recovery_notes.append({"target": target, "status": "patched", "primary_source_url": primary_url})
+
+merged_registry = restore_registry(records, registry_shape)
+dump_json(merged_registry_path, merged_registry)
+
+summary = {
+    "mode": "blocked-recovery",
+    "attempted_count": len(targets),
+    "recovered_count": recovered_count,
+    "patched_count": patched_count,
+    "seed_files_used": used_files,
+    "notes": recovery_notes,
+    "registry_path": str(merged_registry_path),
+}
+print(json.dumps(summary, ensure_ascii=False))
+PY
+)"
+
+printf '%s\n' "${RECOVERY_JSON}" > "${RECOVERY_META_PATH}"
+
+RERUN_ARGS=(
+  "${PYTHON_BIN}"
+  "${LOCAL_GENERATOR}"
+  --handle "${HANDLE}"
+  --registry-seed-input "${MERGED_REGISTRY_PATH}"
+  --extract-mode "${EXTRACT_MODE}"
+  --generate-mode "${GENERATE_MODE}"
+  --max-candidates "${MAX_CANDIDATES}"
+  --min-chars "${MIN_CHARS}"
+  --registry-dump-output "${RUN_DIR}/xauto-blocked-recovery.registry-dump.json"
+)
+if [[ -n "${RECENT_DRAFTS_INPUT}" ]]; then
+  RERUN_ARGS+=(--recent-drafts-input "${RECENT_DRAFTS_INPUT}")
+fi
+if [[ -n "${FROM_DATE}" ]]; then
+  RERUN_ARGS+=(--from-date "${FROM_DATE}")
+fi
+if [[ -n "${TO_DATE}" ]]; then
+  RERUN_ARGS+=(--to-date "${TO_DATE}")
+fi
+
+RERUN_RESULT="$("${RERUN_ARGS[@]}")"
+printf '%s\n' "${RERUN_RESULT}" > "${RERUN_RESULT_PATH}"
+
+"${PYTHON_BIN}" - "${RECOVERY_META_PATH}" "${RERUN_RESULT_PATH}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+recovery = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+rerun_result = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+json.dump({"recovery": recovery, "rerun_result": rerun_result}, sys.stdout, ensure_ascii=False)
+PY

--- a/scripts/local/integrations/xauto-quoted-author-ensure-schema.sh
+++ b/scripts/local/integrations/xauto-quoted-author-ensure-schema.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="smoke"
+RUN_DIR=""
+PROJECT_REF="${SUPABASE_PROJECT_REF:-}"
+MIGRATION_FILE=""
+
+usage() {
+  cat <<'EOF'
+Usage: xauto-quoted-author-ensure-schema.sh [options]
+
+Options:
+  --mode <smoke|execute>      Verify only or apply migration (default: smoke)
+  --run-dir <path>            Output directory (optional)
+  --project-ref <ref>         Supabase project ref (optional if derivable)
+  --migration-file <path>     SQL file to apply in execute mode
+  -h, --help                  Show help
+
+Environment:
+  SUPABASE_ACCESS_TOKEN       Required for execute mode
+  SUPABASE_SERVICE_ROLE_KEY   Required for verification
+  SUPABASE_URL                Optional; used for verification and ref derivation
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE="${2:-}"
+      shift 2
+      ;;
+    --run-dir)
+      RUN_DIR="${2:-}"
+      shift 2
+      ;;
+    --project-ref)
+      PROJECT_REF="${2:-}"
+      shift 2
+      ;;
+    --migration-file)
+      MIGRATION_FILE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "${MODE}" != "smoke" && "${MODE}" != "execute" ]]; then
+  echo "xauto-quoted-author-ensure-schema: --mode must be smoke|execute" >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DEFAULT_MIGRATION="${ROOT_DIR}/supabase/migrations/20260406193000_x_auto_quoted_author_registry_v1.sql"
+if [[ -z "${MIGRATION_FILE}" ]]; then
+  MIGRATION_FILE="${DEFAULT_MIGRATION}"
+fi
+
+command -v curl >/dev/null 2>&1 || { echo "xauto-quoted-author-ensure-schema: curl is required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "xauto-quoted-author-ensure-schema: jq is required" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "xauto-quoted-author-ensure-schema: python3 is required" >&2; exit 1; }
+[[ -f "${MIGRATION_FILE}" ]] || { echo "xauto-quoted-author-ensure-schema: missing migration file: ${MIGRATION_FILE}" >&2; exit 1; }
+
+derive_project_ref() {
+  if [[ -n "${PROJECT_REF}" ]]; then
+    printf '%s' "${PROJECT_REF}"
+    return 0
+  fi
+  if [[ -n "${SUPABASE_URL:-}" ]]; then
+    python3 - "${SUPABASE_URL}" <<'PY'
+import re
+import sys
+url = sys.argv[1].strip()
+m = re.match(r"https://([a-z0-9]+)\.supabase\.co/?", url)
+print(m.group(1) if m else "")
+PY
+    return 0
+  fi
+  if [[ -n "${SUPABASE_SERVICE_ROLE_KEY:-}" ]]; then
+    python3 - "${SUPABASE_SERVICE_ROLE_KEY}" <<'PY'
+import base64
+import json
+import sys
+token = sys.argv[1]
+parts = token.split(".")
+if len(parts) < 2:
+    print("")
+    raise SystemExit(0)
+payload = parts[1]
+payload += "=" * (-len(payload) % 4)
+try:
+    data = json.loads(base64.urlsafe_b64decode(payload.encode()).decode())
+except Exception:
+    print("")
+    raise SystemExit(0)
+print(data.get("ref", ""))
+PY
+    return 0
+  fi
+  printf '%s' ""
+}
+
+derive_supabase_url() {
+  if [[ -n "${SUPABASE_URL:-}" ]]; then
+    printf '%s' "${SUPABASE_URL}"
+    return 0
+  fi
+  local ref="$1"
+  if [[ -n "${ref}" ]]; then
+    printf 'https://%s.supabase.co' "${ref}"
+    return 0
+  fi
+  printf '%s' ""
+}
+
+run_dir=""
+if [[ -n "${RUN_DIR}" ]]; then
+  mkdir -p "${RUN_DIR}"
+  run_dir="${RUN_DIR}"
+else
+  run_dir="$(mktemp -d)"
+fi
+
+result_path="${run_dir}/xauto-quoted-author-ensure-schema.result.json"
+meta_path="${run_dir}/xauto-quoted-author-ensure-schema.meta"
+verify_path="${run_dir}/xauto-quoted-author-ensure-schema.verify.json"
+apply_path="${run_dir}/xauto-quoted-author-ensure-schema.apply.json"
+
+project_ref="$(derive_project_ref)"
+supabase_url="$(derive_supabase_url "${project_ref}")"
+verify_http="n/a"
+apply_http="n/a"
+status="not-run"
+
+if [[ -n "${supabase_url}" && -n "${SUPABASE_SERVICE_ROLE_KEY:-}" ]]; then
+  verify_http="$(curl -sS -o "${verify_path}" -w '%{http_code}' "${supabase_url}/rest/v1/quoted_authors?select=author_id&limit=1" \
+    -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+    -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}")"
+  if [[ "${verify_http}" == "200" || "${verify_http}" == "206" ]]; then
+    status="schema-present"
+  elif [[ "${verify_http}" == "404" ]]; then
+    status="schema-missing"
+  else
+    status="verify-error"
+  fi
+else
+  status="verify-skipped-missing-creds"
+fi
+
+if [[ "${MODE}" == "execute" && "${status}" == "schema-missing" ]]; then
+  [[ -n "${project_ref}" ]] || { echo "xauto-quoted-author-ensure-schema: project ref unavailable" >&2; exit 1; }
+  [[ -n "${SUPABASE_ACCESS_TOKEN:-}" ]] || { echo "xauto-quoted-author-ensure-schema: SUPABASE_ACCESS_TOKEN is required for execute mode" >&2; exit 1; }
+  sql_body="$(jq -Rs '{query: .}' < "${MIGRATION_FILE}")"
+  apply_http="$(curl -sS -o "${apply_path}" -w '%{http_code}' "https://api.supabase.com/v1/projects/${project_ref}/database/query" \
+    -H "Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}" \
+    -H "Content-Type: application/json" \
+    --data "${sql_body}")"
+  verify_http="$(curl -sS -o "${verify_path}" -w '%{http_code}' "${supabase_url}/rest/v1/quoted_authors?select=author_id&limit=1" \
+    -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+    -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}")"
+  if [[ "${apply_http}" =~ ^20[01]$|^204$ ]] && [[ "${verify_http}" == "200" || "${verify_http}" == "206" ]]; then
+    status="schema-applied"
+  else
+    status="apply-error"
+  fi
+fi
+
+jq -n \
+  --arg mode "${MODE}" \
+  --arg project_ref "${project_ref}" \
+  --arg supabase_url "${supabase_url}" \
+  --arg status "${status}" \
+  --arg verify_http "${verify_http}" \
+  --arg apply_http "${apply_http}" \
+  --arg migration_file "${MIGRATION_FILE}" \
+  '{
+    system: "xauto-quoted-author-ensure-schema",
+    mode: $mode,
+    project_ref: $project_ref,
+    supabase_url: $supabase_url,
+    status: $status,
+    verify_http: $verify_http,
+    apply_http: $apply_http,
+    migration_file: $migration_file
+  }' > "${result_path}"
+
+{
+  echo "system=xauto-quoted-author-ensure-schema"
+  echo "mode=${MODE}"
+  echo "project_ref=${project_ref}"
+  echo "supabase_url=${supabase_url}"
+  echo "status=${status}"
+  echo "verify_http=${verify_http}"
+  echo "apply_http=${apply_http}"
+  echo "migration_file=${MIGRATION_FILE}"
+  echo "result_path=${result_path}"
+} > "${meta_path}"
+
+cat "${result_path}"

--- a/scripts/local/integrations/xauto-quoted-author-sync.sh
+++ b/scripts/local/integrations/xauto-quoted-author-sync.sh
@@ -1,0 +1,710 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="smoke"
+RUN_DIR=""
+SEED_INPUT="${X_AUTO_QUOTED_AUTHOR_SYNC_SEED_INPUT:-}"
+POSTS_SEED_INPUT="${X_AUTO_QUOTED_AUTHOR_SYNC_POSTS_SEED_INPUT:-}"
+X_HANDLE="${X_AUTO_QUOTED_AUTHOR_SYNC_HANDLE:-cursorvers}"
+FETCH_LIMIT="${X_AUTO_QUOTED_AUTHOR_SYNC_LIMIT:-50}"
+FROM_DATE="${X_AUTO_QUOTED_AUTHOR_SYNC_FROM_DATE:-}"
+TO_DATE="${X_AUTO_QUOTED_AUTHOR_SYNC_TO_DATE:-}"
+EXTRACT_MODE="${X_AUTO_QUOTED_AUTHOR_SYNC_EXTRACT_MODE:-auto}" # auto|xai|heuristic
+WRITE_MODE="${X_AUTO_QUOTED_AUTHOR_SYNC_WRITE_MODE:-best-effort}" # off|best-effort|required
+HELPER_SCRIPT=""
+
+usage() {
+  cat <<'EOF'
+Usage: xauto-quoted-author-sync.sh [options]
+
+Options:
+  --mode <smoke|execute>   Run mode (default: smoke)
+  --run-dir <path>         FUGUE run directory (optional)
+  --seed-input <path>      Optional JSON array used for deterministic dry runs
+  --posts-seed-input <path> Optional raw post JSON array for deterministic extraction tests
+  --handle <x-handle>      X handle to inspect (default: cursorvers)
+  --limit <n>              Max post count to inspect when fetching via X API
+  --from-date <YYYY-MM-DD> Optional inclusive start date for X API fetch
+  --to-date <YYYY-MM-DD>   Optional inclusive end date for X API fetch
+  --extract-mode <mode>    auto|xai|heuristic (default: auto)
+  -h, --help               Show help
+
+Environment:
+  X_AUTO_QUOTED_AUTHOR_SYNC_WRITE_MODE=off|best-effort|required
+                           Control whether execute mode attempts Supabase writes.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE="${2:-}"
+      shift 2
+      ;;
+    --run-dir)
+      RUN_DIR="${2:-}"
+      shift 2
+      ;;
+    --seed-input)
+      SEED_INPUT="${2:-}"
+      shift 2
+      ;;
+    --posts-seed-input)
+      POSTS_SEED_INPUT="${2:-}"
+      shift 2
+      ;;
+    --handle)
+      X_HANDLE="${2:-}"
+      shift 2
+      ;;
+    --limit)
+      FETCH_LIMIT="${2:-}"
+      shift 2
+      ;;
+    --from-date)
+      FROM_DATE="${2:-}"
+      shift 2
+      ;;
+    --to-date)
+      TO_DATE="${2:-}"
+      shift 2
+      ;;
+    --extract-mode)
+      EXTRACT_MODE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "${MODE}" != "smoke" && "${MODE}" != "execute" ]]; then
+  echo "Error: --mode must be smoke|execute" >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER_SCRIPT="${ROOT_DIR}/scripts/local/integrations/xauto_quoted_author_sync.py"
+
+command -v curl >/dev/null 2>&1 || { echo "xauto-quoted-author-sync: curl is required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "xauto-quoted-author-sync: jq is required" >&2; exit 1; }
+command -v python3 >/dev/null 2>&1 || { echo "xauto-quoted-author-sync: python3 is required" >&2; exit 1; }
+[[ -f "${HELPER_SCRIPT}" ]] || { echo "xauto-quoted-author-sync: missing helper script: ${HELPER_SCRIPT}" >&2; exit 1; }
+if [[ -n "${SEED_INPUT}" ]]; then
+  [[ -f "${SEED_INPUT}" ]] || { echo "xauto-quoted-author-sync: missing seed input: ${SEED_INPUT}" >&2; exit 1; }
+fi
+if [[ -n "${POSTS_SEED_INPUT}" ]]; then
+  [[ -f "${POSTS_SEED_INPUT}" ]] || { echo "xauto-quoted-author-sync: missing posts seed input: ${POSTS_SEED_INPUT}" >&2; exit 1; }
+fi
+if ! [[ "${FETCH_LIMIT}" =~ ^[0-9]+$ ]] || (( FETCH_LIMIT < 1 )); then
+  echo "xauto-quoted-author-sync: --limit must be an integer >= 1" >&2
+  exit 2
+fi
+if [[ "${EXTRACT_MODE}" != "auto" && "${EXTRACT_MODE}" != "xai" && "${EXTRACT_MODE}" != "heuristic" ]]; then
+  echo "xauto-quoted-author-sync: --extract-mode must be auto|xai|heuristic" >&2
+  exit 2
+fi
+
+to_bool_env() {
+  local v
+  v="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+  if [[ "${v}" == "true" || "${v}" == "1" || "${v}" == "yes" || "${v}" == "on" ]]; then
+    printf '%s' "true"
+  else
+    printf '%s' "false"
+  fi
+}
+
+normalize_url() {
+  local raw="${1:-}"
+  if [[ -z "${raw}" ]]; then
+    printf '%s' ""
+    return 0
+  fi
+  python3 - "${raw}" <<'PY'
+import sys
+from urllib.parse import urlparse, urlunparse
+
+raw = sys.argv[1].strip()
+if not raw:
+    print("")
+    raise SystemExit(0)
+
+parsed = urlparse(raw)
+scheme = (parsed.scheme or "https").lower()
+netloc = parsed.netloc.lower()
+path = parsed.path.rstrip("/")
+if not path:
+    path = "/"
+print(urlunparse((scheme, netloc, path, "", "", "")))
+PY
+}
+
+normalize_handle() {
+  local raw="${1:-}"
+  raw="$(printf '%s' "${raw}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^@+//; s/^[[:space:]]+|[[:space:]]+$//g')"
+  printf '%s' "${raw}"
+}
+
+extract_url_domain() {
+  local raw="${1:-}"
+  python3 - "${raw}" <<'PY'
+import sys
+from urllib.parse import urlparse
+
+raw = sys.argv[1].strip()
+if not raw:
+    print("")
+    raise SystemExit(0)
+
+parsed = urlparse(raw)
+print((parsed.netloc or "").lower())
+PY
+}
+
+uuid5_from_text() {
+  local namespace="$1"
+  local value="$2"
+  python3 - "${namespace}" "${value}" <<'PY'
+import sys
+import uuid
+
+namespace = uuid.UUID(sys.argv[1])
+value = sys.argv[2]
+print(str(uuid.uuid5(namespace, value)))
+PY
+}
+
+derive_project_ref_from_service_role() {
+  local token="${SUPABASE_SERVICE_ROLE_KEY:-}"
+  if [[ -z "${token}" ]]; then
+    printf '%s' ""
+    return 0
+  fi
+  python3 - "${token}" <<'PY'
+import base64
+import json
+import sys
+
+token = sys.argv[1]
+parts = token.split(".")
+if len(parts) < 2:
+    print("")
+    raise SystemExit(0)
+payload = parts[1]
+payload += "=" * (-len(payload) % 4)
+try:
+    data = json.loads(base64.urlsafe_b64decode(payload.encode()).decode())
+except Exception:
+    print("")
+    raise SystemExit(0)
+print(data.get("ref", ""))
+PY
+}
+
+derive_supabase_url() {
+  if [[ -n "${SUPABASE_URL:-}" ]]; then
+    printf '%s' "${SUPABASE_URL}"
+    return 0
+  fi
+  local ref
+  ref="$(derive_project_ref_from_service_role)"
+  if [[ -n "${ref}" ]]; then
+    printf 'https://%s.supabase.co' "${ref}"
+    return 0
+  fi
+  printf '%s' ""
+}
+
+postgrest_request() {
+  local method="$1"
+  local url="$2"
+  local payload_file="${3:-}"
+  local prefer="${4:-return=minimal}"
+  local output_file="$5"
+  if [[ -n "${payload_file}" ]]; then
+    curl -sS -o "${output_file}" -w '%{http_code}' -X "${method}" "${url}" \
+      -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+      -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+      -H "Content-Type: application/json" \
+      -H "Prefer: ${prefer}" \
+      --data @"${payload_file}"
+  else
+    curl -sS -o "${output_file}" -w '%{http_code}' -X "${method}" "${url}" \
+      -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+      -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}" \
+      -H "Prefer: ${prefer}"
+  fi
+}
+
+json_escape_sql() {
+  printf "%s" "${1}" | sed "s/'/''/g"
+}
+
+base64_decode() {
+  if base64 --help >/dev/null 2>&1; then
+    base64 --decode
+  else
+    base64 -D
+  fi
+}
+
+seed_json='[]'
+if [[ -n "${SEED_INPUT}" ]]; then
+  seed_json="$(cat "${SEED_INPUT}")"
+else
+  helper_args=(
+    "${HELPER_SCRIPT}"
+    --handle "${X_HANDLE}"
+    --limit "${FETCH_LIMIT}"
+    --extract-mode "${EXTRACT_MODE}"
+  )
+  if [[ -n "${FROM_DATE}" ]]; then
+    helper_args+=(--from-date "${FROM_DATE}")
+  fi
+  if [[ -n "${TO_DATE}" ]]; then
+    helper_args+=(--to-date "${TO_DATE}")
+  fi
+  if [[ -n "${POSTS_SEED_INPUT}" ]]; then
+    helper_args+=(--posts-seed-input "${POSTS_SEED_INPUT}")
+  fi
+  seed_json="$(python3 "${helper_args[@]}")"
+fi
+
+normalized_json="$(
+  printf '%s' "${seed_json}" | jq -c '
+    if type == "array" then . else [] end
+    | map({
+        notion_page_id: (.notion_page_id // ""),
+        cursorvers_post_id: (.cursorvers_post_id // ""),
+        source_url: (.source_url // .url // ""),
+        author_handle: (.author_handle // .canonical_handle // .author // ""),
+        display_name: (.display_name // ""),
+        topic_tags: ((.topic_tags // []) | if type == "array" then map(tostring) else [] end),
+        conclusion_tag: (.conclusion_tag // ""),
+        pattern_tag: (.pattern_tag // ""),
+        metadata: (.metadata // {})
+      })
+    | map(select(.source_url != ""))
+  '
+)"
+
+tmp_dir=""
+if [[ -n "${RUN_DIR}" ]]; then
+  mkdir -p "${RUN_DIR}"
+  tmp_dir="${RUN_DIR}"
+else
+  tmp_dir="$(mktemp -d)"
+fi
+
+result_path="${tmp_dir}/xauto-quoted-author-sync.result.json"
+sql_path="${tmp_dir}/xauto-quoted-author-sync.sql"
+meta_path="${tmp_dir}/xauto-quoted-author-sync.meta"
+bridge_response_path="${tmp_dir}/xauto-quoted-author-sync.bridge.json"
+
+authors_json='[]'
+sources_json='[]'
+events_json='[]'
+AUTHOR_NAMESPACE_UUID="e8c35f15-7f08-4c18-a807-bb349a5c2f9c"
+SOURCE_NAMESPACE_UUID="bd8934d2-a4d0-4714-8b12-0c79de147f97"
+EVENT_NAMESPACE_UUID="2ef52b4d-d770-45a3-8c78-d10b010e9085"
+CURRENT_TS_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+while IFS= read -r item; do
+  source_url="$(printf '%s' "${item}" | jq -r '.source_url // ""')"
+  author_handle="$(printf '%s' "${item}" | jq -r '.author_handle // ""')"
+  display_name="$(printf '%s' "${item}" | jq -r '.display_name // ""')"
+  notion_page_id="$(printf '%s' "${item}" | jq -r '.notion_page_id // ""')"
+  cursorvers_post_id="$(printf '%s' "${item}" | jq -r '.cursorvers_post_id // ""')"
+  event_kind="$(printf '%s' "${item}" | jq -r '.event_kind // (.metadata.event_kind // "discovered")')"
+  conclusion_tag="$(printf '%s' "${item}" | jq -r '.conclusion_tag // ""')"
+  pattern_tag="$(printf '%s' "${item}" | jq -r '.pattern_tag // ""')"
+  topic_tags="$(printf '%s' "${item}" | jq -c '.topic_tags // []')"
+  metadata="$(printf '%s' "${item}" | jq -c '.metadata // {}')"
+
+  normalized_source_url="$(normalize_url "${source_url}")"
+  normalized_handle="$(normalize_handle "${author_handle}")"
+
+  source_hash="$(printf '%s' "${normalized_source_url}" | shasum -a 256 | awk '{print $1}')"
+  if [[ -n "${normalized_handle}" ]]; then
+    author_key="$(printf '%s' "x:${normalized_handle}" | shasum -a 256 | awk '{print $1}')"
+  else
+    author_key="$(printf '%s' "x:unknown:${source_hash}" | shasum -a 256 | awk '{print $1}')"
+  fi
+  author_id="$(uuid5_from_text "${AUTHOR_NAMESPACE_UUID}" "${author_key}")"
+  source_id="$(uuid5_from_text "${SOURCE_NAMESPACE_UUID}" "${source_hash}")"
+  event_hash="$(printf '%s' "${event_kind}|${notion_page_id}|${cursorvers_post_id}|${source_hash}|${author_key}|${conclusion_tag}|${pattern_tag}" | shasum -a 256 | awk '{print $1}')"
+  event_id="$(uuid5_from_text "${EVENT_NAMESPACE_UUID}" "${event_hash}")"
+
+  authors_json="$(
+    jq -c \
+      --arg author_id "${author_id}" \
+      --arg normalized_key "${author_key}" \
+      --arg canonical_handle "${normalized_handle}" \
+      --arg display_name "${display_name}" \
+      --arg current_ts "${CURRENT_TS_UTC}" \
+      '
+        . + [{
+          author_id: $author_id,
+          platform: "x",
+          normalized_key: $normalized_key,
+          canonical_handle: $canonical_handle,
+          display_name: $display_name,
+          last_seen_at: $current_ts
+        }]
+      ' <<< "${authors_json}"
+  )"
+
+  sources_json="$(
+    jq -c \
+      --arg source_id "${source_id}" \
+      --arg normalized_source_url "${normalized_source_url}" \
+      --arg source_hash "${source_hash}" \
+      --arg source_url "${source_url}" \
+      --arg source_domain "$(extract_url_domain "${normalized_source_url}")" \
+      --arg author_id "${author_id}" \
+      --arg author_key "${author_key}" \
+      --argjson metadata "${metadata}" \
+      '
+        . + [{
+          source_id: $source_id,
+          normalized_source_url: $normalized_source_url,
+          source_hash: $source_hash,
+          source_url: $source_url,
+          source_domain: $source_domain,
+          source_type: (if ($normalized_source_url | test("https?://(x|twitter)\\.com/"; "i")) then "x-post" else "external" end),
+          author_id: $author_id,
+          author_key: $author_key,
+          metadata: $metadata
+        }]
+      ' <<< "${sources_json}"
+  )"
+
+  events_json="$(
+    jq -c \
+      --arg event_id "${event_id}" \
+      --arg event_hash "${event_hash}" \
+      --arg notion_page_id "${notion_page_id}" \
+      --arg cursorvers_post_id "${cursorvers_post_id}" \
+      --arg author_id "${author_id}" \
+      --arg author_key "${author_key}" \
+      --arg source_id "${source_id}" \
+      --arg source_hash "${source_hash}" \
+      --arg event_kind "${event_kind}" \
+      --arg conclusion_tag "${conclusion_tag}" \
+      --arg pattern_tag "${pattern_tag}" \
+      --argjson topic_tags "${topic_tags}" \
+      --argjson metadata "${metadata}" \
+      '
+        . + [{
+          event_id: $event_id,
+          event_hash: $event_hash,
+          notion_page_id: $notion_page_id,
+          cursorvers_post_id: $cursorvers_post_id,
+          author_id: $author_id,
+          author_key: $author_key,
+          source_id: $source_id,
+          source_hash: $source_hash,
+          event_kind: $event_kind,
+          topic_tags: $topic_tags,
+          conclusion_tag: $conclusion_tag,
+          pattern_tag: $pattern_tag,
+          metadata: $metadata
+        }]
+      ' <<< "${events_json}"
+  )"
+done < <(printf '%s' "${normalized_json}" | jq -c '.[]')
+
+authors_json="$(printf '%s' "${authors_json}" | jq -c 'unique_by(.normalized_key)')"
+sources_json="$(printf '%s' "${sources_json}" | jq -c 'unique_by(.source_hash)')"
+events_json="$(printf '%s' "${events_json}" | jq -c 'unique_by(.event_hash)')"
+
+jq -n \
+  --arg mode "${MODE}" \
+  --arg issue_title "${FUGUE_ISSUE_TITLE:-}" \
+  --arg issue_url "${FUGUE_ISSUE_URL:-}" \
+  --arg write_mode "${WRITE_MODE}" \
+  --argjson authors "${authors_json}" \
+  --argjson sources "${sources_json}" \
+  --argjson events "${events_json}" \
+  '{
+    system: "x-auto-quoted-author-sync",
+    mode: $mode,
+    write_mode: $write_mode,
+    issue_title: $issue_title,
+    issue_url: $issue_url,
+    authors: $authors,
+    sources: $sources,
+    events: $events
+  }' > "${result_path}"
+
+{
+  printf '%s\n' "-- x-auto quoted author sync generated SQL"
+  printf '%s\n' "-- generated_at_utc: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '%s\n' ""
+  printf '%s' "${authors_json}" | jq -r '.[] | @base64' | while IFS= read -r row; do
+    obj="$(printf '%s' "${row}" | base64_decode)"
+    author_id="$(printf '%s' "${obj}" | jq -r '.author_id')"
+    normalized_key="$(printf '%s' "${obj}" | jq -r '.normalized_key')"
+    canonical_handle="$(printf '%s' "${obj}" | jq -r '.canonical_handle')"
+    display_name="$(printf '%s' "${obj}" | jq -r '.display_name')"
+    printf "insert into public.quoted_authors (author_id, platform, canonical_handle, display_name, normalized_key, first_seen_at, last_seen_at)\n"
+    printf "values ('%s', 'x', '%s', %s, '%s', now(), now())\n" \
+      "$(json_escape_sql "${author_id}")" \
+      "$(json_escape_sql "${canonical_handle}")" \
+      "$([[ -n "${display_name}" ]] && printf "'%s'" "$(json_escape_sql "${display_name}")" || printf "null")" \
+      "$(json_escape_sql "${normalized_key}")"
+    printf "on conflict (platform, normalized_key) do update set canonical_handle = excluded.canonical_handle, display_name = coalesce(excluded.display_name, public.quoted_authors.display_name), last_seen_at = now();\n\n"
+  done
+  printf '%s' "${sources_json}" | jq -r '.[] | @base64' | while IFS= read -r row; do
+    obj="$(printf '%s' "${row}" | base64_decode)"
+    source_id="$(printf '%s' "${obj}" | jq -r '.source_id')"
+    source_url="$(printf '%s' "${obj}" | jq -r '.source_url')"
+    normalized_source_url="$(printf '%s' "${obj}" | jq -r '.normalized_source_url')"
+    source_hash="$(printf '%s' "${obj}" | jq -r '.source_hash')"
+    source_domain="$(printf '%s' "${obj}" | jq -r '.source_domain')"
+    source_type="$(printf '%s' "${obj}" | jq -r '.source_type')"
+    author_id="$(printf '%s' "${obj}" | jq -r '.author_id')"
+    author_key="$(printf '%s' "${obj}" | jq -r '.author_key')"
+    metadata_literal="$(printf '%s' "${obj}" | jq -c '.metadata // {}')"
+    printf "insert into public.quoted_sources (source_id, author_id, source_url, normalized_source_url, source_type, source_domain, source_hash, metadata, created_at)\n"
+    printf "select '%s', a.author_id, '%s', '%s', '%s', %s, '%s', '%s'::jsonb, now()\n" \
+      "$(json_escape_sql "${source_id}")" \
+      "$(json_escape_sql "${source_url}")" \
+      "$(json_escape_sql "${normalized_source_url}")" \
+      "$(json_escape_sql "${source_type}")" \
+      "$([[ -n "${source_domain}" ]] && printf "'%s'" "$(json_escape_sql "${source_domain}")" || printf "null")" \
+      "$(json_escape_sql "${source_hash}")" \
+      "$(json_escape_sql "${metadata_literal}")"
+    printf "from public.quoted_authors a\n"
+    printf "where a.platform = 'x' and a.normalized_key = '%s'\n" "$(json_escape_sql "${author_key}")"
+    printf "union all\n"
+    printf "select '%s', '%s', '%s', '%s', %s, '%s', '%s'::jsonb, now()\n" \
+      "$(json_escape_sql "${source_id}")" \
+      "$(json_escape_sql "${author_id}")" \
+      "$(json_escape_sql "${source_url}")" \
+      "$(json_escape_sql "${normalized_source_url}")" \
+      "$(json_escape_sql "${source_type}")" \
+      "$([[ -n "${source_domain}" ]] && printf "'%s'" "$(json_escape_sql "${source_domain}")" || printf "null")" \
+      "$(json_escape_sql "${source_hash}")" \
+      "$(json_escape_sql "${metadata_literal}")"
+    printf "where not exists (select 1 from public.quoted_authors a where a.platform = 'x' and a.normalized_key = '%s')\n" "$(json_escape_sql "${author_key}")"
+    printf "on conflict (normalized_source_url) do update set source_url = excluded.source_url, source_domain = coalesce(excluded.source_domain, public.quoted_sources.source_domain), source_type = excluded.source_type, metadata = public.quoted_sources.metadata || excluded.metadata;\n\n"
+  done
+  printf '%s' "${events_json}" | jq -r '.[] | @base64' | while IFS= read -r row; do
+    obj="$(printf '%s' "${row}" | base64_decode)"
+    event_id="$(printf '%s' "${obj}" | jq -r '.event_id')"
+    event_hash="$(printf '%s' "${obj}" | jq -r '.event_hash')"
+    notion_page_id="$(printf '%s' "${obj}" | jq -r '.notion_page_id')"
+    cursorvers_post_id="$(printf '%s' "${obj}" | jq -r '.cursorvers_post_id')"
+    author_id="$(printf '%s' "${obj}" | jq -r '.author_id')"
+    author_key="$(printf '%s' "${obj}" | jq -r '.author_key')"
+    source_id="$(printf '%s' "${obj}" | jq -r '.source_id')"
+    source_hash="$(printf '%s' "${obj}" | jq -r '.source_hash')"
+    event_kind="$(printf '%s' "${obj}" | jq -r '.event_kind')"
+    topic_tags_literal="$(printf '%s' "${obj}" | jq -r '(.topic_tags // []) | @json')"
+    conclusion_tag="$(printf '%s' "${obj}" | jq -r '.conclusion_tag')"
+    pattern_tag="$(printf '%s' "${obj}" | jq -r '.pattern_tag')"
+    metadata_literal="$(printf '%s' "${obj}" | jq -c '.metadata // {}')"
+    printf "insert into public.quote_events (event_id, event_hash, source_id, author_id, notion_page_id, cursorvers_post_id, event_kind, topic_tags, conclusion_tag, pattern_tag, context)\n"
+    printf "select '%s', '%s', s.source_id, a.author_id, %s, %s, '%s', '%s'::jsonb, %s, %s, '%s'::jsonb\n" \
+      "$(json_escape_sql "${event_id}")" \
+      "$(json_escape_sql "${event_hash}")" \
+      "$([[ -n "${notion_page_id}" ]] && printf "'%s'" "$(json_escape_sql "${notion_page_id}")" || printf "null")" \
+      "$([[ -n "${cursorvers_post_id}" ]] && printf "'%s'" "$(json_escape_sql "${cursorvers_post_id}")" || printf "null")" \
+      "$(json_escape_sql "${event_kind}")" \
+      "$(json_escape_sql "${topic_tags_literal}")" \
+      "$([[ -n "${conclusion_tag}" ]] && printf "'%s'" "$(json_escape_sql "${conclusion_tag}")" || printf "null")" \
+      "$([[ -n "${pattern_tag}" ]] && printf "'%s'" "$(json_escape_sql "${pattern_tag}")" || printf "null")" \
+      "$(json_escape_sql "${metadata_literal}")"
+    printf "from public.quoted_sources s\n"
+    printf "left join public.quoted_authors a on a.platform = 'x' and a.normalized_key = '%s'\n" "$(json_escape_sql "${author_key}")"
+    printf "where s.source_hash = '%s' and s.source_id = '%s'\n" "$(json_escape_sql "${source_hash}")" "$(json_escape_sql "${source_id}")"
+    printf "on conflict (event_hash) do nothing;\n\n"
+  done
+} > "${sql_path}"
+
+bridge_status="not-attempted"
+bridge_http="n/a"
+supabase_url="$(derive_supabase_url)"
+schema_probe_http="n/a"
+schema_probe_file="${tmp_dir}/xauto-quoted-author-sync.schema.json"
+authors_payload_path="${tmp_dir}/xauto-quoted-author-sync.authors.payload.json"
+sources_payload_path="${tmp_dir}/xauto-quoted-author-sync.sources.payload.json"
+events_payload_path="${tmp_dir}/xauto-quoted-author-sync.events.payload.json"
+
+printf '%s' "${authors_json}" | jq -c --arg current_ts "${CURRENT_TS_UTC}" '
+  map(
+    {
+      author_id,
+      platform,
+      normalized_key,
+      canonical_handle,
+      display_name,
+      last_seen_at: $current_ts
+    }
+    | with_entries(select(.value != null and .value != ""))
+  )
+' > "${authors_payload_path}"
+
+printf '%s' "${sources_json}" | jq -c '
+  map(
+    {
+      source_id,
+      author_id,
+      source_url,
+      normalized_source_url,
+      source_type,
+      source_domain,
+      source_hash,
+      metadata
+    }
+    | with_entries(select(.value != null and .value != ""))
+  )
+' > "${sources_payload_path}"
+
+printf '%s' "${events_json}" | jq -c '
+  map(
+    {
+      event_id,
+      event_hash,
+      source_id,
+      author_id,
+      notion_page_id,
+      cursorvers_post_id,
+      event_kind,
+      topic_tags,
+      conclusion_tag,
+      pattern_tag,
+      context: .metadata
+    }
+    | with_entries(select(.value != null and .value != ""))
+  )
+' > "${events_payload_path}"
+
+if [[ "${MODE}" == "smoke" ]]; then
+  if [[ -n "${supabase_url}" && -n "${SUPABASE_SERVICE_ROLE_KEY:-}" ]]; then
+    schema_probe_http="$(postgrest_request "GET" "${supabase_url}/rest/v1/quoted_authors?select=author_id&limit=1" "" "return=minimal" "${schema_probe_file}")"
+    bridge_http="${schema_probe_http}"
+    if [[ "${schema_probe_http}" == "200" || "${schema_probe_http}" == "206" ]]; then
+      bridge_status="smoke-ok"
+    elif [[ "${schema_probe_http}" == "404" ]]; then
+      bridge_status="schema-missing"
+    else
+      bridge_status="smoke-error"
+    fi
+  else
+    bridge_status="skipped-missing-creds"
+  fi
+else
+  should_write="false"
+  case "${WRITE_MODE}" in
+    off)
+      should_write="false"
+      ;;
+    best-effort|required)
+      should_write="true"
+      ;;
+    *)
+      echo "xauto-quoted-author-sync: invalid write mode: ${WRITE_MODE}" >&2
+      exit 2
+      ;;
+  esac
+
+  if [[ "${should_write}" == "true" && -n "${supabase_url}" && -n "${SUPABASE_SERVICE_ROLE_KEY:-}" ]]; then
+    schema_probe_http="$(postgrest_request "GET" "${supabase_url}/rest/v1/quoted_authors?select=author_id&limit=1" "" "return=minimal" "${schema_probe_file}")"
+    if [[ "${schema_probe_http}" == "404" ]]; then
+      bridge_status="schema-missing"
+      bridge_http="${schema_probe_http}"
+      cp "${schema_probe_file}" "${bridge_response_path}" 2>/dev/null || true
+      if [[ "${WRITE_MODE}" == "required" ]]; then
+        echo "xauto-quoted-author-sync: required quoted-author schema is missing" >&2
+        exit 1
+      fi
+    else
+      set +e
+      authors_http="$(postgrest_request "POST" "${supabase_url}/rest/v1/quoted_authors?on_conflict=platform,normalized_key" "${authors_payload_path}" "resolution=merge-duplicates,return=minimal" "${tmp_dir}/quoted-authors.write.json")"
+      authors_rc=$?
+      if (( authors_rc == 0 )) && [[ "${authors_http}" =~ ^20[01]$|^204$ ]]; then
+        sources_http="$(postgrest_request "POST" "${supabase_url}/rest/v1/quoted_sources?on_conflict=normalized_source_url" "${sources_payload_path}" "resolution=merge-duplicates,return=minimal" "${tmp_dir}/quoted-sources.write.json")"
+        sources_rc=$?
+      else
+        sources_rc=1
+        sources_http="n/a"
+      fi
+      if (( sources_rc == 0 )) && [[ "${sources_http}" =~ ^20[01]$|^204$ ]]; then
+        events_http="$(postgrest_request "POST" "${supabase_url}/rest/v1/quote_events?on_conflict=event_hash" "${events_payload_path}" "resolution=merge-duplicates,return=minimal" "${tmp_dir}/quote-events.write.json")"
+        events_rc=$?
+      else
+        events_rc=1
+        events_http="n/a"
+      fi
+      set -e
+      jq -n \
+        --arg schema_probe_http "${schema_probe_http}" \
+        --arg authors_http "${authors_http:-n/a}" \
+        --arg sources_http "${sources_http:-n/a}" \
+        --arg events_http "${events_http:-n/a}" \
+        --arg authors_status "$([[ ${authors_rc:-1} -eq 0 ]] && printf ok || printf error)" \
+        --arg sources_status "$([[ ${sources_rc:-1} -eq 0 ]] && printf ok || printf error)" \
+        --arg events_status "$([[ ${events_rc:-1} -eq 0 ]] && printf ok || printf error)" \
+        '{
+          schema_probe_http: $schema_probe_http,
+          authors: {status: $authors_status, http: $authors_http},
+          sources: {status: $sources_status, http: $sources_http},
+          events: {status: $events_status, http: $events_http}
+        }' > "${bridge_response_path}"
+      if (( ${authors_rc:-1} == 0 )) && [[ "${authors_http}" =~ ^20[01]$|^204$ ]] &&
+         (( ${sources_rc:-1} == 0 )) && [[ "${sources_http}" =~ ^20[01]$|^204$ ]] &&
+         (( ${events_rc:-1} == 0 )) && [[ "${events_http}" =~ ^20[01]$|^204$ ]]; then
+        bridge_status="applied"
+        bridge_http="${events_http}"
+      else
+        bridge_status="apply-error"
+        bridge_http="${events_http:-${sources_http:-${authors_http:-n/a}}}"
+        if [[ "${WRITE_MODE}" == "required" ]]; then
+          echo "xauto-quoted-author-sync: required Supabase write failed" >&2
+          exit 1
+        fi
+      fi
+    fi
+  elif [[ "${should_write}" == "true" ]]; then
+    bridge_status="deferred-missing-creds"
+    if [[ "${WRITE_MODE}" == "required" ]]; then
+      echo "xauto-quoted-author-sync: required Supabase credentials are missing" >&2
+      exit 1
+    fi
+  else
+    bridge_status="write-disabled"
+  fi
+fi
+
+{
+  echo "system=x-auto-quoted-author-sync"
+  echo "mode=${MODE}"
+  echo "write_mode=${WRITE_MODE}"
+  echo "seed_input=${SEED_INPUT}"
+  echo "posts_seed_input=${POSTS_SEED_INPUT}"
+  echo "handle=${X_HANDLE}"
+  echo "limit=${FETCH_LIMIT}"
+  echo "from_date=${FROM_DATE}"
+  echo "to_date=${TO_DATE}"
+  echo "extract_mode=${EXTRACT_MODE}"
+  echo "authors_count=$(jq 'length' <<< "${authors_json}")"
+  echo "sources_count=$(jq 'length' <<< "${sources_json}")"
+  echo "events_count=$(jq 'length' <<< "${events_json}")"
+  echo "supabase_url=${supabase_url}"
+  echo "bridge_status=${bridge_status}"
+  echo "bridge_http=${bridge_http}"
+  echo "schema_probe_http=${schema_probe_http}"
+  echo "sql_path=${sql_path}"
+  echo "result_path=${result_path}"
+} > "${meta_path}"
+
+cat "${result_path}"

--- a/scripts/local/integrations/xauto_quoted_author_sync.py
+++ b/scripts/local/integrations/xauto_quoted_author_sync.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+import argparse
+import base64
+import datetime as dt
+import hashlib
+import hmac
+import json
+import os
+import random
+import re
+import string
+import sys
+import time
+import urllib.parse
+import urllib.request
+
+
+SELF_HANDLE_DEFAULT = "cursorvers"
+X_API_BASE = "https://api.x.com/2"
+XAI_BASE = "https://api.x.ai/v1/responses"
+X_STATUS_ID_RE = re.compile(r"https?://(?:x|twitter)\.com/[^/]+/status/(\d+)", re.IGNORECASE)
+PRIMARY_SOURCE_MAX_REF_DEPTH = max(1, int(os.getenv("X_AUTO_PRIMARY_SOURCE_MAX_REF_DEPTH", "4")))
+AUTHOR_THREAD_SCAN_LIMIT = max(20, int(os.getenv("X_AUTO_AUTHOR_THREAD_SCAN_LIMIT", "100")))
+TOPIC_NORMALIZATION_RULES = [
+    ("medical-ai", {"medical ai", "medical-ai", "healthcare ai", "clinical ai"}),
+    ("medical", {"medical", "medicine", "clinical", "healthcare"}),
+    ("ai", {"ai", "artificial intelligence"}),
+    ("governance", {"governance", "governed", "safety", "oversight"}),
+    ("local-llm", {"local llm", "local-llm", "local_llm", "on-prem llm", "onprem llm"}),
+    ("business", {"business", "management", "leadership"}),
+    ("strategy", {"strategy", "strategic"}),
+    ("workflow", {"workflow", "operations", "ops", "process", "productivity"}),
+    ("curiosity", {"curiosity"}),
+    ("vitality", {"vitality"}),
+]
+
+
+def b64url(data: bytes) -> str:
+    return base64.b64encode(data).decode("utf-8")
+
+
+def percent_encode(value: str) -> str:
+    return urllib.parse.quote(value, safe="~")
+
+
+def oauth1_header(method: str, url: str, query_params: dict) -> str:
+    consumer_key = os.getenv("X_API_KEY", "")
+    consumer_secret = os.getenv("X_API_KEY_SECRET", "")
+    token = os.getenv("X_ACCESS_TOKEN", "")
+    token_secret = os.getenv("X_ACCESS_TOKEN_SECRET", "")
+    if not all([consumer_key, consumer_secret, token, token_secret]):
+        raise RuntimeError("missing X API OAuth 1.0a credentials")
+
+    oauth_params = {
+        "oauth_consumer_key": consumer_key,
+        "oauth_nonce": "".join(random.choices(string.ascii_letters + string.digits, k=32)),
+        "oauth_signature_method": "HMAC-SHA1",
+        "oauth_timestamp": str(int(time.time())),
+        "oauth_token": token,
+        "oauth_version": "1.0",
+    }
+    all_params = {**query_params, **oauth_params}
+    param_string = "&".join(
+        f"{percent_encode(str(k))}={percent_encode(str(all_params[k]))}"
+        for k in sorted(all_params.keys())
+    )
+    base_string = "&".join(
+        [
+            method.upper(),
+            percent_encode(url),
+            percent_encode(param_string),
+        ]
+    )
+    signing_key = "&".join([percent_encode(consumer_secret), percent_encode(token_secret)])
+    signature = b64url(hmac.new(signing_key.encode(), base_string.encode(), hashlib.sha1).digest())
+    oauth_params["oauth_signature"] = signature
+    header = "OAuth " + ", ".join(
+        f'{percent_encode(k)}="{percent_encode(v)}"' for k, v in sorted(oauth_params.items())
+    )
+    return header
+
+
+def http_json(method: str, url: str, headers: dict | None = None, body: dict | None = None) -> dict:
+    payload = None
+    if body is not None:
+        payload = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, method=method, headers=headers or {}, data=payload)
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def fetch_user_id(handle: str) -> str:
+    path = f"/users/by/username/{urllib.parse.quote(handle)}"
+    url = X_API_BASE + path
+    auth = oauth1_header("GET", url, {})
+    res = http_json("GET", url, {"Authorization": auth})
+    return res["data"]["id"]
+
+
+def fetch_user_tweets_by_id(user_id: str, limit: int, from_date: str | None, to_date: str | None) -> list[dict]:
+    tweets: list[dict] = []
+    pagination_token = None
+    while len(tweets) < limit:
+        remaining = limit - len(tweets)
+        batch_size = min(100, max(5, remaining))
+        query = {
+            "max_results": str(batch_size),
+            "tweet.fields": "author_id,conversation_id,created_at,entities,referenced_tweets,attachments",
+            "expansions": "referenced_tweets.id",
+            "exclude": "retweets",
+        }
+        if pagination_token:
+            query["pagination_token"] = pagination_token
+        if from_date:
+            query["start_time"] = from_date + "T00:00:00Z"
+        if to_date:
+            query["end_time"] = to_date + "T23:59:59Z"
+
+        url = X_API_BASE + f"/users/{user_id}/tweets?" + urllib.parse.urlencode(query)
+        auth = oauth1_header("GET", X_API_BASE + f"/users/{user_id}/tweets", query)
+        res = http_json("GET", url, {"Authorization": auth})
+        tweets.extend(res.get("data", []))
+        pagination_token = res.get("meta", {}).get("next_token")
+        if not pagination_token:
+            break
+    return tweets[:limit]
+
+
+def fetch_user_tweets(handle: str, limit: int, from_date: str | None, to_date: str | None) -> list[dict]:
+    user_id = fetch_user_id(handle)
+    return fetch_user_tweets_by_id(user_id, limit, from_date, to_date)
+
+
+def fetch_tweets_by_ids(tweet_ids: list[str]) -> dict[str, dict]:
+    resolved: dict[str, dict] = {}
+    chunk_size = 100
+    for i in range(0, len(tweet_ids), chunk_size):
+        chunk = [tweet_id for tweet_id in tweet_ids[i : i + chunk_size] if tweet_id]
+        if not chunk:
+            continue
+        query = {
+            "ids": ",".join(chunk),
+            "tweet.fields": "author_id,conversation_id,created_at,entities,referenced_tweets,attachments",
+            "expansions": "referenced_tweets.id",
+        }
+        url = X_API_BASE + "/tweets?" + urllib.parse.urlencode(query)
+        auth = oauth1_header("GET", X_API_BASE + "/tweets", query)
+        res = http_json("GET", url, {"Authorization": auth})
+        for row in res.get("data", []):
+            if row.get("id"):
+                resolved[row["id"]] = row
+        for row in res.get("includes", {}).get("tweets", []):
+            if row.get("id"):
+                resolved[row["id"]] = row
+    return resolved
+
+
+def parse_status_id(url: str) -> str:
+    match = X_STATUS_ID_RE.search(url or "")
+    return match.group(1) if match else ""
+
+
+def is_x_url(url: str) -> bool:
+    lowered = (url or "").lower()
+    return "x.com/" in lowered or "twitter.com/" in lowered
+
+
+def first_non_x_url(post: dict) -> str:
+    entities = post.get("entities") or {}
+    for url_obj in entities.get("urls", []):
+        candidate = (url_obj.get("expanded_url") or url_obj.get("url") or "").strip()
+        if candidate and not is_x_url(candidate):
+            return candidate
+    return ""
+
+
+def infer_primary_url_from_author_thread(
+    post: dict,
+    post_index: dict[str, dict],
+    timeline_cache: dict[str, list[dict]],
+    timeline_errors: dict[str, str],
+) -> tuple[str, list[str]]:
+    author_id = str(post.get("author_id", "")).strip()
+    conversation_id = str(post.get("conversation_id", "")).strip()
+    post_id = str(post.get("id", "")).strip()
+    if not author_id or not conversation_id:
+        return "", []
+    local_matches = []
+    for candidate in post_index.values():
+        if str(candidate.get("author_id", "")).strip() != author_id:
+            continue
+        if str(candidate.get("conversation_id", "")).strip() != conversation_id:
+            continue
+        candidate_url = first_non_x_url(candidate)
+        if candidate_url:
+            local_matches.append(candidate)
+    if local_matches:
+        local_matches.sort(key=lambda row: (str(row.get("id", "")) != conversation_id, row.get("created_at", "")))
+        for candidate in local_matches:
+            candidate_url = first_non_x_url(candidate)
+            if candidate_url:
+                return candidate_url, ["author-conversation", author_id, conversation_id, str(candidate.get("id", post_id))]
+    if author_id not in timeline_cache:
+        try:
+            timeline_cache[author_id] = fetch_user_tweets_by_id(author_id, AUTHOR_THREAD_SCAN_LIMIT, None, None)
+        except Exception as exc:
+            timeline_cache[author_id] = []
+            timeline_errors[author_id] = str(exc)
+    matches: list[dict] = []
+    for candidate in timeline_cache[author_id]:
+        if str(candidate.get("conversation_id", "")).strip() != conversation_id:
+            continue
+        candidate_url = first_non_x_url(candidate)
+        if candidate_url:
+            matches.append(candidate)
+    if not matches:
+        return "", []
+    matches.sort(key=lambda row: (str(row.get("id", "")) != conversation_id, row.get("created_at", "")))
+    for candidate in matches:
+        candidate_url = first_non_x_url(candidate)
+        if candidate_url:
+            return candidate_url, ["author-conversation", author_id, conversation_id, str(candidate.get("id", post_id))]
+    return "", []
+
+
+def expand_post_index_with_references(
+    seed_post_ids: list[str],
+    post_index: dict[str, dict],
+    max_depth: int,
+) -> tuple[set[str], str]:
+    frontier = {post_id for post_id in seed_post_ids if post_id}
+    fetch_error = ""
+    depth = 0
+    seen = set()
+    while frontier and depth < max_depth:
+        unresolved = set()
+        next_frontier = set()
+        for post_id in frontier:
+            if post_id in seen:
+                continue
+            seen.add(post_id)
+            post = post_index.get(post_id)
+            if not post:
+                unresolved.add(post_id)
+                continue
+            for ref in post.get("referenced_tweets", []) or []:
+                ref_id = str(ref.get("id", "")).strip()
+                if not ref_id:
+                    continue
+                next_frontier.add(ref_id)
+                if ref_id not in post_index:
+                    unresolved.add(ref_id)
+        if unresolved:
+            try:
+                fetched = fetch_tweets_by_ids(sorted(unresolved))
+                post_index.update(fetched)
+            except Exception as exc:
+                fetch_error = str(exc)
+                break
+        frontier = next_frontier
+        depth += 1
+    return seen, fetch_error
+
+
+def enrich_records_with_primary_sources(records: list[dict], posts: list[dict]) -> list[dict]:
+    post_index = {str(post.get("id", "")): post for post in posts if post.get("id")}
+    timeline_cache: dict[str, list[dict]] = {}
+    timeline_errors: dict[str, str] = {}
+    reference_fetch_errors: list[str] = []
+    seed_post_ids: list[str] = []
+    for record in records:
+        source_url = str(record.get("source_url", "")).strip()
+        if source_url and is_x_url(source_url):
+            status_id = parse_status_id(source_url)
+            if status_id:
+                seed_post_ids.append(status_id)
+        cursorvers_post_id = str(record.get("cursorvers_post_id", "")).strip()
+        if cursorvers_post_id:
+            seed_post_ids.append(cursorvers_post_id)
+
+    seen_reference_posts, fetch_ids_error = expand_post_index_with_references(
+        seed_post_ids,
+        post_index,
+        PRIMARY_SOURCE_MAX_REF_DEPTH,
+    )
+    if fetch_ids_error:
+        reference_fetch_errors.append(fetch_ids_error)
+
+    def resolve_primary_url(post_id: str, depth: int, visited: set[str]) -> str:
+        if not post_id or post_id in visited or depth > PRIMARY_SOURCE_MAX_REF_DEPTH:
+            return ""
+        visited.add(post_id)
+        post = post_index.get(post_id)
+        if not post:
+            return ""
+        direct_url = first_non_x_url(post)
+        if direct_url:
+            return direct_url
+        for ref in post.get("referenced_tweets", []) or []:
+            ref_id = str(ref.get("id", "")).strip()
+            resolved = resolve_primary_url(ref_id, depth + 1, visited)
+            if resolved:
+                return resolved
+        return ""
+
+    enriched = []
+    for record in records:
+        metadata = dict(record.get("metadata") or {})
+        source_url = str(record.get("source_url", "")).strip()
+        cursorvers_post_id = str(record.get("cursorvers_post_id", "")).strip()
+        primary_url = ""
+        resolution_path: list[str] = []
+        if source_url and not is_x_url(source_url):
+            primary_url = source_url
+            resolution_path = ["direct-source-url"]
+        else:
+            source_status_id = parse_status_id(source_url)
+            if source_status_id:
+                primary_url = resolve_primary_url(source_status_id, 0, set())
+                if primary_url:
+                    resolution_path = ["quoted-post", source_status_id]
+                else:
+                    source_post = post_index.get(source_status_id)
+                    if source_post:
+                        inferred_url, inferred_path = infer_primary_url_from_author_thread(
+                            source_post,
+                            post_index,
+                            timeline_cache,
+                            timeline_errors,
+                        )
+                        if inferred_url:
+                            primary_url = inferred_url
+                            resolution_path = inferred_path
+            if not primary_url and cursorvers_post_id:
+                primary_url = resolve_primary_url(cursorvers_post_id, 0, set())
+                if primary_url:
+                    resolution_path = ["cursorvers-post", cursorvers_post_id]
+                else:
+                    source_post = post_index.get(cursorvers_post_id)
+                    if source_post:
+                        inferred_url, inferred_path = infer_primary_url_from_author_thread(
+                            source_post,
+                            post_index,
+                            timeline_cache,
+                            timeline_errors,
+                        )
+                        if inferred_url:
+                            primary_url = inferred_url
+                            resolution_path = inferred_path
+        recovery_errors: list[str] = []
+        source_status_id = parse_status_id(source_url)
+        if fetch_ids_error and ((source_status_id and source_status_id in seen_reference_posts) or (cursorvers_post_id and cursorvers_post_id in seen_reference_posts)):
+            recovery_errors.append("fetch-referenced-posts-failed")
+        if source_status_id:
+            source_post = post_index.get(source_status_id)
+            source_author_id = str((source_post or {}).get("author_id", "")).strip()
+            if source_author_id and source_author_id in timeline_errors:
+                recovery_errors.append("fetch-author-thread-failed")
+        if cursorvers_post_id:
+            cursorvers_post = post_index.get(cursorvers_post_id)
+            cursorvers_author_id = str((cursorvers_post or {}).get("author_id", "")).strip()
+            if cursorvers_author_id and cursorvers_author_id in timeline_errors:
+                recovery_errors.append("fetch-author-thread-failed")
+        if primary_url:
+            metadata["primary_source_url"] = primary_url
+            metadata["source_resolution_path"] = resolution_path
+            metadata["primary_source_evidence_post_id"] = resolution_path[-1] if resolution_path else ""
+            if resolution_path[:1] == ["direct-source-url"]:
+                metadata["primary_source_strategy"] = "direct"
+                metadata["primary_source_confidence"] = 1.0
+            elif resolution_path[:1] == ["quoted-post"]:
+                metadata["primary_source_strategy"] = "quoted-reference"
+                metadata["primary_source_confidence"] = 0.92
+            elif resolution_path[:1] == ["author-conversation"]:
+                metadata["primary_source_strategy"] = "author-conversation"
+                metadata["primary_source_confidence"] = 0.78
+            else:
+                metadata["primary_source_strategy"] = "cursorvers-reference"
+                metadata["primary_source_confidence"] = 0.74
+        if recovery_errors:
+            metadata["source_recovery_errors"] = sorted(set(recovery_errors))
+        record_with_meta = dict(record)
+        record_with_meta["metadata"] = metadata
+        enriched.append(record_with_meta)
+    return enriched
+
+
+def heuristic_extract(posts: list[dict], self_handle: str) -> list[dict]:
+    url_pattern = re.compile(r"https?://[^\s)]+")
+    records = []
+    for post in posts:
+        text = post.get("text", "")
+        entities = post.get("entities") or {}
+        urls = [u.get("expanded_url") or u.get("url") for u in entities.get("urls", []) if u.get("expanded_url") or u.get("url")]
+        if not urls:
+            urls = url_pattern.findall(text)
+        mentions = [m.get("username", "") for m in entities.get("mentions", []) if m.get("username")]
+        author_handle = ""
+        for mention in mentions:
+            if mention.lower() != self_handle.lower():
+                author_handle = mention
+                break
+        for source_url in urls:
+            records.append(
+                {
+                    "cursorvers_post_id": post.get("id", ""),
+                    "source_url": source_url,
+                    "author_handle": author_handle,
+                    "display_name": "",
+                    "topic_tags": [],
+                    "conclusion_tag": "",
+                    "pattern_tag": "",
+                    "metadata": {
+                        "extractor": "heuristic",
+                        "post_created_at": post.get("created_at", ""),
+                    },
+                }
+            )
+    return records
+
+
+def normalize_topic_tags(tags: list[str]) -> list[str]:
+    normalized: list[str] = []
+    seen = set()
+    for raw_tag in tags or []:
+        cleaned = str(raw_tag).strip()
+        if not cleaned:
+            continue
+        lowered = cleaned.lower()
+        canonical = ""
+        for label, variants in TOPIC_NORMALIZATION_RULES:
+            if lowered == label or lowered in variants:
+                canonical = label
+                break
+        if not canonical:
+            canonical = re.sub(r"[^a-z0-9]+", "-", lowered).strip("-") or lowered
+        if canonical not in seen:
+            normalized.append(canonical)
+            seen.add(canonical)
+    return normalized
+
+
+def normalize_conclusion_tag(tag: str) -> str:
+    lowered = str(tag or "").strip().lower()
+    if not lowered:
+        return ""
+    if "vitality" in lowered and ("curiosity" in lowered or "possible" in lowered or "suffice" in lowered):
+        return "possible_with_vitality"
+    if "vitality" in lowered:
+        return "vitality_over_age"
+    if "local" in lowered and "llm" in lowered:
+        return "local_llm_recommended"
+    if "broader" in lowered or "wider" in lowered or "view" in lowered:
+        return "broader_view"
+    if "confirm" in lowered or "layer" in lowered:
+        return "confirmation_layers"
+    if "agree" in lowered or "affirm" in lowered or "endorse" in lowered:
+        return "agreement"
+    return re.sub(r"[^a-z0-9]+", "_", lowered).strip("_")
+
+
+def normalize_pattern_tag(tag: str) -> str:
+    lowered = str(tag or "").strip().lower()
+    if not lowered:
+        return ""
+    if "quote" in lowered:
+        return "quoted"
+    if "reply" in lowered:
+        return "reply"
+    if "support" in lowered or "endorse" in lowered or "advocacy" in lowered:
+        return "quoted_agreement"
+    if "original" in lowered:
+        return "original"
+    return re.sub(r"[^a-z0-9]+", "_", lowered).strip("_")
+
+
+def normalize_records(records: list[dict]) -> list[dict]:
+    normalized = []
+    for record in records:
+        updated = dict(record)
+        metadata = dict(updated.get("metadata") or {})
+        raw_topic_tags = [str(tag) for tag in updated.get("topic_tags", []) if str(tag).strip()]
+        raw_conclusion_tag = str(updated.get("conclusion_tag", "")).strip()
+        raw_pattern_tag = str(updated.get("pattern_tag", "")).strip()
+        updated["author_handle"] = str(updated.get("author_handle", "")).strip().lstrip("@").lower()
+        updated["topic_tags"] = normalize_topic_tags(raw_topic_tags)
+        updated["conclusion_tag"] = normalize_conclusion_tag(raw_conclusion_tag)
+        updated["pattern_tag"] = normalize_pattern_tag(raw_pattern_tag)
+        source_url = str(updated.get("source_url", "")).strip()
+        if source_url and not is_x_url(source_url) and not str(metadata.get("primary_source_url", "")).strip():
+            metadata["primary_source_url"] = source_url
+        if raw_topic_tags and raw_topic_tags != updated["topic_tags"]:
+            metadata["raw_topic_tags"] = raw_topic_tags
+        if raw_conclusion_tag and raw_conclusion_tag != updated["conclusion_tag"]:
+            metadata["raw_conclusion_tag"] = raw_conclusion_tag
+        if raw_pattern_tag and raw_pattern_tag != updated["pattern_tag"]:
+            metadata["raw_pattern_tag"] = raw_pattern_tag
+        updated["metadata"] = metadata
+        normalized.append(updated)
+    return normalized
+
+
+def postprocess_records(records: list[dict], posts: list[dict]) -> list[dict]:
+    return normalize_records(enrich_records_with_primary_sources(records, posts))
+
+
+def analyze_with_xai(posts: list[dict], self_handle: str) -> list[dict]:
+    api_key = os.getenv("XAI_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("missing XAI_API_KEY")
+    model = os.getenv("FUGUE_XAI_MODEL", os.getenv("XAI_MODEL", "grok-4.20-reasoning"))
+    prompt = (
+        "You are extracting quoted-author provenance from posts by "
+        f"@{self_handle}. Return only JSON.\n"
+        "Given the post list, identify external quoted or referenced sources and the likely author handle.\n"
+        "Return an array of objects with keys: cursorvers_post_id, source_url, author_handle, display_name, "
+        "topic_tags, conclusion_tag, pattern_tag, metadata.\n"
+        "Rules:\n"
+        "- Prefer explicit quoted or linked external sources.\n"
+        "- If author is unknown, use empty string.\n"
+        "- topic_tags must be a short array of strings.\n"
+        "- metadata must include extractor=\"xai\" and confidence 0..1.\n"
+        "- Do not include commentary or markdown.\n"
+        f"Posts JSON:\n{json.dumps(posts, ensure_ascii=False)}"
+    )
+    body = {
+        "model": model,
+        "input": [{"role": "user", "content": prompt}],
+        "temperature": 0.1,
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    res = http_json("POST", XAI_BASE, headers, body)
+    output_text_parts = []
+    for item in res.get("output", []):
+        for content in item.get("content", []):
+            if content.get("type") in ("output_text", "text"):
+                output_text_parts.append(content.get("text", ""))
+    raw_text = "".join(output_text_parts).strip()
+    if not raw_text:
+        raise RuntimeError("xAI response did not include output text")
+    return json.loads(raw_text)
+
+
+def load_posts_from_seed(path: str) -> list[dict]:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if isinstance(data, dict) and "posts" in data and isinstance(data["posts"], list):
+        return data["posts"]
+    if isinstance(data, list):
+        return data
+    raise RuntimeError("seed input must be a post array or {posts:[...]}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--handle", default=os.getenv("X_AUTO_QUOTED_AUTHOR_SYNC_HANDLE", SELF_HANDLE_DEFAULT))
+    parser.add_argument("--limit", type=int, default=int(os.getenv("X_AUTO_QUOTED_AUTHOR_SYNC_LIMIT", "50")))
+    parser.add_argument("--from-date", default=os.getenv("X_AUTO_QUOTED_AUTHOR_SYNC_FROM_DATE", ""))
+    parser.add_argument("--to-date", default=os.getenv("X_AUTO_QUOTED_AUTHOR_SYNC_TO_DATE", ""))
+    parser.add_argument("--posts-seed-input", default="")
+    parser.add_argument("--extract-mode", default=os.getenv("X_AUTO_QUOTED_AUTHOR_SYNC_EXTRACT_MODE", "auto"))
+    args = parser.parse_args()
+
+    if args.posts_seed_input:
+        posts = load_posts_from_seed(args.posts_seed_input)
+    else:
+        posts = fetch_user_tweets(args.handle, args.limit, args.from_date or None, args.to_date or None)
+
+    if args.extract_mode == "heuristic":
+        records = heuristic_extract(posts, args.handle)
+    else:
+        try:
+            records = analyze_with_xai(posts, args.handle)
+        except Exception:
+            records = heuristic_extract(posts, args.handle)
+
+    records = postprocess_records(records, posts)
+
+    json.dump(records, sys.stdout, ensure_ascii=False)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/supabase/migrations/20260406193000_x_auto_quoted_author_registry_v1.sql
+++ b/supabase/migrations/20260406193000_x_auto_quoted_author_registry_v1.sql
@@ -1,0 +1,83 @@
+-- 20260406193000_x_auto_quoted_author_registry_v1.sql
+-- Minimal quoted-author registry for x-auto diversity tracking and replayable provenance.
+
+create table if not exists public.quoted_authors (
+  author_id uuid primary key default gen_random_uuid(),
+  platform text not null,
+  canonical_handle text,
+  display_name text,
+  profile_url text,
+  normalized_key text not null,
+  first_seen_at timestamptz not null default now(),
+  last_seen_at timestamptz not null default now(),
+  quote_count integer not null default 0,
+  last_quoted_at timestamptz,
+  status text not null default 'active',
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint quoted_authors_platform_check check (platform in ('x', 'note', 'site', 'paper', 'other')),
+  constraint quoted_authors_status_check check (status in ('active', 'merged', 'suppressed')),
+  constraint quoted_authors_platform_normalized_key_key unique (platform, normalized_key)
+);
+
+create table if not exists public.quoted_sources (
+  source_id uuid primary key default gen_random_uuid(),
+  author_id uuid references public.quoted_authors(author_id),
+  source_url text not null,
+  normalized_source_url text not null,
+  source_type text not null,
+  source_domain text,
+  title text,
+  published_at timestamptz,
+  source_hash text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint quoted_sources_normalized_source_url_key unique (normalized_source_url),
+  constraint quoted_sources_source_hash_key unique (source_hash)
+);
+
+create table if not exists public.quote_events (
+  event_id uuid primary key default gen_random_uuid(),
+  event_hash text not null unique,
+  source_id uuid not null references public.quoted_sources(source_id) on delete cascade,
+  author_id uuid references public.quoted_authors(author_id) on delete set null,
+  notion_page_id text,
+  cursorvers_post_id text,
+  event_kind text not null,
+  topic_tags jsonb not null default '[]'::jsonb,
+  conclusion_tag text,
+  pattern_tag text,
+  diversity_score numeric(5,2),
+  similarity_to_recent numeric(5,2),
+  decision text,
+  decided_by text,
+  context jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint quote_events_event_kind_check check (event_kind in ('discovered', 'drafted', 'approved', 'rejected', 'posted'))
+);
+
+create index if not exists idx_quoted_authors_last_quoted_at
+  on public.quoted_authors (last_quoted_at desc nulls last);
+
+create index if not exists idx_quoted_sources_author_id
+  on public.quoted_sources (author_id);
+
+create index if not exists idx_quoted_sources_source_domain
+  on public.quoted_sources (source_domain);
+
+create index if not exists idx_quote_events_created_at
+  on public.quote_events (created_at desc);
+
+create index if not exists idx_quote_events_source_id
+  on public.quote_events (source_id);
+
+create index if not exists idx_quote_events_event_hash
+  on public.quote_events (event_hash);
+
+create index if not exists idx_quote_events_author_id
+  on public.quote_events (author_id);
+
+create index if not exists idx_quote_events_conclusion_tag
+  on public.quote_events (conclusion_tag);

--- a/tests/test-xauto-blocked-recovery.sh
+++ b/tests/test-xauto-blocked-recovery.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/local/integrations/xauto-blocked-recovery.sh"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+cat > "${TMP_DIR}/registry.json" <<'JSON'
+[
+  {
+    "cursorvers_post_id": "cur-9",
+    "source_url": "https://x.com/z/status/999",
+    "author_handle": "zeta",
+    "display_name": "Zeta",
+    "topic_tags": ["medical", "clinical"],
+    "conclusion_tag": "agreement",
+    "pattern_tag": "quoted",
+    "metadata": {
+      "confidence": 0.88
+    }
+  }
+]
+JSON
+
+cat > "${TMP_DIR}/draft-result.json" <<'JSON'
+{
+  "blocked": [
+    {
+      "draft_id": "draft-zeta",
+      "source_url": "https://x.com/z/status/999",
+      "quoted_author_handle": "zeta",
+      "blocked_reason_canonical": "missing-non-x-primary-source"
+    }
+  ],
+  "closeout": {
+    "backfill_targets": [
+      {
+        "draft_id": "draft-zeta",
+        "source_url": "https://x.com/z/status/999",
+        "quoted_author_handle": "zeta"
+      }
+    ]
+  }
+}
+JSON
+
+mkdir -p "${TMP_DIR}/recovery-posts"
+cat > "${TMP_DIR}/recovery-posts/zeta.json" <<'JSON'
+[
+  {
+    "id": "zeta-1",
+    "author_id": "author-zeta",
+    "conversation_id": "thread-zeta",
+    "text": "same source thread",
+    "created_at": "2026-04-02T00:00:00Z",
+    "entities": {
+      "urls": [
+        {"expanded_url": "https://x.com/z/status/999"}
+      ]
+    },
+    "referenced_tweets": [
+      {"type": "quoted", "id": "999"}
+    ]
+  },
+  {
+    "id": "999",
+    "author_id": "author-src",
+    "conversation_id": "thread-src",
+    "text": "external source",
+    "created_at": "2026-04-01T23:00:00Z",
+    "entities": {
+      "urls": [
+        {"expanded_url": "https://example.com/recovered-article"}
+      ]
+    }
+  }
+]
+JSON
+
+RESULT="$(
+  bash "${SCRIPT}" \
+    --mode execute \
+    --draft-result-input "${TMP_DIR}/draft-result.json" \
+    --registry-input "${TMP_DIR}/registry.json" \
+    --extract-mode heuristic \
+    --generate-mode heuristic \
+    --only-reason missing-non-x-primary-source \
+    --max-candidates 1 \
+    --min-chars 800 \
+    --run-dir "${TMP_DIR}/run" \
+    --recovery-posts-seed-dir "${TMP_DIR}/recovery-posts"
+)"
+
+printf '%s\n' "${RESULT}" | jq -e '.recovery.attempted_count == 1' >/dev/null
+printf '%s\n' "${RESULT}" | jq -e '.recovery.recovered_count == 1' >/dev/null
+printf '%s\n' "${RESULT}" | jq -e '.rerun_result.promotable | length == 1' >/dev/null
+printf '%s\n' "${RESULT}" | jq -e '.rerun_result.promotable[0].quoted_author_handle == "zeta"' >/dev/null
+printf '%s\n' "${RESULT}" | jq -e '.rerun_result.promotable[0].category == "医療AIガバナンス"' >/dev/null
+test -f "${TMP_DIR}/run/xauto-blocked-recovery.registry.json"
+test -f "${TMP_DIR}/run/xauto-blocked-recovery.result.json"

--- a/tests/test-xauto-quoted-author-sync.sh
+++ b/tests/test-xauto-quoted-author-sync.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="${ROOT_DIR}/scripts/local/integrations/xauto_quoted_author_sync.py"
+ADAPTER="${ROOT_DIR}/scripts/local/integrations/xauto-quoted-author-sync.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+POSTS_SEED="${TMP_DIR}/posts.json"
+RECORDS_SEED="${TMP_DIR}/records.json"
+cat > "${POSTS_SEED}" <<'JSON'
+[
+  {
+    "id": "cur-1",
+    "text": "see this",
+    "created_at": "2026-04-01T00:00:00Z",
+    "entities": {
+      "urls": [
+        {"expanded_url": "https://x.com/example/status/111"}
+      ]
+    },
+    "referenced_tweets": [
+      {"type": "quoted", "id": "111"}
+    ]
+  },
+  {
+    "id": "111",
+    "author_id": "user-1",
+    "conversation_id": "thread-1",
+    "text": "quoted source",
+    "created_at": "2026-03-31T00:00:00Z",
+    "entities": {
+      "urls": [
+        {"expanded_url": "https://example.com/source-article"}
+      ]
+    }
+  },
+  {
+    "id": "cur-2",
+    "text": "same thread child",
+    "created_at": "2026-04-01T01:00:00Z",
+    "entities": {
+      "urls": [
+        {"expanded_url": "https://x.com/example/status/222"}
+      ]
+    },
+    "referenced_tweets": [
+      {"type": "quoted", "id": "222"}
+    ]
+  },
+  {
+    "id": "222",
+    "author_id": "user-2",
+    "conversation_id": "thread-2",
+    "text": "thread child without external url",
+    "created_at": "2026-04-01T00:30:00Z",
+    "entities": {
+      "urls": []
+    }
+  },
+  {
+    "id": "thread-2",
+    "author_id": "user-2",
+    "conversation_id": "thread-2",
+    "text": "thread head with article",
+    "created_at": "2026-04-01T00:00:00Z",
+    "entities": {
+      "urls": [
+        {"expanded_url": "https://example.com/thread-article"}
+      ]
+    }
+  },
+  {
+    "id": "cur-3",
+    "text": "deep reference chain",
+    "created_at": "2026-04-01T02:00:00Z",
+    "entities": {
+      "urls": [
+        {"expanded_url": "https://x.com/example/status/333"}
+      ]
+    },
+    "referenced_tweets": [
+      {"type": "quoted", "id": "333"}
+    ]
+  },
+  {
+    "id": "333",
+    "author_id": "user-3",
+    "conversation_id": "thread-3",
+    "text": "level one",
+    "created_at": "2026-04-01T01:30:00Z",
+    "entities": {"urls": []},
+    "referenced_tweets": [
+      {"type": "quoted", "id": "444"}
+    ]
+  },
+  {
+    "id": "444",
+    "author_id": "user-3",
+    "conversation_id": "thread-3",
+    "text": "level two",
+    "created_at": "2026-04-01T01:20:00Z",
+    "entities": {"urls": []},
+    "referenced_tweets": [
+      {"type": "quoted", "id": "555"}
+    ]
+  },
+  {
+    "id": "555",
+    "author_id": "user-3",
+    "conversation_id": "thread-3",
+    "text": "level three",
+    "created_at": "2026-04-01T01:10:00Z",
+    "entities": {"urls": []},
+    "referenced_tweets": [
+      {"type": "quoted", "id": "666"}
+    ]
+  },
+  {
+    "id": "666",
+    "author_id": "user-3",
+    "conversation_id": "thread-3",
+    "text": "level four article",
+    "created_at": "2026-04-01T01:00:00Z",
+    "entities": {
+      "urls": [
+        {"expanded_url": "https://example.com/deep-article"}
+      ]
+    }
+  }
+]
+JSON
+
+cat > "${RECORDS_SEED}" <<'JSON'
+[
+  {
+    "cursorvers_post_id": "cur-2",
+    "source_url": "https://x.com/example/status/111",
+    "author_handle": "@MedDX_Innovator",
+    "topic_tags": ["medical AI", "governance", "local LLM"],
+    "conclusion_tag": "local LLM optimal for governed medical AI",
+    "pattern_tag": "supportive-endorsement",
+    "metadata": {"confidence": 0.9}
+  }
+]
+JSON
+
+OUT="${TMP_DIR}/out.json"
+python3 "${HELPER}" --posts-seed-input "${POSTS_SEED}" --extract-mode heuristic --handle cursorvers > "${OUT}"
+
+jq -e 'map(select(.source_url == "https://x.com/example/status/111" and .metadata.primary_source_url == "https://example.com/source-article")) | length == 1' "${OUT}" >/dev/null
+jq -e 'map(select(.source_url == "https://x.com/example/status/222" and .metadata.primary_source_url == "https://example.com/thread-article")) | length == 1' "${OUT}" >/dev/null
+jq -e 'map(select(.source_url == "https://x.com/example/status/222" and .metadata.primary_source_strategy == "author-conversation")) | length == 1' "${OUT}" >/dev/null
+jq -e 'map(select(.source_url == "https://x.com/example/status/333" and .metadata.primary_source_url == "https://example.com/deep-article")) | length == 1' "${OUT}" >/dev/null
+jq -e 'map(select(.source_url == "https://x.com/example/status/333" and .metadata.primary_source_strategy == "quoted-reference")) | length == 1' "${OUT}" >/dev/null
+
+NORM_OUT="${TMP_DIR}/norm.json"
+python3 - <<'PY' "${RECORDS_SEED}" "${POSTS_SEED}" > "${NORM_OUT}"
+import json
+import sys
+from scripts.local.integrations import xauto_quoted_author_sync as s
+
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    records = json.load(fh)
+with open(sys.argv[2], "r", encoding="utf-8") as fh:
+    posts = json.load(fh)
+print(json.dumps(s.postprocess_records(records, posts), ensure_ascii=False))
+PY
+
+jq -e '.[0].author_handle == "meddx_innovator"' "${NORM_OUT}" >/dev/null
+jq -e '.[0].conclusion_tag == "local_llm_recommended"' "${NORM_OUT}" >/dev/null
+jq -e '.[0].pattern_tag == "quoted_agreement"' "${NORM_OUT}" >/dev/null
+jq -e '.[0].topic_tags == ["medical-ai","governance","local-llm"]' "${NORM_OUT}" >/dev/null
+
+env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY -u SUPABASE_ACCESS_TOKEN \
+bash "${ADAPTER}" \
+  --mode smoke \
+  --seed-input "${NORM_OUT}" \
+  --run-dir "${TMP_DIR}/adapter-run" >/dev/null
+
+grep -Fq "primary_source_url" "${TMP_DIR}/adapter-run/xauto-quoted-author-sync.sql"
+grep -Fq "on conflict (event_hash) do nothing" "${TMP_DIR}/adapter-run/xauto-quoted-author-sync.sql"
+grep -Fq "source_type" "${TMP_DIR}/adapter-run/xauto-quoted-author-sync.sql"
+
+echo "xauto quoted author sync enrichment check passed"


### PR DESCRIPTION
## Summary
- add quoted-author registry schema migration and local schema/sync helpers
- add deterministic quoted-author sync enrichment tests
- add blocked recovery helper and test coverage so draft-only can recover missing non-X primary sources

## Validation
- bash -n scripts/local/integrations/xauto-blocked-recovery.sh scripts/local/integrations/xauto-quoted-author-ensure-schema.sh scripts/local/integrations/xauto-quoted-author-sync.sh tests/test-xauto-blocked-recovery.sh tests/test-xauto-quoted-author-sync.sh tests/test-xauto-draft-only.sh
- python3 -m py_compile scripts/local/integrations/xauto_quoted_author_sync.py
- bash tests/test-xauto-quoted-author-sync.sh
- bash tests/test-xauto-blocked-recovery.sh
- bash tests/test-xauto-draft-only.sh
- actionlint .github/workflows/fugue-orchestration-gate.yml
- git diff --check