### PR TITLE
Add x-auto production verification bridge

### DIFF
--- a/.github/workflows/x-auto-prod-verify.yml
+++ b/.github/workflows/x-auto-prod-verify.yml
@@ -1,0 +1,118 @@
+name: x-auto-prod-verify
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number used for linked-system verification"
+        required: true
+        default: "565"
+      cursorvers_post_id:
+        description: "Deterministic probe post id"
+        required: true
+        default: "gha-e2e-quoted-author-verify"
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  verify-prod-path:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_TOKEN: ${{ github.token }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      RUN_ROOT: ${{ github.workspace }}/.fugue/gha-xauto-verify
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare deterministic registry seed
+        id: prep
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUN_ROOT}"
+          seed_file="${RUNNER_TEMP}/xauto-linked-e2e-registry.json"
+          cat > "${seed_file}" <<JSON
+          [
+            {
+              "cursorvers_post_id": "${{ inputs.cursorvers_post_id }}",
+              "source_url": "https://x.com/carverfomo/status/2041157102723375342?s=20",
+              "author_handle": "carverfomo",
+              "display_name": "Carver",
+              "topic_tags": ["business", "strategy"],
+              "conclusion_tag": "broader_view",
+              "pattern_tag": "quoted",
+              "metadata": {
+                "confidence": 0.9,
+                "primary_source_url": "https://example.com/aviation-weather-market-observation",
+                "primary_source_strategy": "quoted-reference",
+                "primary_source_confidence": 0.92,
+                "event_kind": "discovered",
+                "probe_source": "github-actions"
+              }
+            }
+          ]
+          JSON
+          echo "seed_file=${seed_file}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify quoted-author schema
+        run: |
+          set -euo pipefail
+          scripts/local/integrations/xauto-quoted-author-ensure-schema.sh \
+            --mode smoke \
+            --run-dir "${RUN_ROOT}/schema"
+
+      - name: Run linked-system execute path
+        run: |
+          set -euo pipefail
+          POST_ISSUE_COMMENT=false \
+          X_AUTO_DRAFT_GENERATOR_MODE=registry-local \
+          X_AUTO_DRAFT_LOCAL_GENERATE_MODE=heuristic \
+          X_AUTO_WRITE_NOTION_ON_EXECUTE=false \
+          X_AUTO_DRAFT_REGISTRY_SEED_INPUT="${{ steps.prep.outputs.seed_file }}" \
+          X_AUTO_QUOTED_AUTHOR_SYNC_WRITE_MODE=required \
+          scripts/local/run-linked-systems.sh \
+            --issue "${{ inputs.issue_number }}" \
+            --repo "${{ github.repository }}" \
+            --mode execute \
+            --systems x-auto-draft-only \
+            --max-parallel 2 \
+            --out-dir "${RUN_ROOT}"
+
+      - name: Verify linked run artifacts
+        id: artifact_check
+        env:
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+        run: |
+          set -euo pipefail
+          run_dir="$(
+            find "${RUN_ROOT}" -maxdepth 1 -type d -name "linked-issue-${ISSUE_NUMBER}-*" -print \
+              | sort -r \
+              | head -n1
+          )"
+          test -n "${run_dir}"
+          grep -Fq 'quoted_author_sync_status=applied' "${run_dir}/systems/x-auto-draft-only/xauto-draft-only.meta"
+          grep -Fq 'bridge_status=applied' "${run_dir}/systems/x-auto-draft-only/quoted-author-sync/xauto-quoted-author-sync.meta"
+          echo "run_dir=${run_dir}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify live quote event
+        run: |
+          set -euo pipefail
+          response="$(curl -sS "${SUPABASE_URL}/rest/v1/quote_events?select=event_hash,cursorvers_post_id,event_kind&cursorvers_post_id=eq.${{ inputs.cursorvers_post_id }}" \
+            -H "apikey: ${SUPABASE_SERVICE_ROLE_KEY}" \
+            -H "Authorization: Bearer ${SUPABASE_SERVICE_ROLE_KEY}")"
+          echo "${response}" > "${RUN_ROOT}/live-quote-events.json"
+          count="$(jq 'length' <<< "${response}")"
+          test "${count}" -ge 1
+
+      - name: Upload verification artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: x-auto-prod-verify-${{ github.run_id }}
+          path: |
+            ${{ steps.artifact_check.outputs.run_dir }}
+            ${{ env.RUN_ROOT }}/schema
+            ${{ env.RUN_ROOT }}/live-quote-events.json

