### PR TITLE
Verify MBP/macmini shared secret continuity

### DIFF
--- a/.github/workflows/fugue-orchestration-gate.yml
+++ b/.github/workflows/fugue-orchestration-gate.yml
@@ -74,6 +74,7 @@ on:
       - 'tests/test-canary-trust-policy.sh'
       - 'tests/test-kernel-canary-plan.sh'
       - 'tests/test-watchdog-alert-policy.sh'
+      - 'tests/test-watchdog-waiting-run-workflow.sh'
       - 'tests/test-watchdog-alert-delivery-policy.sh'
       - 'tests/test-primary-heartbeat-state.sh'
       - 'tests/test-workspace-root-policy.sh'
@@ -180,6 +181,7 @@ on:
       - 'tests/test-canary-trust-policy.sh'
       - 'tests/test-kernel-canary-plan.sh'
       - 'tests/test-watchdog-alert-policy.sh'
+      - 'tests/test-watchdog-waiting-run-workflow.sh'
       - 'tests/test-watchdog-alert-delivery-policy.sh'
       - 'tests/test-primary-heartbeat-state.sh'
       - 'tests/test-workspace-root-policy.sh'
@@ -313,6 +315,7 @@ jobs:
           bash_n tests/test-workspace-root-policy.sh
           bash_n tests/test-canary-trust-policy.sh
           bash_n tests/test-kernel-canary-plan.sh
+          bash_n tests/test-watchdog-waiting-run-workflow.sh
           bash_n tests/test-kernel-entrypoint.sh
           bash_n tests/test-kernel-launcher.sh
           bash_n tests/test-kernel-launcher-template.sh
@@ -373,6 +376,7 @@ jobs:
           bash tests/test-route-task-handoff.sh
           bash tests/test-resolve-orchestration-context.sh
           bash tests/test-watchdog-alert-policy.sh
+          bash tests/test-watchdog-waiting-run-workflow.sh
           bash tests/test-watchdog-alert-delivery-policy.sh
           bash tests/test-primary-heartbeat-state.sh
           bash tests/test-publish-decision-journal.sh

--- a/.github/workflows/fugue-watchdog.yml
+++ b/.github/workflows/fugue-watchdog.yml
@@ -407,6 +407,52 @@ jobs:
             echo "failover_variable_sync_status=${failover_variable_sync_status}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Detect waiting workflow runs
