### PR TITLE
fieldy(telegram-review): Stage 1-4 security hardening

### DIFF
--- a/fieldy-task-shifter/scripts/fieldy-telegram-review.mjs
+++ b/fieldy-task-shifter/scripts/fieldy-telegram-review.mjs
@@ -21,6 +21,8 @@ const DEFAULT_STATE_PATH = path.join(os.homedir(), 'Fieldy', 'state', 'telegram-
 const POLL_LOCK_FILENAME = 'telegram-review-poll.pid';
 const TELEGRAM_API_BASE = 'https://api.telegram.org';
 const CALLBACK_PREFIX = 'fr:';
+const FIELDY_TELEGRAM_KEYCHAIN_SERVICE = 'fieldy-telegram-review';
+const DEFAULT_EXPECTED_BOT_USERNAME = 'masayuki_fieldy_review_bot';
 const BUCKET_LABELS = {
   task_candidates: 'Task',
   belief_candidates: 'Belief/Philosophy',
@@ -38,9 +40,15 @@ const REQUIRED_REVIEW_ENV = [
   'TELEGRAM_REVIEW_CHAT_ID',
   'TELEGRAM_ALLOWED_USER_ID',
 ];
+const SECRET_ALIASES = {
+  TELEGRAM_BOT_TOKEN: ['FIELDY_TELEGRAM_BOT_TOKEN', 'TELEGRAM_REVIEW_BOT_TOKEN', 'TELEGRAM_BOT_TOKEN'],
+  TELEGRAM_REVIEW_CHAT_ID: ['FIELDY_TELEGRAM_REVIEW_CHAT_ID', 'TELEGRAM_REVIEW_CHAT_ID'],
+  TELEGRAM_ALLOWED_USER_ID: ['FIELDY_TELEGRAM_ALLOWED_USER_ID', 'TELEGRAM_ALLOWED_USER_ID'],
+};
 const defaultFsOps = {
   writeFileSync: fs.writeFileSync,
   openSync: fs.openSync,
+  writeSync: fs.writeSync,
   fsyncSync: fs.fsyncSync,
   closeSync: fs.closeSync,
   renameSync: fs.renameSync,
@@ -56,16 +64,45 @@ function getArg(name) {
   return index >= 0 ? args[index + 1] ?? null : null;
 }
 
-function resolveSecret(name) {
+function resolveSecretName(name) {
   if (process.env[name]) return process.env[name] || '';
   try {
-    return execFileSync('zsh', [
+    const fugueValue = execFileSync('zsh', [
       '-lc',
       `source "$HOME/.zshenv" >/dev/null 2>&1 || true; if typeset -f _fugue_secret >/dev/null 2>&1; then _fugue_secret ${name}; fi`,
+    ], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    if (fugueValue) return fugueValue;
+  } catch {
+    // Fall through to the dedicated Fieldy keychain service.
+  }
+  try {
+    return execFileSync('/usr/bin/security', [
+      'find-generic-password',
+      '-s',
+      FIELDY_TELEGRAM_KEYCHAIN_SERVICE,
+      '-a',
+      name,
+      '-w',
     ], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
   } catch {
     return '';
   }
+}
+
+function resolveSecret(name) {
+  for (const candidate of SECRET_ALIASES[name] || [name]) {
+    const value = resolveSecretName(candidate);
+    if (value) return value;
+  }
+  return '';
+}
+
+function resolveConfiguredSecret(name, resolver) {
+  for (const candidate of SECRET_ALIASES[name] || [name]) {
+    const value = String(resolver(candidate) || '').trim();
+    if (value) return value;
+  }
+  return '';
 }
 
 function requireEnv(name) {
@@ -88,7 +125,7 @@ export function preflightTelegramReviewEnv(commandName, resolver = resolveSecret
   const values = {};
   const missing = [];
   for (const name of REQUIRED_REVIEW_ENV) {
-    const value = String(resolver(name) || '').trim();
+    const value = resolveConfiguredSecret(name, resolver);
     if (!value) {
       missing.push(name);
     } else {
@@ -167,9 +204,20 @@ function writeJson(filePath, value) {
   atomicWriteFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
 }
 
-function appendJsonl(filePath, value) {
-  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
-  atomicWriteFileSync(filePath, `${existing}${JSON.stringify(value)}\n`);
+export function appendJsonl(filePath, value) {
+  const line = `${JSON.stringify(value)}\n`;
+  const byteLength = Buffer.byteLength(line);
+  if (byteLength > 4096) {
+    throw new Error(`appendJsonl: line too large for atomic O_APPEND (${byteLength} > 4096 bytes)`);
+  }
+  ensureDir(path.dirname(filePath));
+  const fd = fsOps.openSync(filePath, 'a');
+  try {
+    fsOps.writeSync(fd, line);
+    fsOps.fsyncSync(fd);
+  } finally {
+    fsOps.closeSync(fd);
+  }
 }
 
 function sleep(ms) {
@@ -328,6 +376,21 @@ async function telegramRequest(token, method, body, options) {
   return telegramFetch(token, method, body, options);
 }
 
+function expectedBotUsername() {
+  return (optionalEnv('FIELDY_TELEGRAM_EXPECTED_BOT_USERNAME') || DEFAULT_EXPECTED_BOT_USERNAME).replace(/^@/, '');
+}
+
+async function assertExpectedBot(token) {
+  const expected = expectedBotUsername();
+  if (!expected) return null;
+  const me = await telegramRequest(token, 'getMe', {});
+  const username = String(me?.username || '').replace(/^@/, '');
+  if (username !== expected) {
+    throw new Error(`Telegram bot mismatch: expected @${expected}, got @${username || 'unknown'}`);
+  }
+  return me;
+}
+
 async function getUpdates(token, offset) {
   return telegramRequest(token, 'getUpdates', {
     offset,
@@ -449,7 +512,7 @@ function createKeyboard(item) {
   const tokens = loadActionTokens();
   const actions = [
     { text: '採用', action: 'approve' },
-    { text: 'あとで', action: 'snooze' },
+    { text: '修正', action: 'revise' },
     { text: '捨てる', action: 'reject' },
     { text: '詳細', action: 'detail' },
   ];
@@ -586,6 +649,7 @@ async function cmdWhoami() {
 async function cmdSendTest() {
   const token = requireEnv('TELEGRAM_BOT_TOKEN');
   const chatId = requireEnv('TELEGRAM_REVIEW_CHAT_ID');
+  await assertExpectedBot(token);
   await telegramRequest(token, 'sendMessage', {
     chat_id: chatId,
     text: 'Fieldy Review Bot test',
@@ -598,6 +662,7 @@ async function cmdDaily() {
   const env = preflightTelegramReviewEnv('daily');
   const token = env.TELEGRAM_BOT_TOKEN;
   const chatId = env.TELEGRAM_REVIEW_CHAT_ID;
+  if (!dryRun) await assertExpectedBot(token);
   const date = todayJst();
   const existing = loadReviewItems(date);
   const existingIds = new Set(existing.map((item) => item.id));
@@ -663,9 +728,16 @@ async function removeButtons(token, callback) {
 
 function nextStatus(action) {
   if (action === 'approve') return 'approved';
-  if (action === 'snooze') return 'snoozed';
+  if (action === 'revise') return 'needs_edit';
   if (action === 'reject') return 'rejected';
   return null;
+}
+
+function actionResponseText(action) {
+  if (action === 'approve') return '採用しました';
+  if (action === 'revise') return '修正対象にしました';
+  if (action === 'reject') return '捨てました';
+  return '処理しました';
 }
 
 export async function handleCallback(token, callback, env = preflightTelegramReviewEnv('poll')) {
@@ -742,7 +814,7 @@ export async function handleCallback(token, callback, env = preflightTelegramRev
   saveActionTokens(tokens);
 
   await removeButtons(token, callback);
-  await answerCallback(token, callback.id, actionToken.action === 'approve' ? '採用しました' : actionToken.action === 'snooze' ? 'あとで見ます' : '捨てました');
+  await answerCallback(token, callback.id, actionResponseText(actionToken.action));
 }
 
 async function cmdPoll() {
@@ -750,6 +822,7 @@ async function cmdPoll() {
   registerTelegramPollLockCleanup(lock);
   const env = preflightTelegramReviewEnv('poll');
   const token = env.TELEGRAM_BOT_TOKEN;
+  await assertExpectedBot(token);
   const state = readJson(statePath(), {});
   const updates = await getUpdates(token, state.offset);
   let maxUpdateId = state.offset ? state.offset - 1 : -1;
@@ -767,6 +840,9 @@ function usage() {
   npm run fieldy:telegram:send-test
   npm run fieldy:telegram:daily -- [--dry-run] [--limit 5]
   npm run fieldy:telegram:poll
+
+Expected bot username:
+  FIELDY_TELEGRAM_EXPECTED_BOT_USERNAME defaults to ${DEFAULT_EXPECTED_BOT_USERNAME}
 
 Required secrets/env:
   TELEGRAM_BOT_TOKEN

--- a/fieldy-task-shifter/scripts/fieldy-telegram-review.mjs
+++ b/fieldy-task-shifter/scripts/fieldy-telegram-review.mjs
@@ -1,0 +1,792 @@
+#!/usr/bin/env node
+/**
+ * Telegram review UI for Fieldy distilled candidates.
+ *
+ * Telegram is a review surface only. It never stores source-of-truth state and
+ * never receives raw transcripts. Secrets must be provided through env or the
+ * local _fugue_secret helper; they are never printed.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_INTELLIGENCE_DIR = path.join(os.homedir(), 'Fieldy', 'intelligence');
+const DEFAULT_REVIEW_DIR = path.join(os.homedir(), 'Fieldy', 'telegram-review');
+const DEFAULT_DECISION_DIR = path.join(os.homedir(), 'Fieldy', 'review-decisions');
+const DEFAULT_STATE_PATH = path.join(os.homedir(), 'Fieldy', 'state', 'telegram-review-state.json');
+const POLL_LOCK_FILENAME = 'telegram-review-poll.pid';
+const TELEGRAM_API_BASE = 'https://api.telegram.org';
+const CALLBACK_PREFIX = 'fr:';
+const BUCKET_LABELS = {
+  task_candidates: 'Task',
+  belief_candidates: 'Belief/Philosophy',
+  cursorvers_ops_candidates: 'Cursorvers Ops',
+  knowledge_candidates: 'Knowledge',
+};
+const CATEGORY_PRIORITY = {
+  'Cursorvers Ops': 10,
+  Task: 20,
+  'Belief/Philosophy': 30,
+  Knowledge: 40,
+};
+const REQUIRED_REVIEW_ENV = [
+  'TELEGRAM_BOT_TOKEN',
+  'TELEGRAM_REVIEW_CHAT_ID',
+  'TELEGRAM_ALLOWED_USER_ID',
+];
+const defaultFsOps = {
+  writeFileSync: fs.writeFileSync,
+  openSync: fs.openSync,
+  fsyncSync: fs.fsyncSync,
+  closeSync: fs.closeSync,
+  renameSync: fs.renameSync,
+  unlinkSync: fs.unlinkSync,
+};
+let fsOps = { ...defaultFsOps };
+
+const args = process.argv.slice(2);
+const command = args[0] || 'help';
+
+function getArg(name) {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] ?? null : null;
+}
+
+function resolveSecret(name) {
+  if (process.env[name]) return process.env[name] || '';
+  try {
+    return execFileSync('zsh', [
+      '-lc',
+      `source "$HOME/.zshenv" >/dev/null 2>&1 || true; if typeset -f _fugue_secret >/dev/null 2>&1; then _fugue_secret ${name}; fi`,
+    ], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function requireEnv(name) {
+  const value = resolveSecret(name);
+  if (!value) throw new Error(`Missing ${name}. Set it in env or _fugue_secret.`);
+  return value;
+}
+
+function optionalEnv(name) {
+  return resolveSecret(name);
+}
+
+function isDirectUserChatId(chatId) {
+  return /^[1-9]\d*$/.test(String(chatId || '').trim());
+}
+
+export function preflightTelegramReviewEnv(commandName, resolver = resolveSecret) {
+  if (!['daily', 'poll'].includes(commandName)) return {};
+
+  const values = {};
+  const missing = [];
+  for (const name of REQUIRED_REVIEW_ENV) {
+    const value = String(resolver(name) || '').trim();
+    if (!value) {
+      missing.push(name);
+    } else {
+      values[name] = value;
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required Telegram review env: ${missing.join(', ')}`);
+  }
+
+  if (!isDirectUserChatId(values.TELEGRAM_REVIEW_CHAT_ID)) {
+    throw new Error(`TELEGRAM_REVIEW_CHAT_ID must be a direct user chat id; group/channel chat ids are not allowed for ${commandName} review.`);
+  }
+
+  return values;
+}
+
+export function __setFieldyTelegramFsOpsForTest(overrides = {}) {
+  fsOps = { ...defaultFsOps, ...overrides };
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true, mode: 0o700 });
+}
+
+function hash(input, length = 16) {
+  return createHash('sha256').update(input).digest('hex').slice(0, length);
+}
+
+function todayJst() {
+  return new Intl.DateTimeFormat('sv-SE', { timeZone: 'Asia/Tokyo' }).format(new Date());
+}
+
+function readJson(filePath, fallback) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return fallback;
+  }
+}
+
+function atomicWriteFileSync(filePath, content) {
+  ensureDir(path.dirname(filePath));
+  const tmpPath = path.join(path.dirname(filePath), `${path.basename(filePath)}.tmp-${randomBytes(8).toString('hex')}`);
+  try {
+    fsOps.writeFileSync(tmpPath, content, { mode: 0o600, flag: 'wx' });
+    const fd = fsOps.openSync(tmpPath, 'r');
+    try {
+      fsOps.fsyncSync(fd);
+    } finally {
+      fsOps.closeSync(fd);
+    }
+    fsOps.renameSync(tmpPath, filePath);
+    try {
+      const dirFd = fsOps.openSync(path.dirname(filePath), 'r');
+      try {
+        fsOps.fsyncSync(dirFd);
+      } finally {
+        fsOps.closeSync(dirFd);
+      }
+    } catch (error) {
+      console.warn(`WARN: failed to fsync parent directory for ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  } catch (error) {
+    try {
+      fsOps.unlinkSync(tmpPath);
+    } catch {
+      // Best effort cleanup; preserve the original write/rename error.
+    }
+    throw error;
+  }
+}
+
+function writeJson(filePath, value) {
+  atomicWriteFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function appendJsonl(filePath, value) {
+  const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf-8') : '';
+  atomicWriteFileSync(filePath, `${existing}${JSON.stringify(value)}\n`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function retryDelayMs(attempt, parsed) {
+  const retryAfter = Number(parsed?.parameters?.retry_after);
+  if (Number.isFinite(retryAfter) && retryAfter >= 0) {
+    return Math.min(retryAfter * 1000, 30_000);
+  }
+  return Math.min(1000 * (2 ** attempt), 30_000);
+}
+
+function pidIsAlive(pid, killFn = process.kill) {
+  try {
+    killFn(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ESRCH') return false;
+    if (error?.code === 'EPERM') return true;
+    return false;
+  }
+}
+
+function readLockedPid(lockPath) {
+  const raw = fs.readFileSync(lockPath, 'utf-8').trim();
+  const pid = Number.parseInt(raw, 10);
+  return Number.isFinite(pid) && pid > 0 ? pid : null;
+}
+
+export function acquireTelegramPollLock({ lockPath = telegramPollLockPath(), pid = process.pid, killFn = process.kill } = {}) {
+  fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+
+  while (true) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx', 0o600);
+      try {
+        fs.writeFileSync(fd, `${pid}\n`, 'utf-8');
+        fs.fsyncSync(fd);
+      } finally {
+        fs.closeSync(fd);
+      }
+      const lock = {
+        lockPath,
+        ownedPid: pid,
+        release() {
+          releaseTelegramPollLock(lock);
+        },
+      };
+      return lock;
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+
+      const lockedPid = readLockedPid(lockPath);
+      if (lockedPid && pidIsAlive(lockedPid, killFn)) {
+        throw new Error(`poll already running (pid=${lockedPid})`);
+      }
+
+      try {
+        fs.unlinkSync(lockPath);
+      } catch (unlinkError) {
+        if (unlinkError?.code !== 'ENOENT') throw unlinkError;
+      }
+    }
+  }
+}
+
+export function releaseTelegramPollLock(lock) {
+  if (!lock?.lockPath) return;
+  const ownedPid = lock.ownedPid ?? lock.pid;
+  try {
+    const lockedPid = fs.readFileSync(lock.lockPath, 'utf-8').trim();
+    if (String(lockedPid) !== String(ownedPid)) {
+      console.warn(`WARN: refusing to release poll lock owned by pid=${lockedPid || 'unknown'}; current owner pid=${ownedPid || 'unknown'}`);
+      return;
+    }
+    fs.unlinkSync(lock.lockPath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return;
+    console.warn(`WARN: failed to release poll lock ${lock.lockPath}: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export function registerTelegramPollLockCleanup(lock) {
+  let released = false;
+  const releaseOnce = () => {
+    if (released) return;
+    released = true;
+    releaseTelegramPollLock(lock);
+  };
+  const handleExit = () => {
+    releaseOnce();
+  };
+  const handleSigint = () => {
+    releaseOnce();
+    process.exit(0);
+  };
+  const handleSigterm = () => {
+    releaseOnce();
+    process.exit(0);
+  };
+
+  process.on('exit', handleExit);
+  process.on('SIGINT', handleSigint);
+  process.on('SIGTERM', handleSigterm);
+
+  return () => {
+    releaseOnce();
+    process.off('exit', handleExit);
+    process.off('SIGINT', handleSigint);
+    process.off('SIGTERM', handleSigterm);
+  };
+}
+
+async function parseTelegramResponse(response) {
+  try {
+    return await response.json();
+  } catch {
+    return {};
+  }
+}
+
+export async function telegramFetch(token, endpoint, body, { maxRetries = 3, timeoutMs = 15_000 } = {}) {
+  let attempt = 0;
+  while (true) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    let response;
+    let parsed;
+    try {
+      response = await fetch(`${TELEGRAM_API_BASE}/bot${token}/${endpoint}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      parsed = await parseTelegramResponse(response);
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const retryable = response.status === 429 || response.status >= 500;
+    if (response.ok && parsed.ok) return parsed.result;
+    if (!retryable || attempt >= maxRetries) {
+      throw new Error(`telegram_${endpoint}_failed:${response.status}:${parsed?.description || 'unknown'}`);
+    }
+    await sleep(retryDelayMs(attempt, parsed));
+    attempt += 1;
+  }
+}
+
+async function telegramRequest(token, method, body, options) {
+  return telegramFetch(token, method, body, options);
+}
+
+async function getUpdates(token, offset) {
+  return telegramRequest(token, 'getUpdates', {
+    offset,
+    timeout: 0,
+    allowed_updates: ['message', 'callback_query'],
+  });
+}
+
+function reviewDir() {
+  return process.env.FIELDY_TELEGRAM_REVIEW_DIR || DEFAULT_REVIEW_DIR;
+}
+
+function decisionsDir() {
+  return process.env.FIELDY_REVIEW_DECISIONS_DIR || DEFAULT_DECISION_DIR;
+}
+
+function statePath() {
+  return process.env.FIELDY_TELEGRAM_STATE_PATH || DEFAULT_STATE_PATH;
+}
+
+export function telegramPollLockPath() {
+  return path.join(os.homedir(), 'Fieldy', 'state', POLL_LOCK_FILENAME);
+}
+
+function reviewItemsPath(date) {
+  return path.join(reviewDir(), 'review_items', `${date}.json`);
+}
+
+function actionTokensPath() {
+  return path.join(reviewDir(), 'action-tokens.json');
+}
+
+function decisionPath(date) {
+  return path.join(decisionsDir(), `${date}.jsonl`);
+}
+
+function normalizeText(input) {
+  return String(input || '').replace(/\s+/g, ' ').trim();
+}
+
+function truncate(input, max) {
+  const normalized = normalizeText(input);
+  if (normalized.length <= max) return normalized;
+  return `${normalized.slice(0, max - 1)}…`;
+}
+
+export function itemToReviewItem(item) {
+  const now = new Date().toISOString();
+  const canonicalKey = `fieldy:canon:${hash(`${item.sourceId}:${item.category}:${item.title}`, 24)}`;
+  const revisionHash = hash(`${item.sourceHash}:${item.summary}:${item.rationale}`, 24);
+  return {
+    id: `review_${hash(`${canonicalKey}:${revisionHash}`, 24)}`,
+    canonicalKey,
+    revisionHash,
+    sourceId: item.sourceId,
+    sourceDate: item.sourceDate,
+    category: item.category,
+    title: item.title,
+    summary: item.summary,
+    rationale: item.rationale,
+    evidenceExcerpt: item.evidenceExcerpt,
+    confidence: item.confidence,
+    sensitive: item.sensitive,
+    status: 'pending_review',
+    localPath: item.localPath,
+    updatedAt: now,
+  };
+}
+
+export function formatReviewMessage(item) {
+  if (item.sensitive) {
+    return formatSensitiveCard(item);
+  }
+
+  return [
+    `[${item.category}]`,
+    '',
+    truncate(item.title, 90),
+    '',
+    '要点:',
+    truncate(item.summary, 420),
+    '',
+    '理由:',
+    truncate(item.rationale, 260),
+    '',
+    `信頼度: ${Number(item.confidence).toFixed(2)}`,
+  ].join('\n');
+}
+
+export function formatSensitiveCard(item) {
+  const reviewItemHash = hash(item.id || item.review_item_id || item.canonicalKey || '', 8);
+  return [
+    `[${item.category}]`,
+    '',
+    `[Sensitive候補 - ローカル確認要] ${reviewItemHash}`,
+    '',
+    'Sensitive候補です。Telegramには本文を表示しません。',
+    '',
+    `発生日: ${item.sourceDate}`,
+    `信頼度: ${Number(item.confidence).toFixed(2)}`,
+  ].join('\n');
+}
+
+function loadActionTokens() {
+  return readJson(actionTokensPath(), {});
+}
+
+function saveActionTokens(tokens) {
+  writeJson(actionTokensPath(), tokens);
+}
+
+function createActionToken(reviewItemId, action) {
+  const token = randomBytes(12).toString('hex');
+  const expiresAt = new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString();
+  return { token, reviewItemId, action, expiresAt };
+}
+
+function createKeyboard(item) {
+  const tokens = loadActionTokens();
+  const actions = [
+    { text: '採用', action: 'approve' },
+    { text: 'あとで', action: 'snooze' },
+    { text: '捨てる', action: 'reject' },
+    { text: '詳細', action: 'detail' },
+  ];
+  const row = actions.map(({ text, action }) => {
+    const created = createActionToken(item.id, action);
+    tokens[created.token] = created;
+    return { text, callback_data: `${CALLBACK_PREFIX}${created.token}` };
+  });
+  saveActionTokens(tokens);
+  return { inline_keyboard: [row] };
+}
+
+function loadReviewItems(date) {
+  return readJson(reviewItemsPath(date), []);
+}
+
+function saveReviewItems(date, items) {
+  writeJson(reviewItemsPath(date), items);
+}
+
+function readEnvelope(filePath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    if (parsed?.schema_version !== 1 || parsed.provider !== 'glm' || !parsed.source?.source_id) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function dateIsInRange(date, sinceDays) {
+  const parsed = Date.parse(`${date}T00:00:00.000+09:00`);
+  if (Number.isNaN(parsed)) return false;
+  const start = new Date(Date.now() - (sinceDays - 1) * 24 * 60 * 60 * 1000);
+  const startDate = new Intl.DateTimeFormat('sv-SE', { timeZone: 'Asia/Tokyo' }).format(start);
+  return date >= startDate;
+}
+
+function listEnvelopeFiles(inputDir, sinceDays) {
+  if (!fs.existsSync(inputDir)) return [];
+  const files = [];
+  const dates = fs.readdirSync(inputDir)
+    .filter((name) => /^\d{4}-\d{2}-\d{2}$/.test(name))
+    .filter((date) => dateIsInRange(date, sinceDays))
+    .sort()
+    .reverse();
+  for (const date of dates) {
+    const glmDir = path.join(inputDir, date, 'glm');
+    if (!fs.existsSync(glmDir)) continue;
+    const names = fs.readdirSync(glmDir)
+      .filter((name) => name.endsWith('.json'))
+      .sort()
+      .reverse();
+    for (const name of names) files.push(path.join(glmDir, name));
+  }
+  return files;
+}
+
+function envelopeToReviewItems(envelope, localPath) {
+  if (envelope.status !== 'distilled' || !envelope.distillation) return [];
+  const output = [];
+  for (const [bucket, category] of Object.entries(BUCKET_LABELS)) {
+    for (const candidate of envelope.distillation[bucket] || []) {
+      const title = normalizeText(candidate.title);
+      const summary = normalizeText(candidate.detail);
+      const confidence = Number(candidate.confidence);
+      if (!title || !summary || !Number.isFinite(confidence)) continue;
+      output.push(itemToReviewItem({
+        sourceId: envelope.source.source_id,
+        sourceHash: envelope.source.source_hash,
+        sourceDate: envelope.source_time.jst_date,
+        category,
+        title,
+        summary,
+        rationale: normalizeText(candidate.rationale || ''),
+        evidenceExcerpt: normalizeText(candidate.detail),
+        confidence,
+        sensitive: Boolean(envelope.distillation.sensitive_personal_data),
+        localPath,
+      }));
+    }
+  }
+  return output;
+}
+
+function selectDailyReviewItems() {
+  const inputDir = getArg('--in') || process.env.GLM_DISTILLED_OUTPUT_DIR || DEFAULT_INTELLIGENCE_DIR;
+  const sinceDays = Number.parseInt(getArg('--since-days') || process.env.TELEGRAM_REVIEW_SINCE_DAYS || '3', 10);
+  const limit = Number.parseInt(getArg('--limit') || process.env.TELEGRAM_REVIEW_LIMIT || '5', 10);
+  const minConfidence = Number.parseFloat(getArg('--min-confidence') || process.env.TELEGRAM_REVIEW_MIN_CONFIDENCE || '0.55');
+  const minDetailChars = Number.parseInt(getArg('--min-detail-chars') || process.env.TELEGRAM_REVIEW_MIN_DETAIL_CHARS || '80', 10);
+  const files = listEnvelopeFiles(inputDir, sinceDays);
+  const byId = new Map();
+  for (const filePath of files) {
+    const envelope = readEnvelope(filePath);
+    if (!envelope) continue;
+    for (const item of envelopeToReviewItems(envelope, filePath)) {
+      if (item.confidence < minConfidence) continue;
+      if (!item.sensitive && item.summary.length < minDetailChars) continue;
+      const existing = byId.get(item.id);
+      if (!existing || item.confidence > existing.confidence) byId.set(item.id, item);
+    }
+  }
+  return [...byId.values()]
+    .sort((a, b) => (CATEGORY_PRIORITY[a.category] || 90) - (CATEGORY_PRIORITY[b.category] || 90) || b.confidence - a.confidence)
+    .slice(0, Math.max(1, Math.min(limit, 10)));
+}
+
+export async function sendReviewItem(token, chatId, item) {
+  return telegramRequest(token, 'sendMessage', {
+    chat_id: chatId,
+    text: formatReviewMessage(item),
+    reply_markup: createKeyboard(item),
+    disable_web_page_preview: true,
+  });
+}
+
+async function cmdWhoami() {
+  const token = requireEnv('TELEGRAM_BOT_TOKEN');
+  const updates = await getUpdates(token);
+  const seen = updates
+    .flatMap((update) => [update.message, update.callback_query?.message].filter(Boolean))
+    .map((message) => ({
+      chat_id: message.chat.id,
+      chat_type: message.chat.type,
+      user_id: message.from?.id,
+      username: message.from?.username || message.chat.username || '',
+      first_name: message.from?.first_name || message.chat.first_name || '',
+      text: message.text || '',
+    }));
+  console.log(JSON.stringify({ updates: seen }, null, 2));
+}
+
+async function cmdSendTest() {
+  const token = requireEnv('TELEGRAM_BOT_TOKEN');
+  const chatId = requireEnv('TELEGRAM_REVIEW_CHAT_ID');
+  await telegramRequest(token, 'sendMessage', {
+    chat_id: chatId,
+    text: 'Fieldy Review Bot test',
+  });
+  console.log(JSON.stringify({ sent: true }, null, 2));
+}
+
+async function cmdDaily() {
+  const dryRun = args.includes('--dry-run');
+  const env = preflightTelegramReviewEnv('daily');
+  const token = env.TELEGRAM_BOT_TOKEN;
+  const chatId = env.TELEGRAM_REVIEW_CHAT_ID;
+  const date = todayJst();
+  const existing = loadReviewItems(date);
+  const existingIds = new Set(existing.map((item) => item.id));
+  const selected = selectDailyReviewItems().filter((item) => !existingIds.has(item.id));
+
+  if (selected.length === 0) {
+    console.log(JSON.stringify({ sent: 0, reason: 'no_pending_review_items' }, null, 2));
+    return;
+  }
+
+  const updated = [...existing];
+  let sent = 0;
+  for (const item of selected) {
+    if (dryRun) {
+      console.log(formatReviewMessage(item));
+      console.log('---');
+      continue;
+    }
+    const message = await sendReviewItem(token, chatId, item);
+    updated.push({
+      ...item,
+      status: 'sent_to_telegram',
+      telegramChatId: String(message.chat.id),
+      telegramMessageId: message.message_id,
+      sentAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    sent += 1;
+  }
+  if (!dryRun) saveReviewItems(date, updated);
+  console.log(JSON.stringify({ sent, dry_run: dryRun }, null, 2));
+}
+
+function findReviewItemById(reviewItemId) {
+  const root = path.join(reviewDir(), 'review_items');
+  if (!fs.existsSync(root)) return null;
+  const files = fs.readdirSync(root).filter((name) => name.endsWith('.json')).sort().reverse();
+  for (const file of files) {
+    const date = file.replace(/\.json$/, '');
+    const items = loadReviewItems(date);
+    const item = items.find((candidate) => candidate.id === reviewItemId);
+    if (item) return { date, item, items };
+  }
+  return null;
+}
+
+async function answerCallback(token, callbackId, text) {
+  await telegramRequest(token, 'answerCallbackQuery', {
+    callback_query_id: callbackId,
+    text,
+    show_alert: false,
+  });
+}
+
+async function removeButtons(token, callback) {
+  if (!callback.message) return;
+  await telegramRequest(token, 'editMessageReplyMarkup', {
+    chat_id: callback.message.chat.id,
+    message_id: callback.message.message_id,
+    reply_markup: { inline_keyboard: [] },
+  });
+}
+
+function nextStatus(action) {
+  if (action === 'approve') return 'approved';
+  if (action === 'snooze') return 'snoozed';
+  if (action === 'reject') return 'rejected';
+  return null;
+}
+
+export async function handleCallback(token, callback, env = preflightTelegramReviewEnv('poll')) {
+  const allowedUserId = env.TELEGRAM_ALLOWED_USER_ID;
+  const reviewChatId = env.TELEGRAM_REVIEW_CHAT_ID;
+  if (String(callback.from?.id || '') !== allowedUserId) {
+    await answerCallback(token, callback.id, '認可されていません');
+    return;
+  }
+  if (String(callback.message?.chat?.id || '') !== reviewChatId) {
+    await answerCallback(token, callback.id, '認可されていません');
+    return;
+  }
+  const data = callback.data || '';
+  if (!data.startsWith(CALLBACK_PREFIX)) {
+    await answerCallback(token, callback.id, '不明な操作です');
+    return;
+  }
+  const tokenId = data.slice(CALLBACK_PREFIX.length);
+  const tokens = loadActionTokens();
+  const actionToken = tokens[tokenId];
+  if (!actionToken || Date.parse(actionToken.expiresAt) < Date.now()) {
+    await answerCallback(token, callback.id, '期限切れです');
+    return;
+  }
+  if (actionToken.usedAt) {
+    await answerCallback(token, callback.id, '処理済みです');
+    return;
+  }
+  const found = findReviewItemById(actionToken.reviewItemId);
+  if (!found) {
+    await answerCallback(token, callback.id, '候補が見つかりません');
+    return;
+  }
+
+  if (actionToken.action === 'detail') {
+    await answerCallback(token, callback.id, `詳細ID: ${found.item.id}`);
+    return;
+  }
+
+  const status = nextStatus(actionToken.action);
+  if (!status) {
+    await answerCallback(token, callback.id, '不明な操作です');
+    return;
+  }
+
+  const previousState = found.item.status;
+  const now = new Date().toISOString();
+  try {
+    appendJsonl(decisionPath(found.date), {
+      id: `decision_${hash(`${found.item.id}:${actionToken.action}:${now}`, 24)}`,
+      review_item_id: found.item.id,
+      action: actionToken.action,
+      actor: `telegram:${callback.from.id}`,
+      previous_state: previousState,
+      next_state: status,
+      telegram_message_id: callback.message?.message_id || null,
+      created_at: now,
+    });
+  } catch {
+    await answerCallback(token, callback.id, '処理に失敗しました。再試行してください');
+    return;
+  }
+
+  const updatedItem = {
+    ...found.item,
+    status,
+    updatedAt: now,
+  };
+  const nextItems = found.items.map((item) => item.id === updatedItem.id ? updatedItem : item);
+  saveReviewItems(found.date, nextItems);
+  actionToken.usedAt = new Date().toISOString();
+  tokens[tokenId] = actionToken;
+  saveActionTokens(tokens);
+
+  await removeButtons(token, callback);
+  await answerCallback(token, callback.id, actionToken.action === 'approve' ? '採用しました' : actionToken.action === 'snooze' ? 'あとで見ます' : '捨てました');
+}
+
+async function cmdPoll() {
+  const lock = acquireTelegramPollLock();
+  registerTelegramPollLockCleanup(lock);
+  const env = preflightTelegramReviewEnv('poll');
+  const token = env.TELEGRAM_BOT_TOKEN;
+  const state = readJson(statePath(), {});
+  const updates = await getUpdates(token, state.offset);
+  let maxUpdateId = state.offset ? state.offset - 1 : -1;
+  for (const update of updates) {
+    maxUpdateId = Math.max(maxUpdateId, update.update_id);
+    if (update.callback_query) await handleCallback(token, update.callback_query, env);
+  }
+  if (maxUpdateId >= 0) writeJson(statePath(), { offset: maxUpdateId + 1 });
+  console.log(JSON.stringify({ processed_updates: updates.length }, null, 2));
+}
+
+function usage() {
+  console.log(`Usage:
+  npm run fieldy:telegram:whoami
+  npm run fieldy:telegram:send-test
+  npm run fieldy:telegram:daily -- [--dry-run] [--limit 5]
+  npm run fieldy:telegram:poll
+
+Required secrets/env:
+  TELEGRAM_BOT_TOKEN
+  TELEGRAM_REVIEW_CHAT_ID       required for send-test/daily/poll
+  TELEGRAM_ALLOWED_USER_ID      required for daily/poll
+`);
+}
+
+async function main() {
+  if (command === 'whoami') return cmdWhoami();
+  if (command === 'send-test') return cmdSendTest();
+  if (command === 'daily') return cmdDaily();
+  if (command === 'poll') return cmdPoll();
+  usage();
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath && fileURLToPath(import.meta.url) === invokedPath) {
+  main().catch((error) => {
+    console.error('ERROR:', String(error instanceof Error ? error.message : error));
+    process.exit(1);
+  });
+}

--- a/fieldy-task-shifter/scripts/fieldy-telegram-review.test.ts
+++ b/fieldy-task-shifter/scripts/fieldy-telegram-review.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   __setFieldyTelegramFsOpsForTest,
   acquireTelegramPollLock,
+  appendJsonl,
   formatReviewMessage,
   handleCallback,
   itemToReviewItem,
@@ -116,6 +117,21 @@ describe('fieldy telegram review helpers', () => {
       TELEGRAM_ALLOWED_USER_ID: '67890',
     }))).toEqual({
       TELEGRAM_BOT_TOKEN: 'token',
+      TELEGRAM_REVIEW_CHAT_ID: '12345',
+      TELEGRAM_ALLOWED_USER_ID: '67890',
+    });
+  });
+
+  it('prefers Fieldy-specific Telegram secrets over generic Telegram secrets', () => {
+    expect(preflightTelegramReviewEnv('poll', envResolver({
+      FIELDY_TELEGRAM_BOT_TOKEN: 'fieldy-token',
+      FIELDY_TELEGRAM_REVIEW_CHAT_ID: '12345',
+      FIELDY_TELEGRAM_ALLOWED_USER_ID: '67890',
+      TELEGRAM_BOT_TOKEN: 'fugue-token',
+      TELEGRAM_REVIEW_CHAT_ID: '99999',
+      TELEGRAM_ALLOWED_USER_ID: '11111',
+    }))).toEqual({
+      TELEGRAM_BOT_TOKEN: 'fieldy-token',
       TELEGRAM_REVIEW_CHAT_ID: '12345',
       TELEGRAM_ALLOWED_USER_ID: '67890',
     });
@@ -259,14 +275,41 @@ describe('fieldy telegram review helpers', () => {
     expect(body.text).not.toContain(sensitiveTitle);
   });
 
-  it('writes decisions through a tmp file in the same directory before rename', async () => {
+  it('offers approve, revise, reject, and detail actions without snooze', async () => {
+    const item = itemToReviewItem(baseItem);
+
+    await sendReviewItem('token', '12345', item);
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    const labels = body.reply_markup.inline_keyboard[0].map((button: { text: string }) => button.text);
+    expect(labels).toEqual(['採用', '修正', '捨てる', '詳細']);
+  });
+
+  it('appends decisions with O_APPEND and fsyncs before closing', async () => {
     const { callback } = seedCallbackReview(tempDir);
-    const writeCalls: string[] = [];
+    const operations: string[] = [];
+    const fdPaths = new Map<number, string>();
+    const decisionFile = path.join(tempDir, 'decisions', '2026-04-18.jsonl');
     __setFieldyTelegramFsOpsForTest({
-      writeFileSync: ((filePath: fs.PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options?: fs.WriteFileOptions) => {
-        writeCalls.push(String(filePath));
-        return fs.writeFileSync(filePath, data, options);
-      }) as typeof fs.writeFileSync,
+      openSync: ((filePath: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+        const fd = fs.openSync(filePath, flags, mode);
+        fdPaths.set(fd, String(filePath));
+        if (String(filePath) === decisionFile) operations.push(`open:${String(flags)}`);
+        return fd;
+      }) as typeof fs.openSync,
+      writeSync: ((fd: number, buffer: string | NodeJS.ArrayBufferView) => {
+        if (fdPaths.get(fd) === decisionFile) operations.push('write');
+        return typeof buffer === 'string' ? fs.writeSync(fd, buffer) : fs.writeSync(fd, buffer);
+      }) as typeof fs.writeSync,
+      fsyncSync: ((fd: number) => {
+        if (fdPaths.get(fd) === decisionFile) operations.push('fsync');
+        return fs.fsyncSync(fd);
+      }) as typeof fs.fsyncSync,
+      closeSync: ((fd: number) => {
+        if (fdPaths.get(fd) === decisionFile) operations.push('close');
+        fdPaths.delete(fd);
+        return fs.closeSync(fd);
+      }) as typeof fs.closeSync,
     });
 
     await handleCallback('token', callback, {
@@ -275,21 +318,63 @@ describe('fieldy telegram review helpers', () => {
       TELEGRAM_ALLOWED_USER_ID: '67890',
     });
 
-    const decisionTmpCall = writeCalls.find((filePath) => filePath.includes(`${path.sep}decisions${path.sep}2026-04-18.jsonl.tmp-`));
-    expect(decisionTmpCall).toBeTruthy();
-    expect(path.dirname(String(decisionTmpCall))).toBe(path.join(tempDir, 'decisions'));
-    expect(fs.readFileSync(path.join(tempDir, 'decisions', '2026-04-18.jsonl'), 'utf-8')).toContain('"action":"approve"');
+    expect(operations).toEqual(['open:a', 'write', 'fsync', 'close']);
+    expect(fs.readFileSync(decisionFile, 'utf-8')).toContain('"action":"approve"');
   });
 
-  it('fsyncs the parent directory after renaming the decision file', async () => {
+  it('appends multiple JSONL rows in call order', () => {
+    const decisionFile = path.join(tempDir, 'decisions', '2026-04-18.jsonl');
+
+    appendJsonl(decisionFile, { index: 1 });
+    appendJsonl(decisionFile, { index: 2 });
+    appendJsonl(decisionFile, { index: 3 });
+
+    const rows = fs.readFileSync(decisionFile, 'utf-8').trimEnd().split('\n').map((line) => JSON.parse(line));
+    expect(rows).toEqual([{ index: 1 }, { index: 2 }, { index: 3 }]);
+  });
+
+  it('rejects JSONL rows larger than the 4KB O_APPEND guard', () => {
+    const decisionFile = path.join(tempDir, 'decisions', '2026-04-18.jsonl');
+
+    expect(() => appendJsonl(decisionFile, { payload: 'x'.repeat(4096) })).toThrow('appendJsonl: line too large for atomic O_APPEND');
+    expect(fs.existsSync(decisionFile)).toBe(false);
+  });
+
+  it('creates missing parent directories before appending JSONL', () => {
+    const decisionFile = path.join(tempDir, 'missing', 'nested', '2026-04-18.jsonl');
+
+    appendJsonl(decisionFile, { ok: true });
+
+    expect(fs.readFileSync(decisionFile, 'utf-8')).toBe('{"ok":true}\n');
+  });
+
+  it('records revise callbacks as needs_edit decisions', async () => {
+    const { callback } = seedCallbackReview(tempDir, 'revise');
+
+    await handleCallback('token', callback, {
+      TELEGRAM_BOT_TOKEN: 'token',
+      TELEGRAM_REVIEW_CHAT_ID: '12345',
+      TELEGRAM_ALLOWED_USER_ID: '67890',
+    });
+
+    const reviewItems = JSON.parse(fs.readFileSync(path.join(tempDir, 'review', 'review_items', '2026-04-18.json'), 'utf-8'));
+    expect(reviewItems[0].status).toBe('needs_edit');
+    const decision = fs.readFileSync(path.join(tempDir, 'decisions', '2026-04-18.jsonl'), 'utf-8');
+    expect(decision).toContain('"action":"revise"');
+    expect(decision).toContain('"next_state":"needs_edit"');
+    const answerBody = JSON.parse(String(fetchMock.mock.calls.at(-1)?.[1].body));
+    expect(answerBody.text).toBe('修正対象にしました');
+  });
+
+  it('keeps atomic rewrite fsync behavior for review item state files', async () => {
     const { callback } = seedCallbackReview(tempDir);
     const operations: string[] = [];
     const fdPaths = new Map<number, string>();
-    const decisionTmpMarker = `${path.sep}decisions${path.sep}2026-04-18.jsonl.tmp-`;
-    const decisionDir = path.join(tempDir, 'decisions');
+    const reviewItemsTmpMarker = `${path.sep}review_items${path.sep}2026-04-18.json.tmp-`;
+    const reviewItemsDir = path.join(tempDir, 'review', 'review_items');
     __setFieldyTelegramFsOpsForTest({
       writeFileSync: ((filePath: fs.PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options?: fs.WriteFileOptions) => {
-        if (String(filePath).includes(decisionTmpMarker)) operations.push('writeTmp');
+        if (String(filePath).includes(reviewItemsTmpMarker)) operations.push('writeTmp');
         return fs.writeFileSync(filePath, data, options);
       }) as typeof fs.writeFileSync,
       openSync: ((filePath: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
@@ -299,8 +384,8 @@ describe('fieldy telegram review helpers', () => {
       }) as typeof fs.openSync,
       fsyncSync: ((fd: number) => {
         const filePath = fdPaths.get(fd);
-        if (filePath?.includes(decisionTmpMarker)) operations.push('fsyncTmp');
-        if (filePath === decisionDir) operations.push('fsyncParentDir');
+        if (filePath?.includes(reviewItemsTmpMarker)) operations.push('fsyncTmp');
+        if (filePath === reviewItemsDir) operations.push('fsyncParentDir');
         return fs.fsyncSync(fd);
       }) as typeof fs.fsyncSync,
       closeSync: ((fd: number) => {
@@ -308,7 +393,7 @@ describe('fieldy telegram review helpers', () => {
         return fs.closeSync(fd);
       }) as typeof fs.closeSync,
       renameSync: ((oldPath: fs.PathLike, newPath: fs.PathLike) => {
-        if (String(oldPath).includes(decisionTmpMarker)) operations.push('rename');
+        if (String(oldPath).includes(reviewItemsTmpMarker)) operations.push('rename');
         return fs.renameSync(oldPath, newPath);
       }) as typeof fs.renameSync,
     });
@@ -332,13 +417,23 @@ describe('fieldy telegram review helpers', () => {
     const original = fs.readFileSync(decisionFile, 'utf-8');
     const originalReviewItems = fs.readFileSync(reviewItemsFile, 'utf-8');
     const originalActionTokens = fs.readFileSync(actionTokensFile, 'utf-8');
+    const fdPaths = new Map<number, string>();
     __setFieldyTelegramFsOpsForTest({
-      writeFileSync: ((filePath: fs.PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options?: fs.WriteFileOptions) => {
-        if (String(filePath).includes('2026-04-18.jsonl.tmp-')) {
-          throw new Error('simulated kill before rename');
+      openSync: ((filePath: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+        const fd = fs.openSync(filePath, flags, mode);
+        fdPaths.set(fd, String(filePath));
+        return fd;
+      }) as typeof fs.openSync,
+      writeSync: ((fd: number, buffer: string | NodeJS.ArrayBufferView) => {
+        if (fdPaths.get(fd) === decisionFile) {
+          throw new Error('simulated append failure');
         }
-        return fs.writeFileSync(filePath, data, options);
-      }) as typeof fs.writeFileSync,
+        return typeof buffer === 'string' ? fs.writeSync(fd, buffer) : fs.writeSync(fd, buffer);
+      }) as typeof fs.writeSync,
+      closeSync: ((fd: number) => {
+        fdPaths.delete(fd);
+        return fs.closeSync(fd);
+      }) as typeof fs.closeSync,
     });
 
     await handleCallback('token', callback, {
@@ -352,7 +447,6 @@ describe('fieldy telegram review helpers', () => {
     expect(JSON.parse(fs.readFileSync(reviewItemsFile, 'utf-8'))[0].status).toBe(item.status);
     expect(fs.readFileSync(actionTokensFile, 'utf-8')).toBe(originalActionTokens);
     expect(JSON.parse(fs.readFileSync(actionTokensFile, 'utf-8'))['approve-token'].usedAt).toBeUndefined();
-    expect(fs.readdirSync(path.dirname(decisionFile)).filter((name) => name.includes('.tmp-'))).toEqual([]);
     const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
     expect(body.text).toBe('処理に失敗しました。再試行してください');
   });
@@ -435,16 +529,17 @@ describe('fieldy telegram review helpers', () => {
   });
 });
 
-function seedCallbackReview(tempDir: string) {
+function seedCallbackReview(tempDir: string, action = 'approve') {
   const item = itemToReviewItem(baseItem);
+  const token = `${action}-token`;
   const reviewItemsDir = path.join(tempDir, 'review', 'review_items');
   fs.mkdirSync(reviewItemsDir, { recursive: true });
   fs.writeFileSync(path.join(reviewItemsDir, '2026-04-18.json'), `${JSON.stringify([item], null, 2)}\n`);
   fs.writeFileSync(path.join(tempDir, 'review', 'action-tokens.json'), `${JSON.stringify({
-    'approve-token': {
-      token: 'approve-token',
+    [token]: {
+      token,
       reviewItemId: item.id,
-      action: 'approve',
+      action,
       expiresAt: new Date(Date.now() + 60_000).toISOString(),
     },
   }, null, 2)}\n`);
@@ -452,10 +547,10 @@ function seedCallbackReview(tempDir: string) {
   return {
     item,
     callback: {
-      id: 'callback-approve',
+      id: `callback-${action}`,
       from: { id: 67890 },
       message: { chat: { id: 12345 }, message_id: 10 },
-      data: 'fr:approve-token',
+      data: `fr:${token}`,
     },
   };
 }

--- a/fieldy-task-shifter/scripts/fieldy-telegram-review.test.ts
+++ b/fieldy-task-shifter/scripts/fieldy-telegram-review.test.ts
@@ -1,0 +1,461 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  __setFieldyTelegramFsOpsForTest,
+  acquireTelegramPollLock,
+  formatReviewMessage,
+  handleCallback,
+  itemToReviewItem,
+  preflightTelegramReviewEnv,
+  registerTelegramPollLockCleanup,
+  releaseTelegramPollLock,
+  sendReviewItem,
+  telegramFetch,
+  telegramPollLockPath,
+} from './fieldy-telegram-review.mjs';
+
+const baseItem = {
+  sourceHash: 'hash-1',
+  title: 'FieldyレビューをTelegramで判断する',
+  category: 'Cursorvers Ops',
+  sourceId: 'fieldy:abc',
+  sourceDate: '2026-04-18',
+  confidence: 0.86,
+  summary: 'Telegramは細かい報告ではなく、人間レビューの採用、後回し、破棄だけに使う。',
+  evidenceExcerpt: '要点: Telegramはレビュー専用にする。\n根拠: Notion DBを毎回展開しないため。',
+  rationale: 'Notion DBを操作面にするとレビュー体験が重くなるため。',
+  sensitive: false,
+  localPath: '/tmp/glm.json',
+};
+
+function envResolver(values: Record<string, string | undefined>) {
+  return (name: string) => values[name] || '';
+}
+
+describe('fieldy telegram review helpers', () => {
+  let tempDir: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fieldy-telegram-review-'));
+    process.env.FIELDY_TELEGRAM_REVIEW_DIR = path.join(tempDir, 'review');
+    process.env.FIELDY_REVIEW_DECISIONS_DIR = path.join(tempDir, 'decisions');
+    process.env.FIELDY_TELEGRAM_STATE_PATH = path.join(tempDir, 'state.json');
+    fetchMock = vi.fn(async (_url: string, init: RequestInit) => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        ok: true,
+        result: {
+          message_id: 42,
+          chat: { id: 12345 },
+          requestBody: JSON.parse(String(init.body)),
+        },
+      }),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    __setFieldyTelegramFsOpsForTest();
+    delete process.env.FIELDY_TELEGRAM_REVIEW_DIR;
+    delete process.env.FIELDY_REVIEW_DECISIONS_DIR;
+    delete process.env.FIELDY_TELEGRAM_STATE_PATH;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('maps Notion inbox items to stable Telegram review items', () => {
+    const first = itemToReviewItem(baseItem);
+    const second = itemToReviewItem(baseItem);
+
+    expect(first.id).toBe(second.id);
+    expect(first.category).toBe('Cursorvers Ops');
+    expect(first.status).toBe('pending_review');
+    expect(first.summary).toContain('Telegram');
+  });
+
+  it('formats a compact review card without raw transcript framing', () => {
+    const message = formatReviewMessage(itemToReviewItem(baseItem));
+
+    expect(message).toContain('[Cursorvers Ops]');
+    expect(message).toContain('要点:');
+    expect(message).toContain('理由:');
+    expect(message).toContain('信頼度: 0.86');
+    expect(message).not.toContain('raw transcript');
+  });
+
+  it('redacts sensitive review items in Telegram body', () => {
+    const message = formatReviewMessage(itemToReviewItem({
+      ...baseItem,
+      sensitive: true,
+      summary: '顧客名と契約条件を含む詳細本文。',
+    }));
+
+    expect(message).toContain('Sensitive候補');
+    expect(message).toContain('本文を表示しません');
+    expect(message).not.toContain('顧客名と契約条件');
+  });
+
+  it('fails preflight closed when required Telegram review env is missing', () => {
+    expect(() => preflightTelegramReviewEnv('daily', envResolver({
+      TELEGRAM_BOT_TOKEN: 'token',
+      TELEGRAM_REVIEW_CHAT_ID: '12345',
+    }))).toThrow('TELEGRAM_ALLOWED_USER_ID');
+  });
+
+  it('passes preflight when all required Telegram review env is present', () => {
+    expect(preflightTelegramReviewEnv('poll', envResolver({
+      TELEGRAM_BOT_TOKEN: 'token',
+      TELEGRAM_REVIEW_CHAT_ID: '12345',
+      TELEGRAM_ALLOWED_USER_ID: '67890',
+    }))).toEqual({
+      TELEGRAM_BOT_TOKEN: 'token',
+      TELEGRAM_REVIEW_CHAT_ID: '12345',
+      TELEGRAM_ALLOWED_USER_ID: '67890',
+    });
+  });
+
+  it('fails poll preflight closed when Telegram review chat id is a group or channel', () => {
+    expect(() => preflightTelegramReviewEnv('poll', envResolver({
+      TELEGRAM_BOT_TOKEN: 'token',
+      TELEGRAM_REVIEW_CHAT_ID: '-10012345',
+      TELEGRAM_ALLOWED_USER_ID: '67890',
+    }))).toThrow('group/channel chat ids are not allowed for poll review');
+  });
+
+  it('creates the poll PID lock file and records the current PID', () => {
+    const lockPath = path.join(tempDir, 'Fieldy', 'state', 'telegram-review-poll.pid');
+    const lock = acquireTelegramPollLock({ lockPath, pid: 1234 });
+
+    expect(lock.lockPath).toBe(lockPath);
+    expect(lock.ownedPid).toBe(1234);
+    expect(typeof lock.release).toBe('function');
+    expect(fs.readFileSync(lockPath, 'utf-8')).toBe('1234\n');
+  });
+
+  it('rejects poll lock acquisition when another process is alive', () => {
+    const lockPath = path.join(tempDir, 'Fieldy', 'state', 'telegram-review-poll.pid');
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, '4242\n');
+    const killFn = vi.fn(() => true);
+
+    expect(() => acquireTelegramPollLock({ lockPath, pid: 1234, killFn })).toThrow('poll already running (pid=4242)');
+    expect(killFn).toHaveBeenCalledWith(4242, 0);
+    expect(fs.readFileSync(lockPath, 'utf-8')).toBe('4242\n');
+  });
+
+  it('recovers from a stale poll lock and writes the new PID', () => {
+    const lockPath = path.join(tempDir, 'Fieldy', 'state', 'telegram-review-poll.pid');
+    fs.mkdirSync(path.dirname(lockPath), { recursive: true });
+    fs.writeFileSync(lockPath, '4242\n');
+    const killFn = vi.fn(() => {
+      throw Object.assign(new Error('missing process'), { code: 'ESRCH' });
+    });
+
+    const lock = acquireTelegramPollLock({ lockPath, pid: 1234, killFn });
+
+    expect(lock.lockPath).toBe(lockPath);
+    expect(lock.ownedPid).toBe(1234);
+    expect(killFn).toHaveBeenCalledWith(4242, 0);
+    expect(fs.readFileSync(lockPath, 'utf-8')).toBe('1234\n');
+  });
+
+  it('removes the poll lock when the releasing process still owns it', () => {
+    const lockPath = path.join(tempDir, 'Fieldy', 'state', 'telegram-review-poll.pid');
+    const lock = acquireTelegramPollLock({ lockPath, pid: 1234 });
+
+    lock.release();
+
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it('does not remove a poll lock reacquired by another process', () => {
+    const lockPath = path.join(tempDir, 'Fieldy', 'state', 'telegram-review-poll.pid');
+    const lock = acquireTelegramPollLock({ lockPath, pid: 1234 });
+    fs.writeFileSync(lockPath, '5678\n');
+
+    releaseTelegramPollLock(lock);
+
+    expect(fs.readFileSync(lockPath, 'utf-8')).toBe('5678\n');
+  });
+
+  it('unlinks the poll lock from the registered exit cleanup', () => {
+    const lockPath = path.join(tempDir, 'Fieldy', 'state', 'telegram-review-poll.pid');
+    const lock = acquireTelegramPollLock({ lockPath, pid: 1234 });
+    const cleanup = registerTelegramPollLockCleanup(lock);
+
+    process.emit('exit', 0);
+
+    expect(fs.existsSync(lockPath)).toBe(false);
+    cleanup();
+  });
+
+  it('resolves the production poll lock path under the Fieldy state directory', () => {
+    expect(path.basename(telegramPollLockPath())).toBe('telegram-review-poll.pid');
+    expect(path.basename(path.dirname(telegramPollLockPath()))).toBe('state');
+    expect(path.basename(path.dirname(path.dirname(telegramPollLockPath())))).toBe('Fieldy');
+  });
+
+  it('ignores missing lock files during explicit poll lock release', () => {
+    const lockPath = path.join(tempDir, 'Fieldy', 'state', 'telegram-review-poll.pid');
+
+    expect(() => releaseTelegramPollLock({ lockPath, pid: 1234 })).not.toThrow();
+  });
+
+  it('rejects unauthorized callback users without recording a decision', async () => {
+    await handleCallback('token', {
+      id: 'callback-1',
+      from: { id: 99999 },
+      message: { chat: { id: 12345 }, message_id: 10 },
+      data: 'fr:test-token',
+    }, {
+      TELEGRAM_BOT_TOKEN: 'token',
+      TELEGRAM_REVIEW_CHAT_ID: '12345',
+      TELEGRAM_ALLOWED_USER_ID: '67890',
+    });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body.text).toBe('認可されていません');
+    expect(fs.existsSync(process.env.FIELDY_REVIEW_DECISIONS_DIR || '')).toBe(false);
+  });
+
+  it('rejects unauthorized callback chats without recording a decision', async () => {
+    await handleCallback('token', {
+      id: 'callback-2',
+      from: { id: 67890 },
+      message: { chat: { id: 22222 }, message_id: 10 },
+      data: 'fr:test-token',
+    }, {
+      TELEGRAM_BOT_TOKEN: 'token',
+      TELEGRAM_REVIEW_CHAT_ID: '12345',
+      TELEGRAM_ALLOWED_USER_ID: '67890',
+    });
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body.text).toBe('認可されていません');
+    expect(fs.existsSync(process.env.FIELDY_REVIEW_DECISIONS_DIR || '')).toBe(false);
+  });
+
+  it('omits the original title from sensitive sendMessage payloads', async () => {
+    const sensitiveTitle = '山田太郎との契約条件と医療相談';
+    const item = itemToReviewItem({
+      ...baseItem,
+      title: sensitiveTitle,
+      sensitive: true,
+      summary: '本文にも秘密が含まれる。',
+    });
+
+    await sendReviewItem('token', '12345', item);
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body.chat_id).toBe('12345');
+    expect(body.text).toContain('[Sensitive候補 - ローカル確認要]');
+    expect(body.text).not.toContain(sensitiveTitle);
+  });
+
+  it('writes decisions through a tmp file in the same directory before rename', async () => {
+    const { callback } = seedCallbackReview(tempDir);
+    const writeCalls: string[] = [];
+    __setFieldyTelegramFsOpsForTest({
+      writeFileSync: ((filePath: fs.PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options?: fs.WriteFileOptions) => {
+        writeCalls.push(String(filePath));
+        return fs.writeFileSync(filePath, data, options);
+      }) as typeof fs.writeFileSync,
+    });
+
+    await handleCallback('token', callback, {
+      TELEGRAM_BOT_TOKEN: 'token',
+      TELEGRAM_REVIEW_CHAT_ID: '12345',
+      TELEGRAM_ALLOWED_USER_ID: '67890',
+    });
+
+    const decisionTmpCall = writeCalls.find((filePath) => filePath.includes(`${path.sep}decisions${path.sep}2026-04-18.jsonl.tmp-`));
+    expect(decisionTmpCall).toBeTruthy();
+    expect(path.dirname(String(decisionTmpCall))).toBe(path.join(tempDir, 'decisions'));
+    expect(fs.readFileSync(path.join(tempDir, 'decisions', '2026-04-18.jsonl'), 'utf-8')).toContain('"action":"approve"');
+  });
+
+  it('fsyncs the parent directory after renaming the decision file', async () => {
+    const { callback } = seedCallbackReview(tempDir);
+    const operations: string[] = [];
+    const fdPaths = new Map<number, string>();
+    const decisionTmpMarker = `${path.sep}decisions${path.sep}2026-04-18.jsonl.tmp-`;
+    const decisionDir = path.join(tempDir, 'decisions');
+    __setFieldyTelegramFsOpsForTest({
+      writeFileSync: ((filePath: fs.PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options?: fs.WriteFileOptions) => {
+        if (String(filePath).includes(decisionTmpMarker)) operations.push('writeTmp');
+        return fs.writeFileSync(filePath, data, options);
+      }) as typeof fs.writeFileSync,
+      openSync: ((filePath: fs.PathLike, flags: fs.OpenMode, mode?: fs.Mode) => {
+        const fd = fs.openSync(filePath, flags, mode);
+        fdPaths.set(fd, String(filePath));
+        return fd;
+      }) as typeof fs.openSync,
+      fsyncSync: ((fd: number) => {
+        const filePath = fdPaths.get(fd);
+        if (filePath?.includes(decisionTmpMarker)) operations.push('fsyncTmp');
+        if (filePath === decisionDir) operations.push('fsyncParentDir');
+        return fs.fsyncSync(fd);
+      }) as typeof fs.fsyncSync,
+      closeSync: ((fd: number) => {
+        fdPaths.delete(fd);
+        return fs.closeSync(fd);
+      }) as typeof fs.closeSync,
+      renameSync: ((oldPath: fs.PathLike, newPath: fs.PathLike) => {
+        if (String(oldPath).includes(decisionTmpMarker)) operations.push('rename');
+        return fs.renameSync(oldPath, newPath);
+      }) as typeof fs.renameSync,
+    });
+
+    await handleCallback('token', callback, {
+      TELEGRAM_BOT_TOKEN: 'token',
+      TELEGRAM_REVIEW_CHAT_ID: '12345',
+      TELEGRAM_ALLOWED_USER_ID: '67890',
+    });
+
+    expect(operations).toEqual(['writeTmp', 'fsyncTmp', 'rename', 'fsyncParentDir']);
+  });
+
+  it('keeps state unchanged and reports retry when decision append fails before rename', async () => {
+    const { callback, item } = seedCallbackReview(tempDir);
+    const decisionFile = path.join(tempDir, 'decisions', '2026-04-18.jsonl');
+    const reviewItemsFile = path.join(tempDir, 'review', 'review_items', '2026-04-18.json');
+    const actionTokensFile = path.join(tempDir, 'review', 'action-tokens.json');
+    fs.mkdirSync(path.dirname(decisionFile), { recursive: true });
+    fs.writeFileSync(decisionFile, '{"existing":true}\n');
+    const original = fs.readFileSync(decisionFile, 'utf-8');
+    const originalReviewItems = fs.readFileSync(reviewItemsFile, 'utf-8');
+    const originalActionTokens = fs.readFileSync(actionTokensFile, 'utf-8');
+    __setFieldyTelegramFsOpsForTest({
+      writeFileSync: ((filePath: fs.PathOrFileDescriptor, data: string | NodeJS.ArrayBufferView, options?: fs.WriteFileOptions) => {
+        if (String(filePath).includes('2026-04-18.jsonl.tmp-')) {
+          throw new Error('simulated kill before rename');
+        }
+        return fs.writeFileSync(filePath, data, options);
+      }) as typeof fs.writeFileSync,
+    });
+
+    await handleCallback('token', callback, {
+      TELEGRAM_BOT_TOKEN: 'token',
+      TELEGRAM_REVIEW_CHAT_ID: '12345',
+      TELEGRAM_ALLOWED_USER_ID: '67890',
+    });
+
+    expect(fs.readFileSync(decisionFile, 'utf-8')).toBe(original);
+    expect(fs.readFileSync(reviewItemsFile, 'utf-8')).toBe(originalReviewItems);
+    expect(JSON.parse(fs.readFileSync(reviewItemsFile, 'utf-8'))[0].status).toBe(item.status);
+    expect(fs.readFileSync(actionTokensFile, 'utf-8')).toBe(originalActionTokens);
+    expect(JSON.parse(fs.readFileSync(actionTokensFile, 'utf-8'))['approve-token'].usedAt).toBeUndefined();
+    expect(fs.readdirSync(path.dirname(decisionFile)).filter((name) => name.includes('.tmp-'))).toEqual([]);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1].body));
+    expect(body.text).toBe('処理に失敗しました。再試行してください');
+  });
+
+  it('retries 429 responses after retry_after seconds', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        json: async () => ({ ok: false, description: 'rate limited', parameters: { retry_after: 2 } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, result: { message_id: 1 } }),
+      });
+
+    const resultPromise = telegramFetch('token', 'sendMessage', { chat_id: '12345', text: 'safe' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(resultPromise).resolves.toEqual({ message_id: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws AbortError when Telegram fetch times out', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockImplementation((_url: string, init: RequestInit) => new Promise((_resolve, reject) => {
+      init.signal?.addEventListener('abort', () => {
+        reject(new DOMException('aborted', 'AbortError'));
+      });
+    }));
+
+    const resultPromise = telegramFetch('token', 'getUpdates', { timeout: 0 }, { timeoutMs: 100 });
+    const assertion = expect(resultPromise).rejects.toMatchObject({ name: 'AbortError' });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await assertion;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries 5xx responses with exponential backoff', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ ok: false, description: 'server error' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, result: { ok: 'recovered' } }),
+      });
+
+    const resultPromise = telegramFetch('token', 'answerCallbackQuery', { callback_query_id: 'cb' });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await expect(resultPromise).resolves.toEqual({ ok: 'recovered' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry non-429 4xx responses', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ ok: false, description: 'bad request' }),
+    });
+
+    await expect(telegramFetch('token', 'editMessageText', { text: 'safe' })).rejects.toThrow('telegram_editMessageText_failed:400:bad request');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+function seedCallbackReview(tempDir: string) {
+  const item = itemToReviewItem(baseItem);
+  const reviewItemsDir = path.join(tempDir, 'review', 'review_items');
+  fs.mkdirSync(reviewItemsDir, { recursive: true });
+  fs.writeFileSync(path.join(reviewItemsDir, '2026-04-18.json'), `${JSON.stringify([item], null, 2)}\n`);
+  fs.writeFileSync(path.join(tempDir, 'review', 'action-tokens.json'), `${JSON.stringify({
+    'approve-token': {
+      token: 'approve-token',
+      reviewItemId: item.id,
+      action: 'approve',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    },
+  }, null, 2)}\n`);
+
+  return {
+    item,
+    callback: {
+      id: 'callback-approve',
+      from: { id: 67890 },
+      message: { chat: { id: 12345 }, message_id: 10 },
+      data: 'fr:approve-token',
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- マルチエージェント独立検証 (Codex/GLM/Gemini) で検出された HIGH findings を 4-stage で hardening
- 対象: `fieldy-task-shifter/scripts/fieldy-telegram-review.{mjs,test.ts}` (2 files, +1253 lines)
- 24/24 tests pass (`npm run test:fieldy-telegram`)

## Changes

### Stage 1 — H1 authorization fail-closed + H4 sensitive title redaction
- `preflightTelegramReviewEnv()` enforces `TELEGRAM_BOT_TOKEN` / `TELEGRAM_REVIEW_CHAT_ID` / `TELEGRAM_ALLOWED_USER_ID` on daily/poll start
- `handleCallback()` validates both `callback.from.id` and `callback.message.chat.id`; mismatch → reject without recording decision
- `formatSensitiveCard()` forces title replacement with `[Sensitive候補 - ローカル確認要] <hash>` when sensitive=true

### Stage 2 — H2 atomic decision write + H3 Telegram rate limit
- `atomicWriteFileSync` (tmp + fsync + rename) for decision JSONL and state.json
- `telegramFetch()` wrapper: 15s AbortController timeout, exponential backoff respecting `retry_after`, 5xx retry, 4xx immediate throw

### Stage 3 — Poll PID lock
- Lock at `~/Fieldy/state/telegram-review-poll.pid` with stale detection (`process.kill(pid, 0)`)
- SIGINT/SIGTERM cleanup handlers

### Stage 4 — Code-review findings (Codex `approve-with-fixes`)
- **C1**: Decision JSONL append moved to FIRST in `handleCallback()`; items/tokens updated only after decision durably written (prevents orphan approvals)
- **M1**: Parent-dir fsync after rename (POSIX crash durability)
- **M2**: `isDirectUserChatId()` enforced in preflight for all commands (blocks group/channel chat IDs)
- **M3**: `releaseTelegramPollLock()` reads lock file PID and refuses unlink when `ownedPid` doesn't match

## Deferred
- **M4** `appendJsonl` atomic-rewrite pattern — acceptable for single-poll; redesign (O_APPEND or per-file lock) required before multi-process/webhook future work. Tracked as follow-up task.

## Review diversity note
Implementation: Codex architect. Code-review: Codex `code-reviewer` (degraded multi-model mode — GLM 429 rate-limit, Gemini delegator missing `@google/generative-ai`). Full vendor-diversity review pending GLM restoration.

## Test plan
- [x] `npm run test:fieldy-telegram` → 24/24 pass
- [ ] Manual smoke: `daily --dry-run` on env-complete environment
- [ ] Preflight fail-closed verified with missing env
- [ ] Poll mode lock acquisition verified with concurrent launch attempt

FUGUE run: `6aab6364` (spec: `~/.claude/state/runs/6aab6364/phase-a-summary.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)