### PR TITLE
Canonicalize ESTAT shared secret loading

### DIFF
--- a/scripts/lib/load-shared-secrets.sh
+++ b/scripts/lib/load-shared-secrets.sh
@@ -3,6 +3,12 @@ set -euo pipefail
 
 KEYCHAIN_SERVICE="${SHARED_SECRETS_KEYCHAIN_SERVICE:-fugue-secrets}"
 ENV_FILE="${SHARED_SECRETS_ENV_FILE:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SOPS_ENC_FILE_DEFAULT="${ROOT_DIR}/secrets/fugue-secrets.enc"
+SOPS_ENC_FILE="${SHARED_SECRETS_SOPS_FILE:-${SOPS_ENC_FILE_DEFAULT}}"
+SOPS_AGE_KEY_DEFAULT="${HOME}/.config/sops/age/keys.txt"
+SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-${SOPS_AGE_KEY_DEFAULT}}"
 
 DEFAULT_VARS=(
   OPENAI_API_KEY
@@ -10,6 +16,7 @@ DEFAULT_VARS=(
   ZAI_API_KEY
   GEMINI_API_KEY
   XAI_API_KEY
+  ESTAT_API_ID
   TARGET_REPO_PAT
   FUGUE_OPS_PAT
 )
@@ -25,13 +32,15 @@ Usage:
 Resolution order:
   1) process env
   2) macOS Keychain
-  3) explicit external env file (SHARED_SECRETS_ENV_FILE)
+  3) shared sops bundle
+  4) explicit external env file (SHARED_SECRETS_ENV_FILE)
 EOF
 }
 
 canonical_name() {
   case "${1:-}" in
     XAI_API) printf 'XAI_API_KEY\n' ;;
+    ESTAT_APP_ID) printf 'ESTAT_API_ID\n' ;;
     *) printf '%s\n' "${1:-}" ;;
   esac
 }
@@ -39,6 +48,7 @@ canonical_name() {
 legacy_aliases() {
   case "${1:-}" in
     XAI_API_KEY) printf 'XAI_API\n' ;;
+    ESTAT_API_ID) printf 'ESTAT_APP_ID\n' ;;
     *) ;;
   esac
 }
@@ -50,6 +60,7 @@ keychain_account_for() {
     GEMINI_API_KEY) printf 'gemini-api-key\n' ;;
     ZAI_API_KEY) printf 'zai-api-key\n' ;;
     XAI_API_KEY) printf 'xai-api-key\n' ;;
+    ESTAT_API_ID|ESTAT_APP_ID) printf 'estat-app-id\n' ;;
     TARGET_REPO_PAT) printf 'target-repo-pat\n' ;;
     FUGUE_OPS_PAT) printf 'fugue-ops-pat\n' ;;
     *) return 1 ;;
@@ -132,12 +143,44 @@ resolve_from_env_file() {
   return 1
 }
 
+resolve_from_sops_bundle() {
+  local name="$1"
+  command -v sops >/dev/null 2>&1 || return 1
+  [[ -f "${SOPS_ENC_FILE}" ]] || return 1
+  [[ -f "${SOPS_AGE_KEY_FILE}" ]] || return 1
+
+  local decrypted value
+  decrypted="$(
+    env SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE}" \
+      sops decrypt --input-type dotenv --output-type dotenv "${SOPS_ENC_FILE}" 2>/dev/null
+  )" || return 1
+
+  value="$(printf '%s\n' "${decrypted}" | awk -F= -v key="${name}" '$1 == key { print substr($0, index($0, $2)); exit }')"
+  if [[ -n "${value}" ]]; then
+    printf 'sops-bundle\t%s\n' "${value}"
+    return 0
+  fi
+
+  local alias_name
+  while IFS= read -r alias_name; do
+    [[ -n "${alias_name}" ]] || continue
+    value="$(printf '%s\n' "${decrypted}" | awk -F= -v key="${alias_name}" '$1 == key { print substr($0, index($0, $2)); exit }')"
+    if [[ -n "${value}" ]]; then
+      printf 'sops-bundle\t%s\n' "${value}"
+      return 0
+    fi
+  done < <(legacy_aliases "${name}")
+
+  return 1
+}
+
 resolve_secret() {
   local canonical
   canonical="$(canonical_name "${1:-}")"
 
   resolve_from_env "${canonical}" && return 0
   resolve_from_keychain "${canonical}" && return 0
+  resolve_from_sops_bundle "${canonical}" && return 0
   resolve_from_env_file "${canonical}" && return 0
   return 1
 }