+        id: waiting_runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          gh_err="$(mktemp)"
+          now_epoch="$(date -u +%s)"
+          query_failed="false"
+          oldest_label=""
+          max_age_minutes="0"
+          if ! runs_json="$(gh run list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --status waiting \
+            --limit 200 \
+            --json databaseId,workflowName,createdAt,url 2>"${gh_err}")"; then
+            query_failed="true"
+            count="1"
+            max_age_minutes="60"
+            oldest_label="waiting-run-query-failed"
+            echo "::warning::failed to query waiting workflow runs: $(tr '\n' ' ' <"${gh_err}" | sed 's/[[:space:]]\+/ /g')"
+          else
+            count="$(printf '%s' "${runs_json}" | jq 'length')"
+          fi
+
+          if [[ "${query_failed}" != "true" && "${count}" != "0" ]]; then
+            oldest_json="$(printf '%s' "${runs_json}" | jq -c 'sort_by(.createdAt) | .[0]')"
+            oldest_created="$(printf '%s' "${oldest_json}" | jq -r '.createdAt // ""')"
+            oldest_name="$(printf '%s' "${oldest_json}" | jq -r '.workflowName // "unknown"')"
+            oldest_id="$(printf '%s' "${oldest_json}" | jq -r '.databaseId // "unknown"')"
+            if [[ -n "${oldest_created}" ]]; then
+              oldest_epoch="$(date -u -d "${oldest_created}" +%s)"
+              max_age_minutes="$(( (now_epoch - oldest_epoch) / 60 ))"
+            fi
+            oldest_label="${oldest_name}#${oldest_id}"
+            echo "::notice::waiting workflow runs detected: count=${count} oldest=${oldest_label} age_minutes=${max_age_minutes}"
+          fi
+
+          {
+            echo "count=${count}"
+            echo "max_age_minutes=${max_age_minutes}"
+            echo "oldest_label=${oldest_label}"
+            echo "query_failed=${query_failed}"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Decide whether to alert (throttle + relevance)
         id: decide
         env:
@@ -464,6 +510,9 @@ jobs:
               --mainframe-last-success-at "${{ steps.mainframe_success.outputs.last_time }}" \
               --pending-count "${{ steps.pending.outputs.pending_count }}" \
               --mainframe-pending-count "${{ steps.pending.outputs.mainframe_pending_count }}" \
+              --waiting-run-count "${{ steps.waiting_runs.outputs.count }}" \
+              --waiting-run-age-minutes "${{ steps.waiting_runs.outputs.max_age_minutes }}" \
+              --waiting-run-oldest "${{ steps.waiting_runs.outputs.oldest_label }}" \
               --persist-state "${watchdog_alert_persist}" \
               --previous-state-json "${watchdog_alert_state}" \
               --format json

--- a/.github/workflows/shared-secret-contract.yml
+++ b/.github/workflows/shared-secret-contract.yml
@@ -1,0 +1,57 @@
+name: shared-secret-contract
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/shared-secret-contract.yml"
+      - "docs/kernel-fugue-secret-plane.md"
+      - "docs/kernel/dr-continuation-runbook-v1.md"
+      - "docs/org-secrets.md"
+      - "scripts/lib/load-shared-secrets.sh"
+      - "scripts/local/sync-gh-secrets-from-env.sh"
+      - "scripts/org-secrets-audit.json"
+      - "tests/test-load-shared-secrets.sh"
+      - "tests/test-sync-gh-secrets-from-env.sh"
+      - "tests/test-mbp-macmini-shared-secrets.sh"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/shared-secret-contract.yml"
+      - "docs/kernel-fugue-secret-plane.md"
+      - "docs/kernel/dr-continuation-runbook-v1.md"
+      - "docs/org-secrets.md"
+      - "scripts/lib/load-shared-secrets.sh"
+      - "scripts/local/sync-gh-secrets-from-env.sh"
+      - "scripts/org-secrets-audit.json"
+      - "tests/test-load-shared-secrets.sh"
+      - "tests/test-sync-gh-secrets-from-env.sh"
+      - "tests/test-mbp-macmini-shared-secrets.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Shell syntax
+        run: |
+          set -euo pipefail
+          bash -n tests/test-load-shared-secrets.sh
+          bash -n tests/test-sync-gh-secrets-from-env.sh
+          bash -n tests/test-mbp-macmini-shared-secrets.sh
+
+      - name: Shared secret loader tests
+        run: |
+          set -euo pipefail
+          bash tests/test-load-shared-secrets.sh
+          bash tests/test-sync-gh-secrets-from-env.sh
+          bash tests/test-mbp-macmini-shared-secrets.sh
+
+      - name: Audit config JSON
+        run: jq . scripts/org-secrets-audit.json >/dev/null

--- a/docs/kernel-fugue-secret-plane.md
+++ b/docs/kernel-fugue-secret-plane.md
@@ -63,6 +63,7 @@ This is a hard rule, not a convenience preference:
 - `ZAI_API_KEY`
 - `GEMINI_API_KEY`
 - `XAI_API_KEY`
+- `ESTAT_API_ID`
 - `TARGET_REPO_PAT`
 - `FUGUE_OPS_PAT`
 - platform-specific runtime names such as `SUPABASE_SERVICE_ROLE_KEY`
@@ -122,6 +123,7 @@ Use this split:
 - `ANTHROPIC_API_KEY`
 - `GEMINI_API_KEY`
 - `XAI_API_KEY`
+- `ESTAT_API_ID`
 - `FUGUE_OPS_PAT`
 - shared webhook fallbacks such as `DISCORD_WEBHOOK_URL`
 
@@ -213,6 +215,13 @@ For this workspace, the best default is:
 
 1. process env
 2. Keychain
-3. explicit external env file
+3. shared SOPS bundle
+4. explicit external env file
 
-Routine runtime should not decrypt the shared bundle on every invocation. Decryption belongs to bootstrap / restore.
+The canonical bootstrap source is the encrypted SOPS bundle. Keychain,
+process env, and GitHub Actions secrets are derived execution planes, not
+independent sources of truth.
+
+Routine attended operation should be satisfied by Keychain. The SOPS fallback
+exists for host restore and DR continuity on MBP/Mac mini, and `doctor` output
+must report source and length only, never secret values.

--- a/docs/kernel/dr-continuation-runbook-v1.md
+++ b/docs/kernel/dr-continuation-runbook-v1.md
@@ -14,7 +14,7 @@ Continue a frozen Kernel run when `Mac mini` is unavailable, without relying on 
 ## Required Surfaces
 
 - shared secret resolver:
-  - `process env -> Keychain -> explicit external env file`
+  - `process env -> Keychain -> shared SOPS bundle -> explicit external env file`
 - `doctor`
 - `compact artifact`
 - `recover-run`
@@ -23,6 +23,9 @@ Continue a frozen Kernel run when `Mac mini` is unavailable, without relying on 
 
 1. Connect by `Tailscale` and open the repository.
 2. Resolve shared secrets through the standard loader.
+   - Prefer Keychain for normal local continuation.
+   - If Keychain is absent or locked, use the shared SOPS bundle as a DR restore fallback.
+   - Treat GitHub org secrets as the CI plane, not as a local read backend.
 3. Run `codex-kernel-guard doctor --all-runs`.
 4. Identify the target by:
    - `project`
@@ -72,3 +75,5 @@ Continue a frozen Kernel run when `Mac mini` is unavailable, without relying on 
 - `recover-run` regenerates the heavy tmux profile from compact state.
 - `MBP` can continue a stale run from artifacts.
 - `cc pocket` can inspect and continue lightweight work from the same artifacts.
+- `MBP` and `Mac mini` resolve the same canonical shared-secret names without
+  printing values; `doctor` output is limited to present/missing, source, and length.

--- a/docs/org-secrets.md
+++ b/docs/org-secrets.md
@@ -12,12 +12,16 @@ Important: GitHub secrets are the CI plane, not the full runtime plane. Runtime 
 ## Rules Of Thumb
 - Put shared provider keys in org secrets:
   - `OPENAI_API_KEY`, `ZAI_API_KEY`
+  - Shared automation/data API keys: `ESTAT_API_ID`
   - Optional specialists: `GEMINI_API_KEY`, `XAI_API_KEY`
   - Notification lifelines: `DISCORD_WEBHOOK_URL` (fallback: `DISCORD_SYSTEM_WEBHOOK`), `LINE_WEBHOOK_URL` (or `LINE_CHANNEL_ACCESS_TOKEN` + `LINE_TO`; legacy fallback: `LINE_NOTIFY_TOKEN`)
   - Ops token for variable/state auto-recovery: `FUGUE_OPS_PAT` (fallback: `TARGET_REPO_PAT`)
 - Keep repo secrets only for repo-specific credentials:
   - Example: `TARGET_REPO_PAT` (scope-limited PAT for PR creation)
 - Use `selected` visibility unless the secret is truly safe to expose to all repos.
+- `TARGET_REPO_PAT` is not a universal requirement. Prefer `FUGUE_OPS_PAT`
+  for FUGUE/Kernel state recovery where possible, and require `TARGET_REPO_PAT`
+  only for repositories that actually need repo-specific cross-repo write access.
 
 ## Audit
 Run:
@@ -49,3 +53,6 @@ Config:
 Policy:
 - Do not keep live secrets in repository `.env` files.
 - Keep canonical secret names stable so `Kernel` and `FUGUE` can swap without secret migration.
+- Prefer org secrets with `selected` repository visibility for shared keys.
+  Avoid keeping a same-name repo secret because GitHub resolves the lower-level
+  secret first and may hide a rotated org value.

--- a/scripts/lib/watchdog-alert-policy.sh
+++ b/scripts/lib/watchdog-alert-policy.sh
@@ -33,6 +33,9 @@ mainframe_minutes="0"
 mainframe_last_success_at=""
 pending_count="0"
 mainframe_pending_count="0"
+waiting_run_count="0"
+waiting_run_age_minutes="0"
+waiting_run_oldest=""
 persist_state="false"
 previous_state_json='{}'
 now_epoch=""
@@ -77,6 +80,9 @@ Options:
   --mainframe-last-success-at <iso8601>
   --pending-count <n>
   --mainframe-pending-count <n>
+  --waiting-run-count <n>
+  --waiting-run-age-minutes <n>
+  --waiting-run-oldest <workflow/run label>
   --persist-state <true|false>
   --previous-state-json <json>
   --now-epoch <unix-seconds>
@@ -235,6 +241,9 @@ while [[ $# -gt 0 ]]; do
     --mainframe-last-success-at) mainframe_last_success_at="${2:-}"; shift 2 ;;
     --pending-count) pending_count="${2:-}"; shift 2 ;;
     --mainframe-pending-count) mainframe_pending_count="${2:-}"; shift 2 ;;
