### PR TITLE
Hardening residual FUGUE Kernel orchestration

### DIFF
--- a/.github/workflows/fugue-orchestration-gate.yml
+++ b/.github/workflows/fugue-orchestration-gate.yml
@@ -35,19 +35,26 @@ on:
       - 'scripts/lib/kernel-memory-query.sh'
       - 'scripts/lib/kernel-run-recovery.sh'
       - 'scripts/codex-kernel-guard.sh'
+      - 'scripts/audit-org-secrets.sh'
+      - 'scripts/lib/load-shared-secrets.sh'
       - 'scripts/local/install-kernel-launchers.sh'
+      - 'scripts/local/install-github-actions-tools.sh'
+      - 'scripts/local/sync-gh-secrets-from-env.sh'
       - 'scripts/local/kernel-handoff-summary.sh'
       - 'scripts/local/launchers/**'
       - 'scripts/local/kernel-runtime-loop.sh'
       - 'scripts/check-agent-matrix-parity.sh'
       - 'scripts/check-linked-systems-integrity.sh'
+      - 'scripts/check-peripheral-adapters.sh'
       - 'scripts/check-codex-kernel-prompt.sh'
       - 'scripts/check-codex-vote-prompt.sh'
       - 'scripts/sim-orchestrator-switch.sh'
       - 'scripts/local/run-local-orchestration.sh'
       - 'scripts/local/run-linked-systems.sh'
       - 'scripts/local/integrations/**'
+      - 'scripts/harness/manus-recovery-diagnose.js'
       - 'scripts/harness/run-recovery-console.sh'
+      - 'scripts/harness/run-watchdog-waiting-run-drill.sh'
       - 'tests/test-codex-skill-launch.sh'
       - 'tests/test-codex-vote-prompt.sh'
       - 'tests/test-codex-orchestrator-snippet.sh'
@@ -55,6 +62,10 @@ on:
       - 'tests/test-codex-kernel-guard-matrix.sh'
       - 'tests/test-codex-kernel-guard-state-fallback.sh'
       - 'tests/test-install-kernel-launchers.sh'
+      - 'tests/test-install-github-actions-tools.sh'
+      - 'tests/test-shared-secrets-failure-smoke.sh'
+      - 'tests/test-sync-gh-auth-drill.sh'
+      - 'tests/test-org-secrets-shadow-cleanup.sh'
       - 'tests/test-kernel-auth-evidence.sh'
       - 'tests/test-kernel-dr-continuation.sh'
       - 'tests/test-kernel-entrypoint.sh'
@@ -69,10 +80,12 @@ on:
       - 'tests/test-recovery-reroute-claim-gate.sh'
       - 'tests/test-watchdog-reconcile-claim-policy.sh'
       - 'tests/test-watchdog-reconcile-workflow.sh'
+      - 'tests/test-peripheral-adapter-contract.sh'
       - 'tests/test-route-task-handoff.sh'
       - 'tests/test-resolve-orchestration-context.sh'
       - 'tests/test-canary-trust-policy.sh'
       - 'tests/test-kernel-canary-plan.sh'
+      - 'tests/test-kernel-recovery-console.sh'
       - 'tests/test-watchdog-alert-policy.sh'
       - 'tests/test-watchdog-waiting-run-workflow.sh'
       - 'tests/test-watchdog-alert-delivery-policy.sh'
@@ -142,19 +155,26 @@ on:
       - 'scripts/lib/kernel-memory-query.sh'
       - 'scripts/lib/kernel-run-recovery.sh'
       - 'scripts/codex-kernel-guard.sh'
+      - 'scripts/audit-org-secrets.sh'
+      - 'scripts/lib/load-shared-secrets.sh'
       - 'scripts/local/install-kernel-launchers.sh'
+      - 'scripts/local/install-github-actions-tools.sh'
+      - 'scripts/local/sync-gh-secrets-from-env.sh'
       - 'scripts/local/kernel-handoff-summary.sh'
       - 'scripts/local/launchers/**'
       - 'scripts/local/kernel-runtime-loop.sh'
       - 'scripts/check-agent-matrix-parity.sh'
       - 'scripts/check-linked-systems-integrity.sh'
+      - 'scripts/check-peripheral-adapters.sh'
       - 'scripts/check-codex-kernel-prompt.sh'
       - 'scripts/check-codex-vote-prompt.sh'
       - 'scripts/sim-orchestrator-switch.sh'
       - 'scripts/local/run-local-orchestration.sh'
       - 'scripts/local/run-linked-systems.sh'
       - 'scripts/local/integrations/**'
+      - 'scripts/harness/manus-recovery-diagnose.js'
       - 'scripts/harness/run-recovery-console.sh'
+      - 'scripts/harness/run-watchdog-waiting-run-drill.sh'
       - 'tests/test-codex-skill-launch.sh'
       - 'tests/test-codex-vote-prompt.sh'
       - 'tests/test-codex-orchestrator-snippet.sh'
@@ -162,6 +182,10 @@ on:
       - 'tests/test-codex-kernel-guard-matrix.sh'
       - 'tests/test-codex-kernel-guard-state-fallback.sh'
       - 'tests/test-install-kernel-launchers.sh'
+      - 'tests/test-install-github-actions-tools.sh'
+      - 'tests/test-shared-secrets-failure-smoke.sh'
+      - 'tests/test-sync-gh-auth-drill.sh'
+      - 'tests/test-org-secrets-shadow-cleanup.sh'
       - 'tests/test-kernel-auth-evidence.sh'
       - 'tests/test-kernel-dr-continuation.sh'
       - 'tests/test-kernel-entrypoint.sh'
@@ -176,10 +200,12 @@ on:
       - 'tests/test-recovery-reroute-claim-gate.sh'
       - 'tests/test-watchdog-reconcile-claim-policy.sh'
       - 'tests/test-watchdog-reconcile-workflow.sh'
+      - 'tests/test-peripheral-adapter-contract.sh'
       - 'tests/test-route-task-handoff.sh'
       - 'tests/test-resolve-orchestration-context.sh'
       - 'tests/test-canary-trust-policy.sh'
       - 'tests/test-kernel-canary-plan.sh'
+      - 'tests/test-kernel-recovery-console.sh'
       - 'tests/test-watchdog-alert-policy.sh'
       - 'tests/test-watchdog-waiting-run-workflow.sh'
       - 'tests/test-watchdog-alert-delivery-policy.sh'
@@ -289,11 +315,18 @@ jobs:
           bash_n scripts/lib/kernel-memory-query.sh
           bash_n scripts/lib/kernel-run-recovery.sh
           bash_n scripts/codex-kernel-guard.sh
+          bash_n scripts/audit-org-secrets.sh
+          bash_n scripts/lib/load-shared-secrets.sh
+          bash_n scripts/local/install-github-actions-tools.sh
+          bash_n scripts/local/sync-gh-secrets-from-env.sh
           bash_n scripts/local/kernel-handoff-summary.sh
           bash_n scripts/local/kernel-runtime-loop.sh
+          node --check scripts/harness/manus-recovery-diagnose.js
           bash_n scripts/harness/run-recovery-console.sh
+          bash_n scripts/harness/run-watchdog-waiting-run-drill.sh
           bash_n scripts/check-agent-matrix-parity.sh
           bash_n scripts/check-linked-systems-integrity.sh
+          bash_n scripts/check-peripheral-adapters.sh
           bash_n scripts/check-codex-kernel-prompt.sh
           bash_n scripts/check-codex-vote-prompt.sh
           bash_n tests/test-codex-kernel-prompt.sh
@@ -312,15 +345,21 @@ jobs:
           bash_n tests/test-recovery-reroute-claim-gate.sh
           bash_n tests/test-watchdog-reconcile-claim-policy.sh
           bash_n tests/test-watchdog-reconcile-workflow.sh
+          bash_n tests/test-peripheral-adapter-contract.sh
           bash_n tests/test-workspace-root-policy.sh
           bash_n tests/test-canary-trust-policy.sh
           bash_n tests/test-kernel-canary-plan.sh
+          bash_n tests/test-kernel-recovery-console.sh
           bash_n tests/test-watchdog-waiting-run-workflow.sh
           bash_n tests/test-kernel-entrypoint.sh
           bash_n tests/test-kernel-launcher.sh
           bash_n tests/test-kernel-launcher-template.sh
           bash_n tests/test-k4-launcher.sh
           bash_n tests/test-install-kernel-launchers.sh
+          bash_n tests/test-install-github-actions-tools.sh
+          bash_n tests/test-shared-secrets-failure-smoke.sh
+          bash_n tests/test-sync-gh-auth-drill.sh
+          bash_n tests/test-org-secrets-shadow-cleanup.sh
           bash_n tests/test-kernel-runtime-claim.sh
           bash_n tests/test-kernel-runtime-health.sh
           bash_n tests/test-kernel-runtime-launch.sh