--- a/scripts/local/sync-gh-secrets-from-env.sh
+++ b/scripts/local/sync-gh-secrets-from-env.sh
@@ -107,6 +107,7 @@ if [[ -f "${SHARED_SECRETS_LOADER}" ]]; then
       ANTHROPIC_API_KEY \
       GEMINI_API_KEY \
       XAI_API_KEY \
+      ESTAT_API_ID \
       TARGET_REPO_PAT \
       FUGUE_OPS_PAT
   )"
@@ -267,6 +268,7 @@ apply_secret repo TARGET_REPO_PAT optional TARGET_REPO_PAT
 apply_secret org ANTHROPIC_API_KEY optional ANTHROPIC_API_KEY
 apply_secret org GEMINI_API_KEY optional GEMINI_API_KEY
 apply_secret org XAI_API_KEY optional XAI_API_KEY XAI_API
+apply_secret org ESTAT_API_ID optional ESTAT_API_ID ESTAT_APP_ID
 
 # Ops and notification lifelines
 apply_secret org FUGUE_OPS_PAT optional FUGUE_OPS_PAT

--- a/scripts/sops/import-to-keychain.sh
+++ b/scripts/sops/import-to-keychain.sh
@@ -67,6 +67,7 @@ map_to_acct() {
     SUPABASE_SERVICE_ROLE_KEY) echo "supabase-service-role-key" ;;
     LINE_CHANNEL_SECRET) echo "line-channel-secret" ;;
     LINE_HARNESS_API_KEY) echo "line-harness-api-key" ;;
+    ESTAT_API_ID)       echo "estat-app-id" ;;
     ESTAT_APP_ID)       echo "estat-app-id" ;;
     *)                  echo "" ;;
   esac

--- a/tests/test-load-shared-secrets.sh
+++ b/tests/test-load-shared-secrets.sh
@@ -25,12 +25,19 @@ case "${service}:${acct}" in
   fugue-secrets:openai-api-key) printf 'kc-openai' ;;
   fugue-secrets:anthropic-api-key) printf 'kc-anthropic' ;;
   fugue-secrets:xai-api-key) printf 'kc-xai' ;;
+  fugue-secrets:estat-app-id) printf 'kc-estat' ;;
   fugue-secrets:target-repo-pat) printf 'kc-target-repo-pat' ;;
   fugue-secrets:fugue-ops-pat) printf 'kc-fugue-ops-pat' ;;
   *) exit 44 ;;
 esac
 EOF
 chmod +x "${TMP_DIR}/bin/security"
+
+cat >"${TMP_DIR}/bin/sops" <<'EOF'
+#!/usr/bin/env bash
+printf 'ESTAT_APP_ID=sops-estat\n'
+EOF
+chmod +x "${TMP_DIR}/bin/sops"
 
 ENV_FILE="${TMP_DIR}/shared.env"
 cat >"${ENV_FILE}" <<'EOF'
@@ -40,6 +47,9 @@ EOF
 
 export PATH="${TMP_DIR}/bin:${PATH}"
 export SHARED_SECRETS_ENV_FILE="${ENV_FILE}"
+export SHARED_SECRETS_SOPS_FILE="${TMP_DIR}/fugue-secrets.enc"
+export SOPS_AGE_KEY_FILE="${TMP_DIR}/keys.txt"
+touch "${SHARED_SECRETS_SOPS_FILE}" "${SOPS_AGE_KEY_FILE}"
 
 export OPENAI_API_KEY="env-openai"
 out="$(bash "${SCRIPT}" get OPENAI_API_KEY)"