+    --waiting-run-count) waiting_run_count="${2:-}"; shift 2 ;;
+    --waiting-run-age-minutes) waiting_run_age_minutes="${2:-}"; shift 2 ;;
+    --waiting-run-oldest) waiting_run_oldest="${2:-}"; shift 2 ;;
     --persist-state) persist_state="${2:-}"; shift 2 ;;
     --previous-state-json) previous_state_json="${2:-}"; shift 2 ;;
     --now-epoch) now_epoch="${2:-}"; shift 2 ;;
@@ -264,6 +273,8 @@ mainframe_hours="$(normalize_int "${mainframe_hours}" "0")"
 mainframe_minutes="$(normalize_int "${mainframe_minutes}" "0")"
 pending_count="$(normalize_int "${pending_count}" "0")"
 mainframe_pending_count="$(normalize_int "${mainframe_pending_count}" "0")"
+waiting_run_count="$(normalize_int "${waiting_run_count}" "0")"
+waiting_run_age_minutes="$(normalize_int "${waiting_run_age_minutes}" "0")"
 claude_state_age_hours="$(normalize_int "${claude_state_age_hours}" "0")"
 claude_fallback_mentions_24h="$(normalize_int "${claude_fallback_mentions_24h}" "0")"
 
@@ -378,6 +389,10 @@ else
     if [[ "${mainframe_stale}" == "true" ]]; then
       maybe_mark_stale_reason "mainframe-stale" "${mainframe_hours}" "${mainframe_minutes}"
     fi