@@ -363,6 +402,7 @@ jobs:
           run_required tests/test-codex-kernel-prompt.sh
           run_required tests/test-codex-orchestrator-snippet.sh
           run_required tests/test-install-kernel-launchers.sh
+          run_required tests/test-install-github-actions-tools.sh
           run_required tests/test-codex-kernel-guard-doctor.sh
           run_required tests/test-codex-kernel-guard-matrix.sh
           run_required tests/test-codex-kernel-guard-state-fallback.sh
@@ -377,6 +417,10 @@ jobs:
           bash tests/test-resolve-orchestration-context.sh
           bash tests/test-watchdog-alert-policy.sh
           bash tests/test-watchdog-waiting-run-workflow.sh
+          bash tests/test-kernel-recovery-console.sh
+          bash tests/test-shared-secrets-failure-smoke.sh
+          bash tests/test-sync-gh-auth-drill.sh
+          bash tests/test-org-secrets-shadow-cleanup.sh
           bash tests/test-watchdog-alert-delivery-policy.sh
           bash tests/test-primary-heartbeat-state.sh
           bash tests/test-publish-decision-journal.sh
@@ -387,6 +431,7 @@ jobs:
           bash tests/test-recovery-reroute-claim-gate.sh
           bash tests/test-watchdog-reconcile-claim-policy.sh
           bash tests/test-watchdog-reconcile-workflow.sh
+          bash tests/test-peripheral-adapter-contract.sh
           bash tests/test-workspace-root-policy.sh
 
       - name: x-auto linked system tests
@@ -483,6 +528,7 @@ jobs:
           chmod +x scripts/lib/build-agent-matrix.sh scripts/check-agent-matrix-parity.sh scripts/check-linked-systems-integrity.sh
           ./scripts/check-agent-matrix-parity.sh
           ./scripts/check-linked-systems-integrity.sh
+          ./scripts/check-peripheral-adapters.sh --mode contract
 
       - name: Deterministic switch simulation
         run: |

--- a/docs/github-actions-org-secret-migration.md
+++ b/docs/github-actions-org-secret-migration.md
@@ -80,6 +80,28 @@ Use:
 bash scripts/audit-org-secrets.sh --org cursorvers
 ```
 
+To plan repo-secret shadow cleanup after org coverage exists:
+
+```bash
+bash scripts/audit-org-secrets.sh --org cursorvers --cleanup-shadows
+```
+
+To actually delete safe repo shadows:
+
+```bash
+bash scripts/audit-org-secrets.sh --org cursorvers --apply-cleanup
+```
+
+`--apply-cleanup` deletes a repo-level secret only when all of the following are
+true:
+
+- the secret is listed as preferred org scope
+- the secret is not listed in `allow_repo_secrets`
+- org-level access is available
+- the org secret already covers that repo
+
+If any condition is not proven, the script keeps the repo secret and reports why.
+
 To sync available current-shell or external-file values across every configured repo:
 
 ```bash

--- a/docs/kernel-fugue-version-up-completion-2026-04-17.md
+++ b/docs/kernel-fugue-version-up-completion-2026-04-17.md
@@ -151,13 +151,17 @@ Critical review lanes converged on the same result:
 
 ## Remaining Non-Blocking Hardening
 
-These items are outside the current completion gate:
+These items were outside the original completion gate. Follow-up hardening now has implementation support:
 
-- install `actionlint` on macmini for local parity with MBP and CI
-- clean up org-secret / repo-secret shadowing when org-level permission is available
-- add explicit failure-smoke drills for locked Keychain, missing SOPS, and missing `gh` auth
-- document a waiting-run end-to-end drill for operational runbooks
-- add SLO-style metrics for self-heal and canary latency
+- `scripts/local/install-github-actions-tools.sh` checks/installs local `actionlint`
+- `scripts/audit-org-secrets.sh --cleanup-shadows` plans safe repo-shadow cleanup
+- failure-smoke drills cover locked Keychain, missing SOPS, and missing `gh` auth
+- waiting-run drill is documented in `docs/runbook/fugue-watchdog-waiting-run-drill.md`
+- canary and Manus diagnosis emit SLO-compatible metrics
+
+The only remaining external gate is org-level permission for applying org-secret
+cleanup. Without that permission, repo-secret fallback remains the designed safe
+mode.
 
 ## Final Status
 

--- a/docs/kernel-recovery-runbook.md
+++ b/docs/kernel-recovery-runbook.md
@@ -98,6 +98,7 @@ Use when Manus should be checked as a standby recovery lane without spending Man
 Behavior:
 
 - checks whether the Manus client and key resolution path are available
+- emits SLO-compatible fields: health score, blocking condition, and dependency check latency
 - writes a diagnosis and recommendations to the workflow summary
 - does not start a live Manus task by default
 
@@ -113,6 +114,25 @@ Recommended input:
 4. If legacy rollback must remain available, run `rollback-canary`
 5. If Manus may be needed as a standby repair lane, run `manus-diagnose`
 6. If a real issue is stuck, run `reroute-issue`
+
+## Waiting-Run Drill
+
+Use the deterministic local drill before live queue experiments:
+
+```bash
+bash scripts/harness/run-watchdog-waiting-run-drill.sh \
+  --waiting-run-count 1 \
+  --waiting-run-age-minutes 61
+```
+
+Expected result:
+
+- `should_alert=true`
+- `workflow-waiting` appears in the watchdog reasons
+
+Full procedure:
+
+- [fugue-watchdog-waiting-run-drill.md](/Users/masayuki/Dev/fugue-orchestrator-handoff-hardening/docs/runbook/fugue-watchdog-waiting-run-drill.md)
 
 ## Recovery Guarantees
 

--- a/docs/kernel/interfaces/schema-v1.md
+++ b/docs/kernel/interfaces/schema-v1.md
@@ -17,6 +17,7 @@ The canonical shared secret names are:
 - `ZAI_API_KEY`
 - `GEMINI_API_KEY`
 - `XAI_API_KEY`
+- `ESTAT_API_ID`
 - `TARGET_REPO_PAT`
 - `FUGUE_OPS_PAT`
 
@@ -26,14 +27,17 @@ Runtime resolves shared secrets in this order:
 
 1. `process env`
 2. `Keychain`
-3. `explicit external env file`
+3. `shared SOPS bundle`
+4. `explicit external env file`
 
-The encrypted shared bundle is `bootstrap / restore` only. Routine runtime does not decrypt it.
+The encrypted shared bundle is the canonical bootstrap / restore source and a disaster-recovery fallback. Routine attended operation should be satisfied by process env or Keychain, but runtime loaders may use the bundle before falling back to an explicitly configured external env file.
 
 ### Compatibility
 
 - `XAI_API` is a legacy alias for `XAI_API_KEY`.
+- `ESTAT_APP_ID` is a legacy alias for `ESTAT_API_ID`.
 - New runtime code should emit and consume canonical names only.
+- Doctor views must print source and length only, never secret values.
 
 ## 2. Bootstrap Receipt Schema
 

--- a/docs/org-secrets.md
+++ b/docs/org-secrets.md
@@ -29,6 +29,22 @@ Run:
 scripts/audit-org-secrets.sh --org cursorvers
 ```
 
+Plan safe repo-shadow cleanup:
+
+```bash
+scripts/audit-org-secrets.sh --org cursorvers --cleanup-shadows
+```
+
+Apply cleanup only after reviewing the dry-run:
+
+```bash
+scripts/audit-org-secrets.sh --org cursorvers --apply-cleanup
+```
+
+Cleanup is intentionally conservative. It removes a repo-level secret only when
+the preferred org secret is confirmed to cover the repo and the name is not in
+`allow_repo_secrets`.
+
 Bootstrap/update secrets from local process env or an explicit external env file:
 ```bash
 bash scripts/local/sync-gh-secrets-from-env.sh --dry-run

