### PR TITLE
Register x-auto draft linked system

### DIFF
--- a/config/integrations/local-systems.json
+++ b/config/integrations/local-systems.json
@@ -43,6 +43,20 @@
       "enabled": true
     },
     {
+      "id": "x-auto-draft-only",
+      "name": "x-auto Draft Only",
+      "description": "Generate dispatchable x-auto draft candidates and quoted-author recovery artifacts without posting.",
+      "adapter": "scripts/local/integrations/xauto-draft-only.sh",
+      "kind": "content",
+      "adapter_class": "shell",
+      "authority": "artifact-only",
+      "validation_mode": "budgeted",
+      "contract_owner": "kernel-local",
+      "preferred_lane": "codex",
+      "protected_interface": false,
+      "enabled": true
+    },
+    {
       "id": "discord-notify",
       "name": "Discord Notify",
       "description": "Send linked-run health notifications to Discord webhook.",


### PR DESCRIPTION
## Summary
- register x-auto-draft-only in the linked systems manifest
- keep it enabled but budgeted so default smoke runs do not trigger external-heavy x-auto flows
- unblock explicit x-auto production verification workflow selection

## Validation
- bash scripts/check-linked-systems-integrity.sh
- X_AUTO_DRAFT_GENERATOR_MODE=registry-local X_AUTO_DRAFT_LOCAL_GENERATE_MODE=heuristic X_AUTO_WRITE_NOTION_ON_EXECUTE=false X_AUTO_DRAFT_REGISTRY_SEED_INPUT=<deterministic seed> X_AUTO_DRAFT_AUTO_SYNC_QUOTED_AUTHOR_REGISTRY=false bash scripts/local/run-linked-systems.sh --issue 565 --mode smoke --systems x-auto-draft-only --out-dir .fugue/test-xauto-linked-seeded --max-parallel 2
- git diff --check