+
+    if (( waiting_run_count > 0 && waiting_run_age_minutes >= 60 )); then
+      maybe_mark_periodic_reason "workflow-waiting" 180
+    fi
   fi
 fi
 
@@ -438,6 +453,9 @@ xai_ok: ${xai_ok}
 anthropic_ok: ${anthropic_ok}
 pending_count: ${pending_count}
 mainframe_pending_count: ${mainframe_pending_count}
+waiting_run_count: ${waiting_run_count}
+waiting_run_age_minutes: ${waiting_run_age_minutes}
+waiting_run_oldest: ${waiting_run_oldest}
 watchdog_alert_state_persist: ${persist_state}
 watchdog_alert_due_reasons: ${due_reasons_text}
 router_hours_since_success: ${router_hours}

--- a/scripts/org-secrets-audit.json
+++ b/scripts/org-secrets-audit.json
@@ -2,6 +2,7 @@
   "preferred_org_secrets": [
     "OPENAI_API_KEY",
     "ZAI_API_KEY",
+    "ESTAT_API_ID",
     "XAI_API_KEY",
     "DISCORD_ADMIN_WEBHOOK_URL",
     "DISCORD_WEBHOOK_URL",
@@ -33,7 +34,7 @@
       "required": [
         "OPENAI_API_KEY",
         "ZAI_API_KEY",
-        "TARGET_REPO_PAT"
+        "ESTAT_API_ID"
       ],
       "required_any": [
         [
@@ -76,9 +77,6 @@
       "required_any": [
         [
           "OPENAI_API_KEY"
-        ],
-        [
-          "TARGET_REPO_PAT"
         ]
       ]
     }

--- a/tests/test-mbp-macmini-shared-secrets.sh
+++ b/tests/test-mbp-macmini-shared-secrets.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/lib/load-shared-secrets.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+FIXTURE="${TMP_DIR}/shared.env"
+cat >"${FIXTURE}" <<'EOF'
+OPENAI_API_KEY=shared-openai
+ZAI_API_KEY=shared-zai
+XAI_API=shared-xai
+ESTAT_APP_ID=shared-estat
+FUGUE_OPS_PAT=shared-fugue-ops
+EOF
+
+make_profile() {
+  local profile="$1"
+  local mode="$2"
+  local root="${TMP_DIR}/${profile}"
+  mkdir -p "${root}/bin" "${root}/home/.config/sops/age"
+  touch "${root}/bundle.enc" "${root}/home/.config/sops/age/keys.txt"
+
+  cat >"${root}/bin/sops" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" != "decrypt" ]]; then
+  echo "unexpected sops mode" >&2
+  exit 2
+fi
+cat "${FIXTURE}"
+EOF
+  chmod +x "${root}/bin/sops"
+
+  if [[ "${mode}" == "keychain" ]]; then
+    cat >"${root}/bin/security" <<'EOF'
+#!/usr/bin/env bash
+acct=""
+service=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    find-generic-password) shift ;;
+    -a) acct="${2:-}"; shift 2 ;;
+    -s) service="${2:-}"; shift 2 ;;
+    -w) shift ;;
+    *) shift ;;
+  esac
+done
+
+case "${service}:${acct}" in
+  fugue-secrets:openai-api-key) printf 'shared-openai' ;;
+  fugue-secrets:zai-api-key) printf 'shared-zai' ;;
+  fugue-secrets:xai-api-key) printf 'shared-xai' ;;
+  fugue-secrets:estat-app-id) printf 'shared-estat' ;;
+  fugue-secrets:fugue-ops-pat) printf 'shared-fugue-ops' ;;
+  *) exit 44 ;;
+esac
+EOF
+  else
+    cat >"${root}/bin/security" <<'EOF'
+#!/usr/bin/env bash
+exit 44
+EOF
+  fi
+  chmod +x "${root}/bin/security"
+}
+
+run_loader() {
+  local profile="$1"
+  shift
+  local root="${TMP_DIR}/${profile}"
+  env -i \
+    HOME="${root}/home" \
+    PATH="${root}/bin:/usr/bin:/bin" \
+    SHARED_SECRETS_SOPS_FILE="${root}/bundle.enc" \
+    bash "${SCRIPT}" "$@"
+}
+
+assert_resolves() {
+  local profile="$1"
+  local key="$2"
+  local expected_source="$3"
+  local expected_value="$4"
+  local value source
+  value="$(run_loader "${profile}" get "${key}")"
+  source="$(run_loader "${profile}" source-of "${key}")"
+  [[ "${value}" == "${expected_value}" ]]
+  [[ "${source}" == "${expected_source}" ]]
+}
+
+make_profile "macmini" "sops"
+make_profile "mbp" "keychain"
+
+for profile in macmini mbp; do
+  expected_source="sops-bundle"
+  if [[ "${profile}" == "mbp" ]]; then
+    expected_source="keychain"
+  fi
+
+  assert_resolves "${profile}" OPENAI_API_KEY "${expected_source}" shared-openai
+  assert_resolves "${profile}" ZAI_API_KEY "${expected_source}" shared-zai
+  assert_resolves "${profile}" XAI_API_KEY "${expected_source}" shared-xai
+  assert_resolves "${profile}" ESTAT_API_ID "${expected_source}" shared-estat
+  assert_resolves "${profile}" ESTAT_APP_ID "${expected_source}" shared-estat
+  assert_resolves "${profile}" FUGUE_OPS_PAT "${expected_source}" shared-fugue-ops
+
+  doctor="$(run_loader "${profile}" doctor OPENAI_API_KEY ZAI_API_KEY XAI_API_KEY ESTAT_API_ID FUGUE_OPS_PAT)"
+  grep -Fq "OPENAI_API_KEY: present (${expected_source}, len=13)" <<<"${doctor}"
+  grep -Fq "ESTAT_API_ID: present (${expected_source}, len=12)" <<<"${doctor}"
+
+  if grep -Eq 'shared-(openai|zai|xai|estat|fugue-ops)' <<<"${doctor}"; then
+    echo "doctor leaked a secret value for ${profile}" >&2
+    exit 1
+  fi
+
+  export_out="$(run_loader "${profile}" export ESTAT_APP_ID)"
+  grep -Fq 'export ESTAT_API_ID=' <<<"${export_out}"
+  if grep -Fq 'ESTAT_APP_ID=' <<<"${export_out}"; then
+    echo "export emitted legacy ESTAT alias for ${profile}" >&2
+    exit 1
+  fi
+done
+
+echo "mbp/macmini shared secrets simulation passed"