--- a/docs/runbook/fugue-watchdog-waiting-run-drill.md
+++ b/docs/runbook/fugue-watchdog-waiting-run-drill.md
@@ -1,0 +1,77 @@
+# FUGUE Watchdog Waiting-Run Drill
+
+## Purpose
+
+Verify that `fugue-watchdog` treats old GitHub Actions `waiting` runs as a
+control-plane health signal instead of silently collapsing query failures or
+stuck queues to "healthy".
+
+This drill is intentionally split into deterministic local simulation and
+operator-attended live verification.
+
+## Local Deterministic Drill
+
+Run:
+
+```bash
+bash scripts/harness/run-watchdog-waiting-run-drill.sh \
+  --waiting-run-count 1 \
+  --waiting-run-age-minutes 61 \
+  --waiting-run-oldest "drill-workflow/123"
+```
+
+Expected:
+
+- `should_alert=true`
+- `workflow-waiting` appears in the active or due reasons
+- the generated message includes the simulated waiting run label
+
+Suppression check:
+
+```bash
+bash scripts/harness/run-watchdog-waiting-run-drill.sh \
+  --waiting-run-count 0 \
+  --waiting-run-age-minutes 0
+```
+
+Expected:
+
+- `should_alert=false`
+- no `workflow-waiting` reason
+
+## Live Operator Drill
+
+Use this only when an operator intentionally wants to validate live GitHub
+queue behavior. Do not create artificial workload during production incidents.
+
+1. Confirm the current queue:
+
+```bash
+gh run list \
+  --repo cursorvers/fugue-orchestrator \
+  --status waiting \
+  --limit 200 \
+  --json databaseId,workflowName,status,createdAt,url
+```
+
+2. Trigger watchdog manually:
+
+```bash
+gh workflow run fugue-watchdog.yml --repo cursorvers/fugue-orchestrator --ref main
+```
+
+3. Confirm the `Detect waiting workflow runs` and `Decide whether to alert`
+   steps. If no live waiting run is older than the threshold, this is a healthy
+   no-alert result.
+
+4. If a stale waiting run exists, confirm that the alert reason is
+   `workflow-waiting` and that `FUGUE_WATCHDOG_ALERT_STATE` is updated only
+   through the alert or recovery persistence paths.
+
+## Safety Rules
+
+- Do not print secret values.
+- Do not cancel or rerun unrelated production jobs just to force a waiting run.
+- Do not persist drill-only state unless the run is an actual watchdog alert.
+- Treat query failure as unhealthy: the workflow must never turn a failed
+  waiting-run query into an empty list.

--- a/rules/secrets-management.md
+++ b/rules/secrets-management.md
@@ -13,7 +13,7 @@ GitHub Organization Secrets (shared CI)    <- first choice for shared automation
 +-- OPENAI_API_KEY
 +-- ZAI_API_KEY
 +-- ANTHROPIC_API_KEY
-+-- GEMINI_API_KEY / XAI_API_KEY
++-- GEMINI_API_KEY / XAI_API_KEY / ESTAT_API_ID
 +-- shared webhook / ops credentials
 
 GitHub Repository / Environment Secrets    <- repo- or env-specific CI only
@@ -66,9 +66,10 @@ Preferred local resolution order for shared secrets:
 
 1. process env override
 2. local Keychain/shared secret cache
-3. explicit external env file
+3. shared encrypted SOPS bundle
+4. explicit external env file
 
-The encrypted shared bundle is for bootstrap / restore, not for routine runtime reads.
+The encrypted shared bundle is the canonical bootstrap / restore source and a disaster-recovery fallback. Routine attended operation should be satisfied by process env or Keychain; explicit external env files are last-resort imports and must live outside the repository.
 
 ## Workspace Rule
 
@@ -80,7 +81,7 @@ The encrypted shared bundle is for bootstrap / restore, not for routine runtime 
 ## Kernel / FUGUE Compatibility
 
 - Secret **names** are the contract. Orchestrator choice must not require renaming secrets.
-- `Kernel` and `FUGUE` should both resolve the same canonical names (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `ZAI_API_KEY`, `TARGET_REPO_PAT`, `FUGUE_OPS_PAT`, etc.).
+- `Kernel` and `FUGUE` should both resolve the same canonical names (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `ZAI_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`, `ESTAT_API_ID`, `TARGET_REPO_PAT`, `FUGUE_OPS_PAT`, etc.).
 - Provider-specific adapters may be optional, but secret naming stays stable so rollback from `Kernel` to `FUGUE` does not require secret migration.
 - Shared local resolution should happen through a common loader, not by each orchestrator inventing its own lookup order.
 

--- a/scripts/audit-org-secrets.sh
+++ b/scripts/audit-org-secrets.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 # Usage:
 #   scripts/audit-org-secrets.sh --org cursorvers
 #   scripts/audit-org-secrets.sh --org cursorvers --config scripts/org-secrets-audit.json
+#   scripts/audit-org-secrets.sh --org cursorvers --cleanup-shadows
 #
 # Exit codes:
 # - 0: all good (or warnings only)
@@ -19,6 +20,8 @@ set -euo pipefail
 ORG=""
 CONFIG="scripts/org-secrets-audit.json"
 FALLBACK_REASON=""
+CLEANUP_SHADOWS="false"
+APPLY_CLEANUP="false"
 
 while [[ $# -gt 0 ]]; do
   case "${1}" in
@@ -26,13 +29,21 @@ while [[ $# -gt 0 ]]; do
       ORG="${2}"; shift 2;;
     --config)
       CONFIG="${2}"; shift 2;;
+    --cleanup-shadows)
+      CLEANUP_SHADOWS="true"; shift;;
+    --apply-cleanup)
+      CLEANUP_SHADOWS="true"; APPLY_CLEANUP="true"; shift;;
     -h|--help)
       cat <<'EOF'
-Usage: scripts/audit-org-secrets.sh --org <org> [--config <path>]
+Usage: scripts/audit-org-secrets.sh --org <org> [--config <path>] [--cleanup-shadows] [--apply-cleanup]
 
 Audits GitHub Actions secrets to help centralize them as organization secrets.
 If org-level secret access is unavailable, the script falls back to repo-only
 classification so migration planning can continue.
+
+Shadow cleanup is dry-run by default. --apply-cleanup deletes a repo-level
+secret only when a preferred org secret already covers the repo and the secret
+is not listed in allow_repo_secrets.
 EOF
       exit 0;;
     *)
@@ -195,6 +206,54 @@ secret_is_covered_for_repo() {
     return 0
   fi
   return 1
+}
+
+org_secret_covers_repo() {
+  local repo="$1"
+  local secret="$2"
+  [[ "${org_access}" == "true" ]] || return 1
+
+  local org_vis
+  org_vis="$(org_secret_visibility "${secret}")"
+  if [[ "${org_vis}" == "all" ]]; then
+    return 0
+  fi
+  if [[ "${org_vis}" == "selected" ]] && get_selected_repos_for_secret "${secret}" | has_line_exact "${repo}"; then
+    return 0
+  fi
+  return 1
+}
+
+cleanup_repo_shadow_secret() {
+  local repo="$1"
+  local secret="$2"
+
+  if [[ "${CLEANUP_SHADOWS}" != "true" ]]; then
+    return 0
+  fi
+
+  if [[ -n "${allow_repo_secrets}" ]] && printf '%s\n' "${allow_repo_secrets}" | has_line_exact "${secret}"; then
+    printf '  KEEP  %s (repo secret is allowed by allow_repo_secrets)\n' "${secret}"
+    return 0
+  fi
+
+  if ! org_secret_covers_repo "${repo}" "${secret}"; then
+    printf '  KEEP  %s (repo shadow not removed; org coverage is not confirmed)\n' "${secret}"
+    warnings=$((warnings+1))
+    return 0
+  fi
+
+  if [[ "${APPLY_CLEANUP}" != "true" ]]; then
+    printf '  CLEANUP-DRY-RUN %s (repo shadow can be deleted; org secret covers repo)\n' "${secret}"
+    return 0
+  fi
+
+  if GH_PROMPT_DISABLED=1 gh secret delete "${secret}" --repo "${repo}" >/dev/null; then
+    printf '  CLEANUP-OK %s (deleted repo shadow; org secret covers repo)\n' "${secret}"
+  else
+    printf '  CLEANUP-FAIL %s (repo shadow delete failed)\n' "${secret}" >&2
+    failures=$((failures+1))
+  fi
 }
 
 repo_count=0
@@ -420,6 +479,7 @@ while IFS= read -r repo; do
       while IFS= read -r candidate; do
         [[ -z "${candidate}" ]] && continue
         printf '    - %s\n' "${candidate}"
+        cleanup_repo_shadow_secret "${repo}" "${candidate}"
       done <<<"${migrate_candidates}"
     fi
   fi

