### PR TITLE
Fix watchdog alert recovery state persistence

### DIFF
--- a/.github/workflows/fugue-watchdog.yml
+++ b/.github/workflows/fugue-watchdog.yml
@@ -618,6 +618,35 @@ jobs:
             exit 0
           fi
 
+          if [[ -z "${NEXT_STATE_B64:-}" ]]; then
+            echo "::error::watchdog next alert state payload is empty; refusing to overwrite FUGUE_WATCHDOG_ALERT_STATE." >&2
+            exit 1
+          fi
+
+          NEXT_STATE_JSON="$(printf '%s' "${NEXT_STATE_B64:-}" | base64 -d | jq -c 'if type == "object" then . else {} end')"
+          gh variable set FUGUE_WATCHDOG_ALERT_STATE \
+            --repo "${GITHUB_REPOSITORY}" \
+            --body "${NEXT_STATE_JSON}" >/dev/null
+
+      - name: Persist watchdog alert recovery state
+        if: ${{ steps.decide.outputs.should_alert != 'true' && steps.decide.outputs.watchdog_alert_persist == 'true' && steps.decide.outputs.watchdog_alert_state_update_required == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OPS_TOKEN: ${{ secrets.FUGUE_OPS_PAT || secrets.TARGET_REPO_PAT || '' }}
+          NEXT_STATE_B64: ${{ steps.decide.outputs.watchdog_alert_next_state_b64 }}
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${OPS_TOKEN:-}" ]]; then
+            GH_TOKEN="${OPS_TOKEN}"
+            export GH_TOKEN
+          fi
+
+          if [[ -z "${NEXT_STATE_B64:-}" ]]; then
+            echo "::error::watchdog recovery alert state payload is empty; refusing to overwrite FUGUE_WATCHDOG_ALERT_STATE." >&2
+            exit 1
+          fi
+
           NEXT_STATE_JSON="$(printf '%s' "${NEXT_STATE_B64:-}" | base64 -d | jq -c 'if type == "object" then . else {} end')"
           gh variable set FUGUE_WATCHDOG_ALERT_STATE \
             --repo "${GITHUB_REPOSITORY}" \

--- a/tests/test-watchdog-waiting-run-workflow.sh
+++ b/tests/test-watchdog-waiting-run-workflow.sh
@@ -17,5 +17,10 @@ if grep -Fq "2>/dev/null || printf '[]'" "${WORKFLOW}"; then
 fi
 
 grep -Fq 'workflow-waiting' "${ROOT_DIR}/scripts/lib/watchdog-alert-policy.sh"
+grep -Fq 'Persist watchdog alert recovery state' "${WORKFLOW}"
+grep -Fq "steps.decide.outputs.should_alert != 'true'" "${WORKFLOW}"
+grep -Fq "steps.decide.outputs.watchdog_alert_persist == 'true'" "${WORKFLOW}"
+grep -Fq "steps.decide.outputs.watchdog_alert_state_update_required == 'true'" "${WORKFLOW}"
+grep -Fq 'refusing to overwrite FUGUE_WATCHDOG_ALERT_STATE' "${WORKFLOW}"
 
 echo "watchdog waiting-run workflow check passed"


### PR DESCRIPTION
## Summary
- persist pruned watchdog alert state when recovery clears active reasons
- keep alert-path persistence gated by confirmed Discord delivery
- fail closed on empty next-state payload before writing FUGUE_WATCHDOG_ALERT_STATE
- extend watchdog workflow static checks for recovery persistence conditions

## Verification
- bash tests/test-watchdog-waiting-run-workflow.sh
- bash tests/test-watchdog-alert-policy.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/fugue-watchdog.yml"); puts "yaml ok"'
- actionlint .github/workflows/fugue-watchdog.yml
- git diff --check
- bash tests/test-mbp-macmini-shared-secrets.sh
- bash tests/test-load-shared-secrets.sh
- bash tests/test-sync-gh-secrets-from-env.sh
- bash tests/test-install-kernel-launchers.sh
- bash tests/test-vote-launchers.sh