--- a/tests/test-watchdog-alert-policy.sh
+++ b/tests/test-watchdog-alert-policy.sh
@@ -223,6 +223,39 @@ assert_field "workflow-dispatch-force-reason" "due_reasons_csv" "manual-force-li
   --now-epoch 11400 \
   --force-line-alert true
 
+assert_field "waiting-run-under-threshold-suppressed" "should_alert" "false" \
+  --event-name schedule \
+  --persist-state true \
+  --previous-state-json '{}' \
+  --now-epoch 11400 \
+  --openai-ok true \
+  --zai-ok true \
+  --waiting-run-count 1 \
+  --waiting-run-age-minutes 30 \
+  --waiting-run-oldest "Google Workspace Shared Feed Sync#24534657513"
+
+assert_field "waiting-run-over-threshold-alerts" "should_alert" "true" \
+  --event-name schedule \
+  --persist-state true \
+  --previous-state-json '{}' \
+  --now-epoch 11400 \
+  --openai-ok true \
+  --zai-ok true \
+  --waiting-run-count 1 \
+  --waiting-run-age-minutes 61 \
+  --waiting-run-oldest "Google Workspace Shared Feed Sync#24534657513"
+
+assert_field "waiting-run-over-threshold-reason" "due_reasons_csv" "workflow-waiting" \
+  --event-name schedule \
+  --persist-state true \
+  --previous-state-json '{}' \
+  --now-epoch 11400 \
+  --openai-ok true \
+  --zai-ok true \
+  --waiting-run-count 1 \
+  --waiting-run-age-minutes 61 \
+  --waiting-run-oldest "Google Workspace Shared Feed Sync#24534657513"
+
 total=$((total + 1))
 json_output="$(
   bash "${SCRIPT}" \