--- a/scripts/check-peripheral-adapters.sh
+++ b/scripts/check-peripheral-adapters.sh
@@ -2,8 +2,20 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-MANIFEST="${ROOT_DIR}/config/integrations/peripheral-adapters.json"
-LOCAL_SYSTEMS_MANIFEST="${ROOT_DIR}/config/integrations/local-systems.json"
+MANIFEST="${PERIPHERAL_ADAPTER_MANIFEST:-${ROOT_DIR}/config/integrations/peripheral-adapters.json}"
+LOCAL_SYSTEMS_MANIFEST="${PERIPHERAL_LOCAL_SYSTEMS_MANIFEST:-${ROOT_DIR}/config/integrations/local-systems.json}"
+CHECK_MODE="${PERIPHERAL_ADAPTER_CHECK_MODE:-contract}"
+
+usage() {
+  cat <<'EOF'
+Usage: check-peripheral-adapters.sh [--mode contract|strict]
+
+Modes:
+  contract  Validate manifest schema, local-linked paths, and in-repo contract files.
+            Cross-repo paths outside this repository may be absent and are reported as warnings.
+  strict    Validate every declared path exists on this machine.
+EOF
+}
 
 fail() {
   echo "[FAIL] $*" >&2
@@ -17,6 +29,38 @@ pass() {
 require_cmd() {
   command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
 }
+
+while (($# > 0)); do
+  case "$1" in
+    --mode)
+      if [[ -z "${2:-}" ]]; then
+        fail "--mode requires one of: contract, strict"
+      fi
+      CHECK_MODE="${2:-}"
+      shift 2
+      ;;
+    --mode=*)
+      CHECK_MODE="${1#--mode=}"
+      shift
+      ;;
+    --strict)
+      CHECK_MODE="strict"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+case "${CHECK_MODE}" in
+  contract|strict) ;;
+  *) fail "invalid check mode: ${CHECK_MODE}" ;;
+esac
 
 require_cmd jq
 [[ -f "${MANIFEST}" ]] || fail "manifest not found: ${MANIFEST}"
@@ -124,7 +168,18 @@ while IFS= read -r row; do
   else
     resolved_path="${ROOT_DIR}/${path_value}"
   fi
-  [[ -e "${resolved_path}" ]] || fail "adapter=${id} path missing: ${path_value}"
+
+  if [[ ! -e "${resolved_path}" ]]; then
+    if [[ "${CHECK_MODE}" == "contract" && "${scope}" == "cross-repo" && "${resolved_path}" == "${ROOT_DIR}/../"* ]]; then
+      echo "[WARN] adapter=${id} cross-repo path not checked in contract mode: ${path_value}" >&2
+      continue
+    fi
+    if [[ "${CHECK_MODE}" == "contract" && "${scope}" == "skill" && "${resolved_path}" != "${ROOT_DIR}/"* ]]; then
+      echo "[WARN] adapter=${id} external skill path not checked in contract mode: ${path_value}" >&2
+      continue
+    fi
+    fail "adapter=${id} path missing: ${path_value}"
+  fi
 
   if [[ "${adapter_class}" == "shell" ]]; then
     [[ -f "${resolved_path}" ]] || fail "adapter=${id} shell path is not a file: ${path_value}"
@@ -139,5 +194,5 @@ while IFS= read -r row; do
   fi
 done < <(jq -c '.adapters[]' "${MANIFEST}")
 
-pass "adapter paths and local-linked references valid"
+pass "adapter paths and local-linked references valid (mode=${CHECK_MODE})"
 echo "peripheral adapter contract check passed"

--- a/scripts/harness/manus-recovery-diagnose.js
+++ b/scripts/harness/manus-recovery-diagnose.js
@@ -18,11 +18,13 @@ function boolEnv(name, fallback = false) {
 }
 
 function resolveManusAccess() {
+  const started = Date.now();
   if (!fs.existsSync(MANUS_CLIENT_PATH)) {
     return {
       apiKeyAvailable: false,
       clientAvailable: false,
       reason: "manus-client-missing",
+      checkLatencyMs: Date.now() - started,
     };
   }
   try {
@@ -32,12 +34,14 @@ function resolveManusAccess() {
       apiKeyAvailable: Boolean(key),
       clientAvailable: true,
       reason: key ? "key-resolved" : "key-missing",
+      checkLatencyMs: Date.now() - started,
     };
   } catch (err) {
     return {
       apiKeyAvailable: false,
       clientAvailable: false,
       reason: `client-load-failed: ${String(err && err.message ? err.message : err).slice(0, 120)}`,
+      checkLatencyMs: Date.now() - started,
     };
   }
 }