--- a/scripts/local/integrations/xauto-draft-only.sh
+++ b/scripts/local/integrations/xauto-draft-only.sh
@@ -25,13 +25,15 @@ ENABLE_BLOCKED_RECOVERY="${X_AUTO_DRAFT_ENABLE_BLOCKED_RECOVERY:-false}"
 BLOCKED_RECOVERY_ONLY_REASON="${X_AUTO_DRAFT_BLOCKED_RECOVERY_ONLY_REASON:-missing-non-x-primary-source}"
 BLOCKED_RECOVERY_POSTS_SEED_DIR="${X_AUTO_DRAFT_BLOCKED_RECOVERY_POSTS_SEED_DIR:-}"
 BLOCKED_RECOVERY_REGISTRY_INPUT="${X_AUTO_DRAFT_BLOCKED_RECOVERY_REGISTRY_INPUT:-}"
-BLOCKED_RECOVERY_EXTRACT_MODE="${X_AUTO_DRAFT_BLOCKED_RECOVERY_EXTRACT_MODE:-${LOCAL_EXTRACT_MODE}}"
-BLOCKED_RECOVERY_GENERATE_MODE="${X_AUTO_DRAFT_BLOCKED_RECOVERY_GENERATE_MODE:-${LOCAL_GENERATE_MODE}}"
+BLOCKED_RECOVERY_EXTRACT_MODE="${X_AUTO_DRAFT_BLOCKED_RECOVERY_EXTRACT_MODE:-}"
+BLOCKED_RECOVERY_GENERATE_MODE="${X_AUTO_DRAFT_BLOCKED_RECOVERY_GENERATE_MODE:-}"
+AUTO_SYNC_QUOTED_AUTHOR_REGISTRY="${X_AUTO_DRAFT_AUTO_SYNC_QUOTED_AUTHOR_REGISTRY:-true}"
 X_AUTO_DIR="${X_AUTO_DIR:-${HOME}/Dev/x-auto}"
 PYTHON_BIN="${X_AUTO_PYTHON:-${X_AUTO_DIR}/venv/bin/python}"
 GENERATOR="${X_AUTO_DRAFT_GENERATOR:-${X_AUTO_DIR}/scripts/generate_draft_candidates.py}"
 LOCAL_GENERATOR="${X_AUTO_DRAFT_LOCAL_GENERATOR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/xauto_generate_drafts_from_registry.py}"
 BLOCKED_RECOVERY_SCRIPT="${X_AUTO_DRAFT_BLOCKED_RECOVERY_SCRIPT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/xauto-blocked-recovery.sh}"
+QUOTED_AUTHOR_SYNC_SCRIPT="${X_AUTO_DRAFT_QUOTED_AUTHOR_SYNC_SCRIPT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/xauto-quoted-author-sync.sh}"
 
 usage() {
   cat <<'EOF'
@@ -54,6 +56,8 @@ Options:
   --limit <n>                 X post fetch limit for registry-local mode
   --from-date <YYYY-MM-DD>    Optional inclusive start date for registry-local mode
   --to-date <YYYY-MM-DD>      Optional inclusive end date for registry-local mode
+  --auto-sync-quoted-author-registry <true|false>
+                              Run advisory quoted-author registry sync after execute registry-local runs (default: true)
   -h, --help                  Show help
 EOF
 }