--- a/tests/test-watchdog-waiting-run-workflow.sh
+++ b/tests/test-watchdog-waiting-run-workflow.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="${ROOT_DIR}/.github/workflows/fugue-watchdog.yml"
+
+grep -Fq 'id: waiting_runs' "${WORKFLOW}"
+grep -Fq -- '--status waiting' "${WORKFLOW}"
+grep -Fq -- '--limit 200' "${WORKFLOW}"
+grep -Fq 'waiting-run-query-failed' "${WORKFLOW}"
+grep -Fq 'query_failed="true"' "${WORKFLOW}"
+grep -Fq 'max_age_minutes="60"' "${WORKFLOW}"
+
+if grep -Fq "2>/dev/null || printf '[]'" "${WORKFLOW}"; then
+  echo "FAIL: waiting run query must not silently collapse failures to an empty list" >&2
+  exit 1
+fi
+
+grep -Fq 'workflow-waiting' "${ROOT_DIR}/scripts/lib/watchdog-alert-policy.sh"
+
+echo "watchdog waiting-run workflow check passed"


### PR DESCRIPTION
## Summary
- add a MBP/macmini shared-secret simulation test with mocked Keychain and SOPS planes
- document SOPS as canonical bootstrap and Keychain/GitHub/env as derived execution planes
- add ESTAT_API_ID to org-secret audit expectations and remove stale TARGET_REPO_PAT false-positive requirements
- add watchdog detection for workflow runs stuck in waiting state, including query-failure alerting
- add CI coverage for the shared-secret contract and wire the new watchdog workflow test into orchestration gate

## Multi-agent review
- Codex reviewer found CI trigger and waiting-run silent failure issues; both were fixed
- GLM reviewed the concrete diff and scored 7/7 after diff handoff
- Copilot reviewed current diff and approved the implementation
- Cursor reviewed with conditions; the silent waiting query failure was fixed

## Validation
- bash tests/test-mbp-macmini-shared-secrets.sh
- bash tests/test-load-shared-secrets.sh
- bash tests/test-sync-gh-secrets-from-env.sh
- bash tests/test-watchdog-waiting-run-workflow.sh
- bash tests/test-watchdog-alert-policy.sh
- ruby YAML parse for fugue-watchdog/shared-secret-contract/fugue-orchestration-gate
- actionlint for touched workflows
- jq . scripts/org-secrets-audit.json
- bash scripts/audit-org-secrets.sh --org cursorvers
- gh run list --status waiting --limit 200 returned 0 after cleanup

## Operational cleanup
- closed stale PR #608 as superseded
- approved the latest workspace-readonly Google Workspace run and it completed
- cancelled older stale waiting runs instead of executing them