@@ -61,15 +65,35 @@ function main() {
   recommendations.push("use-manus-only-for-novel-diagnosis-or-artifact-synthesis-after-local-tests-fail");
   recommendations.push("keep-manus-live-execution-manual-until-diagnosis-receipts-are-stable");
 
+  const blockingCondition = !access.clientAvailable
+    ? "api"
+    : !access.apiKeyAvailable
+      ? "auth"
+      : "none";
+  const overallHealthScore = access.clientAvailable && access.apiKeyAvailable
+    ? 100
+    : access.clientAvailable
+      ? 70
+      : 40;
+
   const receipt = {
     success: true,
     provider: "manus",
     mode: "diagnose",
+    sloVersion: 1,
     execute,
     liveExecutionStarted: false,
     clientAvailable: access.clientAvailable,
     apiKeyAvailable: access.apiKeyAvailable,
     accessReason: access.reason,
+    checkLatencyMs: access.checkLatencyMs,
+    overallHealthScore,
+    blockingCondition,
+    componentHealth: {
+      client: access.clientAvailable ? "ok" : "missing",
+      apiKey: access.apiKeyAvailable ? "ok" : "missing",
+      liveExecution: "disabled",
+    },
     input: {
       repo,
       issueNumber,
@@ -83,12 +107,15 @@ function main() {
 
   if (execute) {
     receipt.success = false;
+    receipt.overallHealthScore = Math.min(receipt.overallHealthScore, 30);
+    receipt.blockingCondition = "execute";
+    receipt.componentHealth.liveExecution = "blocked";
     receipt.nextAction = "manual-approval-required-for-live-manus-repair";
     receipt.recommendations.unshift("live-manus-repair-is-intentionally-disabled-in-diagnose-mode");
   }
 
-  process.stdout.write(`${JSON.stringify(receipt)}\n`);
-  process.exit(receipt.success ? 0 : 2);
+  console.log(JSON.stringify(receipt));
+  process.exitCode = receipt.success ? 0 : 2;
 }
 
 main();

--- a/scripts/harness/run-canary.sh
+++ b/scripts/harness/run-canary.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 #   CANARY_MODE_INPUT    — full (default) or lite
 #   CANARY_EXECUTION_MODE_OVERRIDE — canary dispatch override (default: primary)
 #   CANARY_PLAN_ONLY     — true to print resolved cases without touching GitHub
+#   CANARY_SLO_TARGET_SECONDS — latency target for full canary completion (default: 900)
 #
 # Usage: bash scripts/harness/run-canary.sh
 
@@ -156,9 +157,11 @@ report_json="${report_dir}/canary-report.json"
 report_md="${report_dir}/canary-report.md"
 case_results_file="${report_dir}/case-results.jsonl"
 progress_file="${report_dir}/progress-events.jsonl"
+metrics_file="${report_dir}/canary-metrics.jsonl"
 mkdir -p "${report_dir}"
 : >"${case_results_file}"
 : >"${progress_file}"
+: >"${metrics_file}"
 
 record_case_result() {
   local case_name="$1"
@@ -253,6 +256,11 @@ write_canary_report() {
   local final_status="$1"
   local elapsed_seconds
   elapsed_seconds="$(( $(date -u '+%s') - canary_started_epoch ))"
+  local slo_target_seconds
+  slo_target_seconds="$(printf '%s' "${CANARY_SLO_TARGET_SECONDS:-900}" | tr -cd '0-9')"
+  if [[ -z "${slo_target_seconds}" || "${slo_target_seconds}" == "0" ]]; then
+    slo_target_seconds="900"
+  fi
 
   jq -n \
     --arg generated_at "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
@@ -271,9 +279,14 @@ write_canary_report() {
     --argjson verify_rollback_case "$( [[ "${verify_rollback_case}" == "true" ]] && printf 'true' || printf 'false' )" \
     --argjson failures "${failures}" \
     --argjson elapsed_seconds "${elapsed_seconds}" \
+    --argjson slo_target_seconds "${slo_target_seconds}" \
     --slurpfile cases "${case_results_file}" \
     --slurpfile progress "${progress_file}" \
-    '{
+    '($cases // []) as $case_rows
+    | ($case_rows | length) as $checks_total
+    | ($case_rows | map(select(.status == "passed")) | length) as $checks_passed
+    | ($case_rows | map(select(.status == "failed")) | length) as $checks_failed
+    | {
       version: 1,
       generated_at: $generated_at,
       repository: $repo,
@@ -292,8 +305,43 @@ write_canary_report() {
       github_ref_name: (if $github_ref_name == "" then null else $github_ref_name end),
       report_dir: $report_dir,
       progress: ($progress // []),
-      cases: ($cases // [])
+      cases: $case_rows,
+      slo: {
+        version: 1,
+        component: "fugue-orchestrator-canary",
+        target_seconds: $slo_target_seconds,
+        elapsed_seconds: $elapsed_seconds,
+        latency_status: (
+          if $plan_only then "not-applicable"
+          elif $elapsed_seconds <= $slo_target_seconds then "ok"
+          else "breach"
+          end
+        ),
+        checks_total: $checks_total,
+        checks_passed: $checks_passed,
+        checks_failed: $checks_failed,
+        pass_rate: (if $checks_total == 0 then 0 else (($checks_passed / $checks_total) * 100) end),
+        error_rate: (if $checks_total == 0 then 0 else (($checks_failed / $checks_total) * 100) end),
+        health_score: (
+          if $plan_only then 100
+          elif $checks_total == 0 then 0
+          else (100 - (($checks_failed / $checks_total) * 100))
+          end
+        )
+      }
     }' >"${report_json}"
+
+  jq -c '{
+    generated_at,
+    repository,
+    canary_mode,
+    final_status,
+    github_run_id,
+    github_ref_name,
+    plan_only,
+    verify_rollback_case,
+    slo
+  }' "${report_json}" >>"${metrics_file}"
 
   {
     echo "## Fugue Orchestrator Canary"
@@ -306,6 +354,9 @@ write_canary_report() {
     echo "- Elapsed seconds: ${elapsed_seconds}"
     echo "- Default main: ${default_main_provider}"
     echo "- Alternate main: ${canary_alternate_main}"
+    echo "- SLO target seconds: $(jq -r '.slo.target_seconds' "${report_json}")"
+    echo "- SLO latency status: $(jq -r '.slo.latency_status' "${report_json}")"
+    echo "- SLO health score: $(jq -r '.slo.health_score' "${report_json}")"
     echo ""
     echo "### Progress"
     jq -r '

--- a/scripts/harness/run-recovery-console.sh
+++ b/scripts/harness/run-recovery-console.sh
@@ -286,7 +286,13 @@ dispatch_workflow() {
 
 load_reconcile_claim_state() {
   if gh variable list --repo "${repo}" >/dev/null 2>&1; then
-    gh api "repos/${repo}/actions/variables/FUGUE_RECONCILE_CLAIM_STATE" --jq '.value' 2>/dev/null || printf '{}'
+    local value
+    value="$(gh api "repos/${repo}/actions/variables/FUGUE_RECONCILE_CLAIM_STATE" --jq '.value' 2>/dev/null || true)"
+    if [[ -n "${value}" ]]; then
+      printf '%s\n' "${value}"
+    else
+      printf '{}'
+    fi
   else
     printf '{}'
   fi
@@ -372,6 +378,7 @@ reroute_issue() {
 
 manus_diagnose() {
   local receipt run_url api_key_available client_available access_reason next_action live_started
+  local health_score blocking_condition check_latency_ms
   run_url="$(current_run_url)"
 
   append_summary "## Manus Recovery Diagnosis"
@@ -392,10 +399,16 @@ manus_diagnose() {
   access_reason="$(printf '%s' "${receipt}" | jq -r '.accessReason')"
   live_started="$(printf '%s' "${receipt}" | jq -r '.liveExecutionStarted')"
   next_action="$(printf '%s' "${receipt}" | jq -r '.nextAction')"
+  health_score="$(printf '%s' "${receipt}" | jq -r '.overallHealthScore')"
+  blocking_condition="$(printf '%s' "${receipt}" | jq -r '.blockingCondition')"
+  check_latency_ms="$(printf '%s' "${receipt}" | jq -r '.checkLatencyMs')"
 
   append_summary "- manus client available: \`${client_available}\`"
   append_summary "- manus api key available: \`${api_key_available}\`"
   append_summary "- access reason: \`${access_reason}\`"
+  append_summary "- health score: \`${health_score}\`"
+  append_summary "- blocking condition: \`${blocking_condition}\`"
+  append_summary "- check latency ms: \`${check_latency_ms}\`"
   append_summary "- live manus task started: \`${live_started}\`"
   append_summary "- next action: \`${next_action}\`"
   append_summary ""

--- a/scripts/harness/run-watchdog-waiting-run-drill.sh
+++ b/scripts/harness/run-watchdog-waiting-run-drill.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+POLICY_SCRIPT="${ROOT_DIR}/scripts/lib/watchdog-alert-policy.sh"
+
+waiting_run_count="1"
+waiting_run_age_minutes="61"
+waiting_run_oldest="drill-workflow/123"
+persist_state="false"
+previous_state_json='{}'
+format="json"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  run-watchdog-waiting-run-drill.sh [options]
+
+Options:
+  --waiting-run-count <n>        Simulated waiting workflow count (default: 1)
+  --waiting-run-age-minutes <n>  Simulated oldest waiting age (default: 61)
+  --waiting-run-oldest <label>   Simulated oldest waiting run label
+  --persist-state <true|false>   Whether policy should calculate persisted state
+  --previous-state-json <json>   Previous watchdog alert state JSON
+  --format <json|env>            Output format passed to policy
+
+This is a deterministic local drill. It does not query or mutate GitHub.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --waiting-run-count)
+      waiting_run_count="${2:-}"
+      shift 2
+      ;;
+    --waiting-run-age-minutes)
+      waiting_run_age_minutes="${2:-}"
+      shift 2
+      ;;
+    --waiting-run-oldest)
+      waiting_run_oldest="${2:-}"
+      shift 2
+      ;;
+    --persist-state)
+      persist_state="${2:-}"
+      shift 2
+      ;;
+    --previous-state-json)
+      previous_state_json="${2:-}"
+      shift 2
+      ;;
+    --format)
+      format="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: ${1}" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+bash "${POLICY_SCRIPT}" \
+  --event-name schedule \
+  --failover-state healthy \
+  --failover-reason primary-heartbeat-fresh \
+  --gha-execution-mode full \
+  --runner-online-count 1 \
+  --heartbeat-status fresh \
+  --heartbeat-age-minutes 1 \
+  --router-hours 0 \
+  --router-minutes 5 \
+  --mainframe-hours 0 \
+  --mainframe-minutes 5 \
+  --pending-count 0 \
+  --mainframe-pending-count 0 \
+  --waiting-run-count "${waiting_run_count}" \
+  --waiting-run-age-minutes "${waiting_run_age_minutes}" \
+  --waiting-run-oldest "${waiting_run_oldest}" \
+  --persist-state "${persist_state}" \
+  --previous-state-json "${previous_state_json}" \
+  --format "${format}"

--- a/scripts/lib/load-shared-secrets.sh
+++ b/scripts/lib/load-shared-secrets.sh
@@ -111,7 +111,8 @@ resolve_from_env_file() {
 
   local value
   value="$(
-    env -i bash -lc '
+    # Deliberately non-login and empty-env: external env imports must not depend on user shell profiles.
+    env -i bash -c '
       set -a
       source "$1"
       set +a
@@ -127,7 +128,8 @@ resolve_from_env_file() {
   while IFS= read -r alias_name; do
     [[ -n "${alias_name}" ]] || continue
     value="$(
-      env -i bash -lc '
+      # Deliberately non-login and empty-env: external env imports must not depend on user shell profiles.
+      env -i bash -c '
         set -a
         source "$1"
         set +a

--- a/scripts/local/install-github-actions-tools.sh
+++ b/scripts/local/install-github-actions-tools.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTIONLINT_GO_PACKAGE="${ACTIONLINT_GO_PACKAGE:-github.com/rhysd/actionlint/cmd/actionlint@latest}"
+CHECK_ONLY=false
+DRY_RUN=false
+
+usage() {
+  cat <<'EOF'
+Usage:
+  install-github-actions-tools.sh [--check] [--dry-run]
+
+Installs local GitHub Actions validation tools used by FUGUE / Kernel operators.
+
+Tools:
+  - actionlint
+
+Install strategy:
+  1) use existing actionlint if present
+  2) brew install actionlint when Homebrew is available
+  3) go install github.com/rhysd/actionlint/cmd/actionlint@latest when Go is available
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --check)
+      CHECK_ONLY=true
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown option: ${1}" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+actionlint_status() {
+  if command -v actionlint >/dev/null 2>&1; then
+    local version
+    version="$(actionlint -version 2>/dev/null || true)"
+    if [[ -z "${version}" ]]; then
+      version="version-unknown"
+    fi
+    echo "actionlint: ok (${version})"
+    return 0
+  fi
+  echo "actionlint: missing"
+  return 1
+}
+
+if [[ "${CHECK_ONLY}" == "true" ]]; then
+  actionlint_status || true
+  exit 0
+fi
+
+if actionlint_status >/dev/null; then
+  actionlint_status
+  exit 0
+fi
+
+if command -v brew >/dev/null 2>&1; then
+  echo "install actionlint via Homebrew"
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "DRY-RUN: brew install actionlint"
+  else
+    brew install actionlint
+  fi
+elif command -v go >/dev/null 2>&1; then
+  echo "install actionlint via go install ${ACTIONLINT_GO_PACKAGE}"
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "DRY-RUN: go install ${ACTIONLINT_GO_PACKAGE}"
+  else
+    go install "${ACTIONLINT_GO_PACKAGE}"
+  fi
+else
+  echo "Error: actionlint missing and neither brew nor go is available." >&2
+  exit 1
+fi
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  exit 0
+fi
+
+actionlint_status

--- a/tests/test-install-github-actions-tools.sh
+++ b/tests/test-install-github-actions-tools.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/local/install-github-actions-tools.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/bin"
+
+out="$(PATH="${TMP_DIR}/bin:/usr/bin:/bin" bash "${SCRIPT}" --check)"
+grep -Fq 'actionlint: missing' <<<"${out}"
+
+cat >"${TMP_DIR}/bin/actionlint" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-version" ]]; then
+  echo "1.7.7"
+else
+  exit 0
+fi
+EOF
+chmod +x "${TMP_DIR}/bin/actionlint"
+out="$(PATH="${TMP_DIR}/bin:/usr/bin:/bin" bash "${SCRIPT}" --check)"
+grep -Fq 'actionlint: ok (1.7.7)' <<<"${out}"
+
+rm -f "${TMP_DIR}/bin/actionlint"
+cat >"${TMP_DIR}/bin/brew" <<'EOF'
+#!/usr/bin/env bash
+printf 'brew %s\n' "$*"
+EOF
+chmod +x "${TMP_DIR}/bin/brew"
+out="$(PATH="${TMP_DIR}/bin:/usr/bin:/bin" bash "${SCRIPT}" --dry-run)"
+grep -Fq 'install actionlint via Homebrew' <<<"${out}"
+grep -Fq 'DRY-RUN: brew install actionlint' <<<"${out}"
+
+rm -f "${TMP_DIR}/bin/brew"
+cat >"${TMP_DIR}/bin/go" <<'EOF'
+#!/usr/bin/env bash
+printf 'go %s\n' "$*"
+EOF
+chmod +x "${TMP_DIR}/bin/go"
+out="$(PATH="${TMP_DIR}/bin:/usr/bin:/bin" ACTIONLINT_GO_PACKAGE="example.com/actionlint@v1" bash "${SCRIPT}" --dry-run)"
+grep -Fq 'install actionlint via go install example.com/actionlint@v1' <<<"${out}"
+grep -Fq 'DRY-RUN: go install example.com/actionlint@v1' <<<"${out}"
+
+echo "install github actions tools check passed"

--- a/tests/test-kernel-canary-plan.sh
+++ b/tests/test-kernel-canary-plan.sh
@@ -71,6 +71,14 @@ grep -q 'progress-events.jsonl' "${CANARY_SCRIPT}" || {
   echo "FAIL: canary script missing durable progress event file" >&2
   exit 1
 }
+grep -q 'canary-metrics.jsonl' "${CANARY_SCRIPT}" || {
+  echo "FAIL: canary script missing durable SLO metrics file" >&2
+  exit 1
+}
+grep -q 'CANARY_SLO_TARGET_SECONDS' "${CANARY_SCRIPT}" || {
+  echo "FAIL: canary script missing SLO target configuration" >&2
+  exit 1
+}
 grep -q 'GITHUB_STEP_SUMMARY' "${CANARY_SCRIPT}" || {
   echo "FAIL: canary script should append report to GITHUB_STEP_SUMMARY when available" >&2
   exit 1
@@ -263,6 +271,7 @@ plan_output="$(
   CANARY_WAIT_FAST_SLEEP_SEC="1" \
     CANARY_WAIT_SLOW_ATTEMPTS="0" \
     CANARY_WAIT_SLOW_SLEEP_SEC="1" \
+    CANARY_SLO_TARGET_SECONDS="900" \
     CANARY_REPORT_DIR="${TMP_DIR}/report" \
     GITHUB_STEP_SUMMARY="${TMP_DIR}/summary.md" \
     bash "${CANARY_SCRIPT}"
@@ -319,6 +328,10 @@ rollback_task_size="$(printf '%s\n' "${plan_output}" | jq -r 'select(.case == "r
   echo "FAIL: expected canary progress event output" >&2
   exit 1
 }
+[[ -f "${TMP_DIR}/report/canary-metrics.jsonl" ]] || {
+  echo "FAIL: expected canary SLO metrics output" >&2
+  exit 1
+}
 report_status="$(jq -r '.final_status' "${TMP_DIR}/report/canary-report.json")"
 [[ "${report_status}" == "planned" ]] || {
   echo "FAIL: expected planned final status in canary report, got ${report_status}" >&2
@@ -331,6 +344,16 @@ report_case_count="$(jq -r '.cases | length' "${TMP_DIR}/report/canary-report.js
 }
 jq -e '.progress | length >= 4' "${TMP_DIR}/report/canary-report.json" >/dev/null || {
   echo "FAIL: expected progress events in canary report json" >&2
+  exit 1
+}
+jq -e '.slo.version == 1 and .slo.component == "fugue-orchestrator-canary" and .slo.target_seconds == 900 and .slo.latency_status == "not-applicable" and .slo.health_score == 100' "${TMP_DIR}/report/canary-report.json" >/dev/null || {
+  echo "FAIL: expected canary report SLO payload" >&2
+  cat "${TMP_DIR}/report/canary-report.json" >&2
+  exit 1
+}
+jq -e '.slo.component == "fugue-orchestrator-canary" and .final_status == "planned"' "${TMP_DIR}/report/canary-metrics.jsonl" >/dev/null || {
+  echo "FAIL: expected canary metrics JSONL payload" >&2
+  cat "${TMP_DIR}/report/canary-metrics.jsonl" >&2
   exit 1
 }
 grep -Fq '"phase":"bootstrap"' "${TMP_DIR}/report/progress-events.jsonl" || {
@@ -347,6 +370,10 @@ grep -Fq '| regular | planned | plan-only | codex |  |' "${TMP_DIR}/report/canar
 }
 grep -Fq '### Progress' "${TMP_DIR}/report/canary-report.md" || {
   echo "FAIL: expected progress section in canary markdown report" >&2
+  exit 1
+}
+grep -Fq 'SLO latency status: not-applicable' "${TMP_DIR}/report/canary-report.md" || {
+  echo "FAIL: expected SLO status in canary markdown report" >&2
   exit 1
 }
 grep -Fq '### Progress' "${TMP_DIR}/summary.md" || {

--- a/tests/test-kernel-recovery-console.sh
+++ b/tests/test-kernel-recovery-console.sh
@@ -39,16 +39,24 @@ grep -q 'manus-recovery-diagnose.js' "${SCRIPT}" || {
   echo "FAIL: manus-diagnose mode should call the Manus diagnosis helper" >&2
   exit 1
 }
+grep -q 'overallHealthScore' "${ROOT_DIR}/scripts/harness/manus-recovery-diagnose.js" || {
+  echo "FAIL: manus diagnosis should emit an SLO-compatible health score" >&2
+  exit 1
+}
+grep -q 'blockingCondition' "${ROOT_DIR}/scripts/harness/manus-recovery-diagnose.js" || {
+  echo "FAIL: manus diagnosis should emit blocking condition telemetry" >&2
+  exit 1
+}
 grep -q 'gh issue comment "${status_issue}"' "${SCRIPT}" || {
   echo "FAIL: mobile-progress should post into the status issue" >&2
   exit 1
 }
 REROUTE_BLOCK="$(sed -n '/reroute_issue()/,/^}/p' "${SCRIPT}")"
-printf '%s' "${REROUTE_BLOCK}" | grep -q '"fugue-caller.yml"' || {
+grep -q '"fugue-caller.yml"' <<<"${REROUTE_BLOCK}" || {
   echo "FAIL: reroute-issue should dispatch fugue-caller.yml" >&2
   exit 1
 }
-if printf '%s' "${REROUTE_BLOCK}" | grep -q '"fugue-task-router.yml"'; then
+if grep -q '"fugue-task-router.yml"' <<<"${REROUTE_BLOCK}"; then
   echo "FAIL: reroute-issue should not dispatch fugue-task-router.yml directly" >&2
   exit 1
 fi
@@ -139,6 +147,14 @@ grep -q 'Manus Recovery Diagnosis' "${FAKE_SUMMARY}" || {
 }
 grep -q 'live manus task started: `false`' "${FAKE_SUMMARY}" || {
   echo "FAIL: manus-diagnose must not start a live Manus task by default" >&2
+  exit 1
+}
+grep -q 'health score:' "${FAKE_SUMMARY}" || {
+  echo "FAIL: manus-diagnose should include health score in summary" >&2
+  exit 1
+}
+grep -q 'blocking condition:' "${FAKE_SUMMARY}" || {
+  echo "FAIL: manus-diagnose should include blocking condition in summary" >&2
   exit 1
 }
 

--- a/tests/test-org-secrets-shadow-cleanup.sh
+++ b/tests/test-org-secrets-shadow-cleanup.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/audit-org-secrets.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+CONFIG="${TMP_DIR}/org-secrets.json"
+cat >"${CONFIG}" <<'EOF'
+{
+  "preferred_org_secrets": ["OPENAI_API_KEY"],
+  "optional_org_secrets": [],
+  "preferred_org_variables": [],
+  "allow_repo_secrets": ["TARGET_REPO_PAT"],
+  "repos": {
+    "cursorvers/fugue-orchestrator": {
+      "required": ["OPENAI_API_KEY"],
+      "required_any": []
+    }
+  }
+}
+EOF
+
+mkdir -p "${TMP_DIR}/bin"
+GH_LOG="${TMP_DIR}/gh.log"
+cat >"${TMP_DIR}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${GH_LOG}"
+
+if [[ "${1:-}" == "secret" && "${2:-}" == "list" && "${3:-}" == "--org" ]]; then
+  printf 'OPENAI_API_KEY\t2026-04-17T00:00:00Z\tselected\n'
+  exit 0
+fi
+if [[ "${1:-}" == "variable" && "${2:-}" == "list" && "${3:-}" == "--org" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" == "secret" && "${2:-}" == "list" && "${3:-}" == "--repo" ]]; then
+  printf 'OPENAI_API_KEY\t2026-04-17T00:00:00Z\n'
+  exit 0
+fi
+if [[ "${1:-}" == "api" && "${2:-}" == "orgs/cursorvers/actions/secrets/OPENAI_API_KEY/repositories" ]]; then
+  printf 'cursorvers/fugue-orchestrator\n'
+  exit 0
+fi
+if [[ "${1:-}" == "secret" && "${2:-}" == "delete" ]]; then
+  for arg in "$@"; do
+    if [[ "${arg}" == "--yes" ]]; then
+      echo "unsupported flag: --yes" >&2
+      exit 2
+    fi
+  done
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "${TMP_DIR}/bin/gh"
+
+out="$(
+  PATH="${TMP_DIR}/bin:/usr/bin:/bin" \
+  GH_LOG="${GH_LOG}" \
+  bash "${SCRIPT}" --org cursorvers --config "${CONFIG}" --cleanup-shadows
+)"
+grep -Fq 'MIGRATE preferred org candidates:' <<<"${out}"
+grep -Fq 'CLEANUP-DRY-RUN OPENAI_API_KEY' <<<"${out}"
+if grep -Fq 'secret delete OPENAI_API_KEY' "${GH_LOG}"; then
+  echo "dry-run cleanup must not delete repo secrets" >&2
+  exit 1
+fi
+
+out="$(
+  PATH="${TMP_DIR}/bin:/usr/bin:/bin" \
+  GH_LOG="${GH_LOG}" \
+  bash "${SCRIPT}" --org cursorvers --config "${CONFIG}" --apply-cleanup
+)"
+grep -Fq 'CLEANUP-OK OPENAI_API_KEY' <<<"${out}"
+grep -Fq 'secret delete OPENAI_API_KEY --repo cursorvers/fugue-orchestrator' "${GH_LOG}"
+
+CONFIG_ALLOWED="${TMP_DIR}/org-secrets-allowed.json"
+cat >"${CONFIG_ALLOWED}" <<'EOF'
+{
+  "preferred_org_secrets": ["OPENAI_API_KEY"],
+  "optional_org_secrets": [],
+  "preferred_org_variables": [],
+  "allow_repo_secrets": ["OPENAI_API_KEY"],
+  "repos": {
+    "cursorvers/fugue-orchestrator": {
+      "required": ["OPENAI_API_KEY"],
+      "required_any": []
+    }
+  }
+}
+EOF
+: >"${GH_LOG}"
+out="$(
+  PATH="${TMP_DIR}/bin:/usr/bin:/bin" \
+  GH_LOG="${GH_LOG}" \
+  bash "${SCRIPT}" --org cursorvers --config "${CONFIG_ALLOWED}" --apply-cleanup
+)"
+grep -Fq 'OK    OPENAI_API_KEY (repo secret)' <<<"${out}"
+if grep -Fq 'secret delete OPENAI_API_KEY' "${GH_LOG}"; then
+  echo "allow_repo_secrets must prevent repo secret cleanup" >&2
+  exit 1
+fi
+
+echo "org secrets shadow cleanup check passed"

--- a/tests/test-peripheral-adapter-contract.sh
+++ b/tests/test-peripheral-adapter-contract.sh
@@ -13,6 +13,80 @@ fi
 bash "${CHECK_SCRIPT}" >/dev/null
 echo "PASS [check-script]"
 
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+cat >"${TMP_DIR}/local-systems.json" <<'JSON'
+{
+  "systems": [
+    {
+      "id": "local-dummy",
+      "name": "Local Dummy",
+      "path": "scripts/local/integrations/auto-video.sh"
+    }
+  ]
+}
+JSON
+
+cat >"${TMP_DIR}/peripheral-adapters.json" <<'JSON'
+{
+  "adapters": [
+    {
+      "id": "cross-repo-missing-contract",
+      "scope": "cross-repo",
+      "kind": "service",
+      "adapter_class": "external-contract",
+      "authority": "protected-external",
+      "validation_mode": "contract",
+      "contract_owner": "external",
+      "preferred_lane": "external",
+      "protected_interface": true,
+      "path": "../definitely-missing-repo/adapter.ts"
+    },
+    {
+      "id": "missing-external-skill",
+      "scope": "skill",
+      "kind": "artifact",
+      "adapter_class": "skill",
+      "authority": "artifact-only",
+      "validation_mode": "contract",
+      "contract_owner": "kernel-local",
+      "preferred_lane": "codex",
+      "protected_interface": false,
+      "path": "/Users/example/.codex/skills/missing/SKILL.md"
+    }
+  ]
+}
+JSON
+
+PERIPHERAL_ADAPTER_MANIFEST="${TMP_DIR}/peripheral-adapters.json" \
+  PERIPHERAL_LOCAL_SYSTEMS_MANIFEST="${TMP_DIR}/local-systems.json" \
+  bash "${CHECK_SCRIPT}" --mode contract >/dev/null
+echo "PASS [contract-mode-missing-cross-repo]"
+echo "PASS [contract-mode-missing-external-skill]"
+
+set +e
+PERIPHERAL_ADAPTER_MANIFEST="${TMP_DIR}/peripheral-adapters.json" \
+  PERIPHERAL_LOCAL_SYSTEMS_MANIFEST="${TMP_DIR}/local-systems.json" \
+  bash "${CHECK_SCRIPT}" --mode strict >/dev/null 2>&1
+strict_rc=$?
+set -e
+if [[ "${strict_rc}" == "0" ]]; then
+  echo "FAIL: strict mode should reject missing cross-repo paths" >&2
+  exit 1
+fi
+echo "PASS [strict-mode-missing-cross-repo]"
+
+set +e
+bash "${CHECK_SCRIPT}" --mode >/dev/null 2>&1
+missing_mode_rc=$?
+set -e
+if [[ "${missing_mode_rc}" == "0" ]]; then
+  echo "FAIL: --mode without value should fail" >&2
+  exit 1
+fi
+echo "PASS [mode-missing-value]"
+
 jq -e '.adapters[] | select(.id == "railway-kernel-edge-intake" and .authority == "gateway" and .ingress_auth == "webhook-signature" and .accepts_signed_payload == true and .fail_closed == true and (.dedupe_strategy | length > 0))' "${MANIFEST}" >/dev/null || {
   echo "FAIL: missing Railway edge intake ingress contract" >&2
   exit 1
@@ -31,4 +105,4 @@ jq -e '.adapters[] | select(.id == "railway-happy-web-boundary" and .authority =
 }
 echo "PASS [railway-happy-web-boundary]"
 
-echo "=== Results: 4/4 passed, 0 failed ==="
+echo "=== Results: 8/8 passed, 0 failed ==="

--- a/tests/test-shared-secrets-failure-smoke.sh
+++ b/tests/test-shared-secrets-failure-smoke.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/lib/load-shared-secrets.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/bin"
+
+cat >"${TMP_DIR}/bin/security" <<'EOF'
+#!/usr/bin/env bash
+echo "security: SecKeychainSearchCopyNext: User interaction is not allowed." >&2
+exit 36
+EOF
+chmod +x "${TMP_DIR}/bin/security"
+
+cat >"${TMP_DIR}/bin/sops" <<'EOF'
+#!/usr/bin/env bash
+printf 'OPENAI_API_KEY=sops-openai\nFUGUE_OPS_PAT=sops-fugue-ops\n'
+EOF
+chmod +x "${TMP_DIR}/bin/sops"
+
+touch "${TMP_DIR}/bundle.enc" "${TMP_DIR}/keys.txt"
+
+run_loader_clean() {
+  env -i \
+    HOME="${TMP_DIR}/home" \
+    PATH="${TMP_DIR}/bin:/usr/bin:/bin" \
+    SHARED_SECRETS_SOPS_FILE="${SHARED_SECRETS_SOPS_FILE:-}" \
+    SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-}" \
+    SHARED_SECRETS_ENV_FILE="${SHARED_SECRETS_ENV_FILE:-}" \
+    bash "${SCRIPT}" "$@"
+}
+
+mkdir -p "${TMP_DIR}/home"
+
+out="$(
+  SHARED_SECRETS_SOPS_FILE="${TMP_DIR}/bundle.enc" \
+    SOPS_AGE_KEY_FILE="${TMP_DIR}/keys.txt" \
+    run_loader_clean source-of OPENAI_API_KEY
+)"
+[[ "${out}" == "sops-bundle" ]]
+
+rm -f "${TMP_DIR}/bin/sops"
+cat >"${TMP_DIR}/external.env" <<'EOF'
+OPENAI_API_KEY=external-openai
+EOF
+out="$(
+  SHARED_SECRETS_SOPS_FILE="${TMP_DIR}/missing.enc" \
+    SOPS_AGE_KEY_FILE="${TMP_DIR}/missing-keys.txt" \
+    SHARED_SECRETS_ENV_FILE="${TMP_DIR}/external.env" \
+    run_loader_clean source-of OPENAI_API_KEY
+)"
+[[ "${out}" == "external-env" ]]
+
+set +e
+missing_out="$(
+  SHARED_SECRETS_SOPS_FILE="${TMP_DIR}/missing.enc" \
+    SOPS_AGE_KEY_FILE="${TMP_DIR}/missing-keys.txt" \
+    SHARED_SECRETS_ENV_FILE="" \
+    run_loader_clean get ZAI_API_KEY 2>&1
+)"
+missing_rc=$?
+set -e
+[[ "${missing_rc}" != "0" ]]
+[[ -z "${missing_out}" ]]
+
+doctor="$(
+  SHARED_SECRETS_SOPS_FILE="${TMP_DIR}/missing.enc" \
+    SOPS_AGE_KEY_FILE="${TMP_DIR}/missing-keys.txt" \
+    SHARED_SECRETS_ENV_FILE="" \
+    run_loader_clean doctor ZAI_API_KEY
+)"
+grep -Fq 'ZAI_API_KEY: missing' <<<"${doctor}"
+if grep -Fq 'external-openai' <<<"${doctor}"; then
+  echo "doctor must not print secret values" >&2
+  exit 1
+fi
+
+echo "shared secrets failure smoke passed"

--- a/tests/test-sync-gh-auth-drill.sh
+++ b/tests/test-sync-gh-auth-drill.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/local/sync-gh-secrets-from-env.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+mkdir -p "${TMP_DIR}/bin"
+cat >"${TMP_DIR}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+  echo "not logged in" >&2
+  exit 1
+fi
+exit 0
+EOF
+chmod +x "${TMP_DIR}/bin/gh"
+
+export OPENAI_API_KEY="dry-run-openai"
+export ZAI_API_KEY="dry-run-zai"
+export ESTAT_API_ID="dry-run-estat"
+export TARGET_REPO_PAT="dry-run-target"
+export FUGUE_OPS_PAT="dry-run-ops"
+export SHARED_SECRETS_SOPS_FILE="${TMP_DIR}/missing.enc"
+export SOPS_AGE_KEY_FILE="${TMP_DIR}/missing-keys.txt"
+
+dry_run_out="$(PATH="${TMP_DIR}/bin:/usr/bin:/bin" bash "${SCRIPT}" --dry-run)"
+grep -Fq 'mode=dry-run' <<<"${dry_run_out}"
+grep -Fq 'DRY-RUN: set org secret OPENAI_API_KEY from OPENAI_API_KEY' <<<"${dry_run_out}"
+
+set +e
+apply_out="$(PATH="${TMP_DIR}/bin:/usr/bin:/bin" bash "${SCRIPT}" --apply 2>&1)"
+apply_rc=$?
+set -e
+[[ "${apply_rc}" == "1" ]]
+grep -Fq 'Error: gh auth is not ready.' <<<"${apply_out}"
+
+echo "sync gh auth drill passed"

--- a/tests/test-watchdog-waiting-run-workflow.sh
+++ b/tests/test-watchdog-waiting-run-workflow.sh
@@ -3,6 +3,17 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="${ROOT_DIR}/.github/workflows/fugue-watchdog.yml"
+DRILL="${ROOT_DIR}/scripts/harness/run-watchdog-waiting-run-drill.sh"
+
+assert_eq() {
+  local actual="$1"
+  local expected="$2"
+  local label="$3"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "FAIL: ${label}: expected=${expected} actual=${actual}" >&2
+    exit 1
+  fi
+}
 
 grep -Fq 'id: waiting_runs' "${WORKFLOW}"
 grep -Fq -- '--status waiting' "${WORKFLOW}"
@@ -22,5 +33,17 @@ grep -Fq "steps.decide.outputs.should_alert != 'true'" "${WORKFLOW}"
 grep -Fq "steps.decide.outputs.watchdog_alert_persist == 'true'" "${WORKFLOW}"
 grep -Fq "steps.decide.outputs.watchdog_alert_state_update_required == 'true'" "${WORKFLOW}"
 grep -Fq 'refusing to overwrite FUGUE_WATCHDOG_ALERT_STATE' "${WORKFLOW}"
+grep -Fq 'run-watchdog-waiting-run-drill.sh' "${ROOT_DIR}/docs/runbook/fugue-watchdog-waiting-run-drill.md"
+
+alert_json="$(bash "${DRILL}" --waiting-run-count 1 --waiting-run-age-minutes 61 --waiting-run-oldest 'drill-workflow/123')"
+if ! jq -e '.active_reasons | index("workflow-waiting") != null' <<<"${alert_json}" >/dev/null; then
+  echo "FAIL: waiting run drill must include workflow-waiting active reason" >&2
+  echo "${alert_json}" >&2
+  exit 1
+fi
+grep -Fq 'drill-workflow/123' <<<"$(jq -r '.message' <<<"${alert_json}")"
+
+quiet_json="$(bash "${DRILL}" --waiting-run-count 0 --waiting-run-age-minutes 0)"
+assert_eq "$(jq -r '.should_alert' <<<"${quiet_json}")" "false" "quiet waiting run should not alert"
 
 echo "watchdog waiting-run workflow check passed"


### PR DESCRIPTION
## Summary
- Add local actionlint installer/check and wire residual hardening tests into fugue-orchestration-gate
- Harden shared secret loader failure paths, MBP/macmini simulation, org-secret shadow cleanup, and peripheral adapter contract/strict modes
- Add canary/Manus SLO telemetry, recovery console diagnostics, and deterministic watchdog waiting-run drill/runbook

## Multi-agent review
- GLM code-reviewer scored the initial patch 5/7 and flagged allow_repo_secrets cleanup safety; fixed with explicit allow-list guard and tests
- Codex reviewer flagged unsupported gh --yes and missing Manus telemetry CI gate; fixed by using GH_PROMPT_DISABLED=1, adding JS/test path triggers, node --check, and test execution
- Gemini/Cursor/Copilot CLIs are present locally, but not consumed for this shell/CI hardening pass to avoid unnecessary quota burn

## Verification
- bash -n changed shell scripts/tests
- node --check scripts/harness/manus-recovery-diagnose.js
- actionlint fugue-orchestration-gate/canary/watchdog workflows
- Ruby YAML parse for all workflows
- git diff --check / git diff --cached --check
- tests/test-shared-secrets-failure-smoke.sh
- tests/test-load-shared-secrets.sh
- tests/test-mbp-macmini-shared-secrets.sh
- tests/test-sync-gh-auth-drill.sh
- tests/test-org-secrets-shadow-cleanup.sh
- tests/test-peripheral-adapter-contract.sh
- scripts/check-peripheral-adapters.sh --mode contract
- tests/test-kernel-canary-plan.sh
- tests/test-kernel-recovery-console.sh
- tests/test-watchdog-waiting-run-workflow.sh
- tests/test-watchdog-alert-policy.sh
- tests/test-watchdog-alert-delivery-policy.sh
- tests/test-watchdog-reconcile-claim-policy.sh
- tests/test-watchdog-reconcile-workflow.sh

## Residual risk
- scripts/sim-kernel-peripherals.sh full peripheral simulation is not runnable on this host until deno is installed; contract-mode peripheral validation is covered.

## Progress report
- Current objective completion: 99% after local implementation and multi-agent fixes.
- Remaining slices: 1 slice for PR CI/merge and macmini application if checks pass.