@@ -124,6 +128,10 @@ while [[ $# -gt 0 ]]; do
       TO_DATE="${2:-}"
       shift 2
       ;;
+    --auto-sync-quoted-author-registry)
+      AUTO_SYNC_QUOTED_AUTHOR_REGISTRY="${2:-}"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -159,8 +167,26 @@ if [[ "${LOCAL_EXTRACT_MODE}" != "auto" && "${LOCAL_EXTRACT_MODE}" != "xai" && "
   echo "Error: --extract-mode must be auto|xai|heuristic" >&2
   exit 2
 fi
+if [[ -z "${BLOCKED_RECOVERY_EXTRACT_MODE}" ]]; then
+  BLOCKED_RECOVERY_EXTRACT_MODE="${LOCAL_EXTRACT_MODE}"
+fi
+if [[ -z "${BLOCKED_RECOVERY_GENERATE_MODE}" ]]; then
+  BLOCKED_RECOVERY_GENERATE_MODE="${LOCAL_GENERATE_MODE}"
+fi
+if [[ "${BLOCKED_RECOVERY_GENERATE_MODE}" != "auto" && "${BLOCKED_RECOVERY_GENERATE_MODE}" != "xai" && "${BLOCKED_RECOVERY_GENERATE_MODE}" != "heuristic" ]]; then
+  echo "Error: blocked recovery generate mode must be auto|xai|heuristic" >&2
+  exit 2
+fi
+if [[ "${BLOCKED_RECOVERY_EXTRACT_MODE}" != "auto" && "${BLOCKED_RECOVERY_EXTRACT_MODE}" != "xai" && "${BLOCKED_RECOVERY_EXTRACT_MODE}" != "heuristic" ]]; then
+  echo "Error: blocked recovery extract mode must be auto|xai|heuristic" >&2
+  exit 2
+fi
 if [[ "${TONE_PROFILE}" != "middle" && "${TONE_PROFILE}" != "polite" ]]; then
   echo "Error: --tone-profile must be middle|polite" >&2
+  exit 2
+fi
+if [[ "${AUTO_SYNC_QUOTED_AUTHOR_REGISTRY}" != "true" && "${AUTO_SYNC_QUOTED_AUTHOR_REGISTRY}" != "false" ]]; then
+  echo "Error: --auto-sync-quoted-author-registry must be true|false" >&2
   exit 2
 fi
 if ! [[ "${FETCH_LIMIT}" =~ ^[0-9]+$ ]] || (( FETCH_LIMIT < 1 )); then
@@ -274,6 +300,9 @@ blocked_count="0"
 rejected_count="0"
 created_count="0"
 recovery_summary='{}'
+quoted_author_sync_status="skipped"
+quoted_author_sync_bridge_status=""
+quoted_author_sync_meta_path=""
 if command -v jq >/dev/null 2>&1; then
   accepted_count="$(printf '%s\n' "${result}" | jq -r '.accepted | length' 2>/dev/null || printf '0')"
   promotable_count="$(printf '%s\n' "${result}" | jq -r '(.promotable // .accepted) | length' 2>/dev/null || printf '0')"
@@ -331,6 +360,71 @@ if [[ "${MODE}" == "execute" && "${GENERATOR_MODE}" == "registry-local" && "${EN
   fi
 fi
 
+quoted_author_sync_seed_input=""
+if [[ -n "${REGISTRY_SEED_INPUT}" ]]; then
+  quoted_author_sync_seed_input="${REGISTRY_SEED_INPUT}"
+elif [[ -n "${RUN_DIR}" && -f "${RUN_DIR}/xauto-draft-only.registry.json" ]]; then
+  quoted_author_sync_seed_input="${RUN_DIR}/xauto-draft-only.registry.json"
+fi
+
+if [[ "${MODE}" == "execute" && "${GENERATOR_MODE}" == "registry-local" && "${AUTO_SYNC_QUOTED_AUTHOR_REGISTRY}" == "true" && -n "${quoted_author_sync_seed_input}" ]]; then
+  if [[ -f "${QUOTED_AUTHOR_SYNC_SCRIPT}" ]]; then
+    sync_run_dir=""
+    if [[ -n "${RUN_DIR}" ]]; then
+      sync_run_dir="${RUN_DIR}/quoted-author-sync"
+    elif [[ -n "${auto_run_dir:-}" ]]; then
+      sync_run_dir="${auto_run_dir}/quoted-author-sync"
+    fi
+    sync_cmd=(
+      "bash"
+      "${QUOTED_AUTHOR_SYNC_SCRIPT}"
+      --mode "${MODE}"
+      --seed-input "${quoted_author_sync_seed_input}"
+      --handle "${HANDLE}"
+      --limit "${FETCH_LIMIT}"
+      --extract-mode "${LOCAL_EXTRACT_MODE}"
+    )
+    if [[ -n "${sync_run_dir}" ]]; then
+      sync_cmd+=(--run-dir "${sync_run_dir}")
+    fi
+    if [[ -n "${POSTS_SEED_INPUT}" ]]; then
+      sync_cmd+=(--posts-seed-input "${POSTS_SEED_INPUT}")
+    fi
+    if [[ -n "${FROM_DATE}" ]]; then
+      sync_cmd+=(--from-date "${FROM_DATE}")
+    fi
+    if [[ -n "${TO_DATE}" ]]; then
+      sync_cmd+=(--to-date "${TO_DATE}")
+    fi
+    set +e
+    sync_output="$("${sync_cmd[@]}" 2>&1)"
+    sync_rc=$?
+    set -e
+    if (( sync_rc != 0 )); then
+      quoted_author_sync_status="failed"
+    fi
+    if [[ -n "${sync_run_dir}" ]]; then
+      quoted_author_sync_meta_path="${sync_run_dir}/xauto-quoted-author-sync.meta"
+      if [[ -f "${quoted_author_sync_meta_path}" ]]; then
+        quoted_author_sync_bridge_status="$(awk -F= '/^bridge_status=/{print $2}' "${quoted_author_sync_meta_path}" | tail -n1)"
+      fi
+    fi
+    if (( sync_rc == 0 )); then
+      if [[ -n "${quoted_author_sync_bridge_status}" ]]; then
+        quoted_author_sync_status="${quoted_author_sync_bridge_status}"
+      else
+        quoted_author_sync_status="completed-no-bridge-status"
+      fi
+    fi
+    if [[ "${quoted_author_sync_status}" == "failed" ]]; then
+      echo "xauto-draft-only: advisory quoted-author sync failed" >&2
+      echo "${sync_output}" >&2
+    fi
+  else
+    quoted_author_sync_status="missing-script"
+  fi
+fi
+
 printf '%s\n' "${result}"
 
 if [[ -n "${RUN_DIR}" ]]; then
@@ -372,6 +466,14 @@ if [[ -n "${RUN_DIR}" ]]; then
     echo "blocked_recovery_only_reason=${BLOCKED_RECOVERY_ONLY_REASON}"
     echo "blocked_recovery_extract_mode=${BLOCKED_RECOVERY_EXTRACT_MODE}"
     echo "blocked_recovery_generate_mode=${BLOCKED_RECOVERY_GENERATE_MODE}"
+    echo "auto_sync_quoted_author_registry=${AUTO_SYNC_QUOTED_AUTHOR_REGISTRY}"
+    echo "quoted_author_sync_status=${quoted_author_sync_status}"
+    if [[ -n "${quoted_author_sync_bridge_status}" ]]; then
+      echo "quoted_author_sync_bridge_status=${quoted_author_sync_bridge_status}"
+    fi
+    if [[ -n "${quoted_author_sync_meta_path}" ]]; then
+      echo "quoted_author_sync_meta_path=${quoted_author_sync_meta_path}"
+    fi
     echo "issue_title=${FUGUE_ISSUE_TITLE:-}"
     echo "issue_url=${FUGUE_ISSUE_URL:-}"
     if [[ -n "${SEED_INPUT}" ]]; then

--- a/tests/test-xauto-draft-only.sh
+++ b/tests/test-xauto-draft-only.sh
@@ -93,6 +93,7 @@ cat > "${REGISTRY_SEED}" <<'JSON'
 JSON
 
 REGISTRY_OUT="${TMP_DIR}/registry.out"
+env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY -u SUPABASE_ACCESS_TOKEN \
 bash "${SCRIPT}" \
   --mode smoke \
   --generator-mode registry-local \
@@ -123,6 +124,7 @@ grep -Fq 'blocked_summary=' "${TMP_DIR}/registry-run/xauto-draft-only.meta"
 grep -Fq 'tone_profile=polite' "${TMP_DIR}/registry-run/xauto-draft-only.meta"
 
 REGISTRY_EXEC_OUT="${TMP_DIR}/registry-exec.out"
+env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY -u SUPABASE_ACCESS_TOKEN \
 bash "${SCRIPT}" \
   --mode execute \
   --generator-mode registry-local \
@@ -134,6 +136,10 @@ bash "${SCRIPT}" \
 jq -e '.dispatchable | length == 1' "${TMP_DIR}/registry-exec-run/xauto-draft-only.dispatch.json" >/dev/null
 jq -e '.dispatchable[0].promotable == true and .dispatchable[0].dispatchable == true' "${TMP_DIR}/registry-exec-run/xauto-draft-only.dispatch.json" >/dev/null
 jq -e '.closeout.operator_next_actions | length >= 1' "${TMP_DIR}/registry-exec-run/xauto-draft-only.dispatch.json" >/dev/null
+grep -Fq 'quoted_author_sync_status=deferred-missing-creds' "${TMP_DIR}/registry-exec-run/xauto-draft-only.meta"
+grep -Fq 'quoted_author_sync_bridge_status=deferred-missing-creds' "${TMP_DIR}/registry-exec-run/xauto-draft-only.meta"
+grep -Fq 'quoted_author_sync_meta_path=' "${TMP_DIR}/registry-exec-run/xauto-draft-only.meta"
+test -f "${TMP_DIR}/registry-exec-run/quoted-author-sync/xauto-quoted-author-sync.meta"
 
 BLOCKED_ONLY_SEED="${TMP_DIR}/registry-blocked-only.json"
 cat > "${BLOCKED_ONLY_SEED}" <<'JSON'
@@ -155,6 +161,7 @@ JSON
 
 BLOCKED_EXEC_OUT="${TMP_DIR}/registry-blocked-exec.out"
 set +e
+env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY -u SUPABASE_ACCESS_TOKEN \
 bash "${SCRIPT}" \
   --mode execute \
   --generator-mode registry-local \
@@ -207,6 +214,7 @@ JSON
 BLOCKED_RECOVER_EXEC_OUT="${TMP_DIR}/registry-blocked-recover-exec.out"
 X_AUTO_DRAFT_ENABLE_BLOCKED_RECOVERY=true \
 X_AUTO_DRAFT_BLOCKED_RECOVERY_POSTS_SEED_DIR="${TMP_DIR}/blocked-recovery-posts" \
+env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY -u SUPABASE_ACCESS_TOKEN \
 bash "${SCRIPT}" \
   --mode execute \
   --generator-mode registry-local \


### PR DESCRIPTION
## Summary
- add standalone x-auto production verification workflow
- bridge registry-local execute runs to quoted-author sync and record bridge status in metadata
- extend draft-only tests to cover deferred missing-credential sync metadata without leaking live credentials

## Validation
- actionlint .github/workflows/x-auto-prod-verify.yml .github/workflows/fugue-orchestration-gate.yml
- bash -n scripts/local/integrations/xauto-draft-only.sh tests/test-xauto-draft-only.sh
- bash tests/test-xauto-draft-only.sh
- bash tests/test-xauto-quoted-author-sync.sh
- bash tests/test-xauto-blocked-recovery.sh
- git diff --check