@@ -60,6 +70,16 @@ src="$(bash "${SCRIPT}" source-of ZAI_API_KEY)"
 
 out="$(bash "${SCRIPT}" get XAI_API_KEY)"
 [[ "${out}" == "kc-xai" || "${out}" == "legacy-xai" ]]
+
+out="$(bash "${SCRIPT}" get ESTAT_API_ID)"
+[[ "${out}" == "kc-estat" ]]
+src="$(bash "${SCRIPT}" source-of ESTAT_API_ID)"
+[[ "${src}" == "keychain" ]]
+
+out="$(SHARED_SECRETS_KEYCHAIN_SERVICE=missing-service bash "${SCRIPT}" get ESTAT_APP_ID)"
+[[ "${out}" == "sops-estat" ]]
+src="$(SHARED_SECRETS_KEYCHAIN_SERVICE=missing-service bash "${SCRIPT}" source-of ESTAT_API_ID)"
+[[ "${src}" == "sops-bundle" ]]
 
 out="$(bash "${SCRIPT}" get TARGET_REPO_PAT)"
 [[ "${out}" == "kc-target-repo-pat" ]]

--- a/tests/test-sync-gh-secrets-from-env.sh
+++ b/tests/test-sync-gh-secrets-from-env.sh
@@ -31,6 +31,7 @@ done
 case "${service}:${acct}" in
   fugue-secrets:openai-api-key) printf 'kc-openai' ;;
   fugue-secrets:zai-api-key) printf 'kc-zai' ;;
+  fugue-secrets:estat-app-id) printf 'kc-estat' ;;
   fugue-secrets:target-repo-pat) printf 'kc-target-repo-pat' ;;
   fugue-secrets:fugue-ops-pat) printf 'kc-fugue-ops-pat' ;;
   *) exit 44 ;;
@@ -39,11 +40,12 @@ EOF
 chmod +x "${TMP_DIR}/bin/gh" "${TMP_DIR}/bin/security"
 
 export PATH="${TMP_DIR}/bin:${PATH}"
-unset OPENAI_API_KEY ZAI_API_KEY TARGET_REPO_PAT FUGUE_OPS_PAT ANTHROPIC_API_KEY GEMINI_API_KEY XAI_API_KEY || true
+unset OPENAI_API_KEY ZAI_API_KEY TARGET_REPO_PAT FUGUE_OPS_PAT ANTHROPIC_API_KEY GEMINI_API_KEY XAI_API_KEY ESTAT_API_ID || true
 
 out="$(bash "${SCRIPT}" --dry-run)"
 grep -Fq 'DRY-RUN: set org secret OPENAI_API_KEY from OPENAI_API_KEY' <<<"${out}"
 grep -Fq 'DRY-RUN: set org secret ZAI_API_KEY from ZAI_API_KEY' <<<"${out}"
+grep -Fq 'DRY-RUN: set org secret ESTAT_API_ID from ESTAT_API_ID' <<<"${out}"
 grep -Fq 'DRY-RUN: set repo secret TARGET_REPO_PAT from TARGET_REPO_PAT' <<<"${out}"
 grep -Fq 'DRY-RUN: set org secret FUGUE_OPS_PAT from FUGUE_OPS_PAT' <<<"${out}"
 


### PR DESCRIPTION
## Summary
- add ESTAT_API_ID / ESTAT_APP_ID alias handling to the shared secret loader
- load ESTAT from Keychain or the shared SOPS bundle before env-file fallback
- wire ESTAT into GitHub secret sync and Keychain import mappings

## Validation
- bash -n scripts/lib/load-shared-secrets.sh scripts/local/sync-gh-secrets-from-env.sh scripts/sops/import-to-keychain.sh tests/test-load-shared-secrets.sh tests/test-sync-gh-secrets-from-env.sh
- bash tests/test-load-shared-secrets.sh
- bash tests/test-sync-gh-secrets-from-env.sh
- git diff --check --cached
- staged diff secret-path scan: no secrets/*.enc, .env, or secret payload files