### PR TITLE
fix: route delivery alerts to system monitor

### DIFF
--- a/.github/workflows/delivery-audit.yml
+++ b/.github/workflows/delivery-audit.yml
@@ -185,26 +185,26 @@ jobs:
           echo "report=| LINE Quota | ${total_usage}/${quota_value} (${usage_pct}%) predicted ${predicted_total} (${predicted_pct}%) | ${status} |" >> "$GITHUB_OUTPUT"
 
       # ----------------------------------------------------------------
-      # 4. Discord Webhook Health Check
+      # 4. Discord System Webhook Health Check
       # ----------------------------------------------------------------
-      - name: Discord Webhook Health Check
+      - name: Discord System Webhook Health Check
         id: discord_health
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         shell: bash
         run: |
           set -euo pipefail
 
-          if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
-            echo "::notice::DISCORD_WEBHOOK_URL not set — skipping Discord webhook check"
-            echo "status=skipped" >> "$GITHUB_OUTPUT"
-            echo "report=| Discord Webhook | skipped | URL not configured |" >> "$GITHUB_OUTPUT"
+          if [[ -z "${DISCORD_SYSTEM_WEBHOOK:-}" ]]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set — system notifications cannot be delivered"
+            echo "status=ERROR" >> "$GITHUB_OUTPUT"
+            echo "report=| Discord System Webhook | missing | ERROR — URL not configured |" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           http_code=$(curl -s -o /dev/null -w "%{http_code}" \
             --connect-timeout 5 --max-time 20 \
-            -X GET "${DISCORD_WEBHOOK_URL}" || echo "000")
+            -X GET "${DISCORD_SYSTEM_WEBHOOK}" || echo "000")
 
           if [[ "${http_code}" == "200" ]]; then
             status="ok"
@@ -212,15 +212,15 @@ jobs:
           elif [[ "${http_code}" == "404" ]]; then
             status="ERROR — webhook revoked"
             overall="ERROR"
-            echo "::error::Discord webhook returned 404 — webhook may be revoked"
+            echo "::error::Discord system webhook returned 404 — webhook may be revoked"
           else
             status="WARNING — HTTP ${http_code}"
             overall="WARNING"
-            echo "::warning::Discord webhook returned unexpected HTTP ${http_code}"
+            echo "::warning::Discord system webhook returned unexpected HTTP ${http_code}"
           fi
 
           echo "status=${overall}" >> "$GITHUB_OUTPUT"
-          echo "report=| Discord Webhook | HTTP ${http_code} | ${status} |" >> "$GITHUB_OUTPUT"
+          echo "report=| Discord System Webhook | HTTP ${http_code} | ${status} |" >> "$GITHUB_OUTPUT"
 
       # ----------------------------------------------------------------
       # 5. Contract Drift Check
@@ -388,7 +388,6 @@ jobs:
         if: ${{ always() && steps.build_report.outputs.overall != 'HEALTHY' }}
         continue-on-error: true
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
           OVERALL: ${{ steps.build_report.outputs.overall }}
           TODAY: ${{ steps.build_report.outputs.today }}
@@ -406,9 +405,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [[ -z "${DISCORD_WEBHOOK_URL:-}" ]]; then
-            echo "::notice::DISCORD_WEBHOOK_URL not set — skipping Discord notification"
-            exit 0
+          if [[ -z "${DISCORD_SYSTEM_WEBHOOK:-}" ]]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set — Discord system notification lost"
+            exit 1
           fi
 
           # Build LINE quota line
@@ -428,7 +427,7 @@ jobs:
             "**GHA Run Health:**" \
             "${gha_lines}" \
             "**${line_line}**" \
-            "**Discord Webhook: ${DISCORD_STATUS}**" \
+            "**Discord System Webhook: ${DISCORD_STATUS}**" \
             "**Contract Drift: ${DRIFT_STATUS}**" \
             "Run: ${RUN_URL}")
 
@@ -438,20 +437,13 @@ jobs:
             --connect-timeout 5 --max-time 20 \
             -H "Content-Type: application/json" \
             -d "${payload}" \
-            "${DISCORD_WEBHOOK_URL}" 2>/dev/null || echo "000")
+            "${DISCORD_SYSTEM_WEBHOOK}" 2>/dev/null || echo "000")
 
           if [[ "${http_status}" =~ ^2 ]]; then
-            echo "Discord anomaly notification sent."
+            echo "Discord system anomaly notification sent."
           else
-            echo "::warning::Primary webhook failed (HTTP ${http_status}); trying system webhook"
-            if [[ -n "${DISCORD_SYSTEM_WEBHOOK:-}" ]]; then
-              curl -s --connect-timeout 5 --max-time 20 \
-                -H "Content-Type: application/json" \
-                -d "${payload}" \
-                "${DISCORD_SYSTEM_WEBHOOK}" || echo "::warning::System webhook also failed"
-            else
-              echo "::warning::DISCORD_SYSTEM_WEBHOOK not set — Discord notification lost"
-            fi
+            echo "::error::Discord system webhook failed (HTTP ${http_status})"
+            exit 1
           fi
 
       # ----------------------------------------------------------------

--- a/.github/workflows/fugue-orchestration-gate.yml
+++ b/.github/workflows/fugue-orchestration-gate.yml
@@ -10,6 +10,10 @@ on:
       - '.github/workflows/fugue-tutti-router.yml'
       - '.github/workflows/fugue-task-router.yml'
       - '.github/workflows/kernel-decision-journal.yml'
+      - '.github/workflows/delivery-audit.yml'
+      - '.github/workflows/line-richmenu-deploy.yml'
+      - '.github/workflows/line-send-note-article.yml'
+      - '.github/workflows/line-value-share.yml'
       - 'scripts/lib/build-agent-matrix.sh'
       - 'scripts/lib/kernel-auth-evidence.sh'
       - 'scripts/lib/canary-trust-policy.sh'
@@ -89,6 +93,8 @@ on:
       - 'tests/test-watchdog-alert-policy.sh'
       - 'tests/test-watchdog-waiting-run-workflow.sh'
       - 'tests/test-watchdog-alert-delivery-policy.sh'
+      - 'tests/test-delivery-system-discord-routing.sh'
+      - 'tests/test-line-delivery-dedup-guards.sh'
       - 'tests/test-primary-heartbeat-state.sh'
       - 'tests/test-workspace-root-policy.sh'
       - 'tests/test-workflow-checkout-order.sh'
@@ -130,6 +136,10 @@ on:
       - '.github/workflows/fugue-tutti-router.yml'
       - '.github/workflows/fugue-task-router.yml'
       - '.github/workflows/kernel-decision-journal.yml'
+      - '.github/workflows/delivery-audit.yml'
+      - '.github/workflows/line-richmenu-deploy.yml'
+      - '.github/workflows/line-send-note-article.yml'
+      - '.github/workflows/line-value-share.yml'
       - 'scripts/lib/build-agent-matrix.sh'
       - 'scripts/lib/kernel-auth-evidence.sh'
       - 'scripts/lib/canary-trust-policy.sh'
@@ -209,6 +219,8 @@ on:
       - 'tests/test-watchdog-alert-policy.sh'
       - 'tests/test-watchdog-waiting-run-workflow.sh'
       - 'tests/test-watchdog-alert-delivery-policy.sh'
+      - 'tests/test-delivery-system-discord-routing.sh'
+      - 'tests/test-line-delivery-dedup-guards.sh'
       - 'tests/test-primary-heartbeat-state.sh'
       - 'tests/test-workspace-root-policy.sh'
       - 'tests/test-workflow-checkout-order.sh'
@@ -347,6 +359,8 @@ jobs:
           bash_n tests/test-watchdog-reconcile-workflow.sh
           bash_n tests/test-peripheral-adapter-contract.sh
           bash_n tests/test-workspace-root-policy.sh
+          bash_n tests/test-delivery-system-discord-routing.sh
+          bash_n tests/test-line-delivery-dedup-guards.sh
           bash_n tests/test-canary-trust-policy.sh
           bash_n tests/test-kernel-canary-plan.sh
           bash_n tests/test-kernel-recovery-console.sh
@@ -422,6 +436,8 @@ jobs:
           bash tests/test-sync-gh-auth-drill.sh
           bash tests/test-org-secrets-shadow-cleanup.sh
           bash tests/test-watchdog-alert-delivery-policy.sh
+          bash tests/test-delivery-system-discord-routing.sh
+          bash tests/test-line-delivery-dedup-guards.sh
           bash tests/test-primary-heartbeat-state.sh
           bash tests/test-publish-decision-journal.sh
           bash tests/test-local-orchestration-heartbeat-cleanup.sh

--- a/.github/workflows/line-richmenu-deploy.yml
+++ b/.github/workflows/line-richmenu-deploy.yml
@@ -318,16 +318,23 @@ jobs:
         if: ${{ failure() }}
         continue-on-error: true
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
           set -euo pipefail
-          if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
-            exit 0
+          if [ -z "${DISCORD_SYSTEM_WEBHOOK:-}" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. System failure notification cannot be delivered."
+            exit 1
           fi
           PAYLOAD=$(jq -n \
             --arg content "[LINE Rich Menu Deploy] Failed. Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             '{content: $content}')
-          curl -s -X POST "${DISCORD_WEBHOOK_URL}" \
+          HTTP_STATUS="$(curl -sS -X POST "${DISCORD_SYSTEM_WEBHOOK}" \
             --connect-timeout 5 --max-time 20 \
+            -o /dev/null \
+            -w "%{http_code}" \
             -H "Content-Type: application/json" \
-            -d "${PAYLOAD}" || true
+            -d "${PAYLOAD}")" || true
+          case "${HTTP_STATUS}" in
+            2*) echo "Discord system failure notification sent." ;;
+            *)  echo "::error::Discord system failure notification failed (HTTP ${HTTP_STATUS:-N/A})."; exit 1 ;;
+          esac

--- a/.github/workflows/line-send-note-article.yml
+++ b/.github/workflows/line-send-note-article.yml
@@ -605,17 +605,17 @@ jobs:
         if: ${{ failure() }}
         continue-on-error: true
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
           set -euo pipefail
-          if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
-            echo "::notice::DISCORD_WEBHOOK_URL not set. Skipping failure notification."
-            exit 0
+          if [ -z "${DISCORD_SYSTEM_WEBHOOK:-}" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. System failure notification cannot be delivered."
+            exit 1
           fi
           PAYLOAD="$(jq -n \
             --arg content "[LINE Send Note Article] Workflow failed. Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             '{content: $content}')"
-          HTTP_STATUS="$(curl -sS -X POST "${DISCORD_WEBHOOK_URL}" \
+          HTTP_STATUS="$(curl -sS -X POST "${DISCORD_SYSTEM_WEBHOOK}" \
             --connect-timeout 5 \
             --max-time 20 \
             -o /dev/null \
@@ -623,6 +623,6 @@ jobs:
             -H "Content-Type: application/json" \
             -d "${PAYLOAD}")" || true
           case "${HTTP_STATUS}" in
-            2*) echo "Discord failure notification sent." ;;
-            *)  echo "::warning::Discord failure notification failed (HTTP ${HTTP_STATUS:-N/A})." ;;
+            2*) echo "Discord system failure notification sent." ;;
+            *)  echo "::error::Discord system failure notification failed (HTTP ${HTTP_STATUS:-N/A})."; exit 1 ;;
           esac

--- a/.github/workflows/line-value-share.yml
+++ b/.github/workflows/line-value-share.yml
@@ -34,6 +34,10 @@ jobs:
             if gh api "repos/${GITHUB_REPOSITORY}/actions/variables/${name}" --jq '.name' >/dev/null 2>&1; then
               return 0
             fi
+            if [ -z "${value}" ]; then
+              echo "::notice::Skipping initialization for ${name} because GitHub Variables cannot store empty strings."
+              return 0
+            fi
             gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/variables" \
               -f name="${name}" \
               -f value="${value}" >/dev/null
@@ -159,7 +163,23 @@ jobs:
 
           read_var() {
             local name="$1"
-            gh api "repos/${GITHUB_REPOSITORY}/actions/variables/${name}" --jq '.value'
+            local out err
+            out="$(mktemp)"
+            err="$(mktemp)"
+            if gh api "repos/${GITHUB_REPOSITORY}/actions/variables/${name}" --jq '.value // empty' >"${out}" 2>"${err}"; then
+              cat "${out}"
+              rm -f "${out}" "${err}"
+              return 0
+            fi
+            if grep -Eq 'HTTP 404|Not Found|"message"[[:space:]]*:[[:space:]]*"Not Found"' "${out}" "${err}"; then
+              rm -f "${out}" "${err}"
+              return 0
+            fi
+            echo "::error::Failed to read GitHub variable ${name}" >&2
+            cat "${err}" >&2 || true
+            cat "${out}" >&2 || true
+            rm -f "${out}" "${err}"
+            return 1
           }
 
           RAW_INDEX="$(read_var "LINE_VALUE_SHARE_INDEX")"
@@ -235,17 +255,16 @@ jobs:
           upsert_var() {
             local name="$1"
             local value="$2"
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/actions/variables/${name}" \
-              -f name="${name}" -f value="${value}" >/dev/null
+            { gh api -X PATCH "repos/${GITHUB_REPOSITORY}/actions/variables/${name}" \
+                -f name="${name}" -f value="${value}" >/dev/null 2>&1 \
+              || gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/variables" \
+                -f name="${name}" -f value="${value}" >/dev/null 2>&1; }
           }
 
           rollback_reservation() {
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/actions/variables/LINE_VALUE_SHARE_PENDING_INDEX" \
-              -f name="LINE_VALUE_SHARE_PENDING_INDEX" -f value="" >/dev/null 2>&1 || true
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/actions/variables/LINE_VALUE_SHARE_PENDING_AT" \
-              -f name="LINE_VALUE_SHARE_PENDING_AT" -f value="" >/dev/null 2>&1 || true
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/actions/variables/LINE_VALUE_SHARE_PENDING_STATE" \
-              -f name="LINE_VALUE_SHARE_PENDING_STATE" -f value="" >/dev/null 2>&1 || true
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/variables/LINE_VALUE_SHARE_PENDING_INDEX" >/dev/null 2>&1 || true
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/variables/LINE_VALUE_SHARE_PENDING_AT" >/dev/null 2>&1 || true
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/variables/LINE_VALUE_SHARE_PENDING_STATE" >/dev/null 2>&1 || true
             gh api -X PATCH "repos/${GITHUB_REPOSITORY}/actions/variables/LINE_VALUE_SHARE_INDEX" \
               -f name="LINE_VALUE_SHARE_INDEX" -f value="${CURRENT_INDEX}" >/dev/null 2>&1 || true
           }
@@ -384,6 +403,10 @@ jobs:
           upsert_var() {
             local name="$1"
             local value="$2"
+            if [ -z "${value}" ]; then
+              gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/variables/${name}" >/dev/null 2>&1 || true
+              return 0
+            fi
             { gh api -X PATCH "repos/${GITHUB_REPOSITORY}/actions/variables/${name}" \
                 -f name="${name}" -f value="${value}" >/dev/null 2>&1 \
               || gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/variables" \
@@ -421,18 +444,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          upsert_var() {
+          clear_var() {
             local name="$1"
-            local value="$2"
-            { gh api -X PATCH "repos/${GITHUB_REPOSITORY}/actions/variables/${name}" \
-                -f name="${name}" -f value="${value}" >/dev/null 2>&1 \
-              || gh api -X POST "repos/${GITHUB_REPOSITORY}/actions/variables" \
-                -f name="${name}" -f value="${value}" >/dev/null 2>&1; }
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/variables/${name}" >/dev/null 2>&1 || true
           }
 
-          upsert_var "LINE_VALUE_SHARE_PENDING_INDEX" ""
-          upsert_var "LINE_VALUE_SHARE_PENDING_AT" ""
-          upsert_var "LINE_VALUE_SHARE_PENDING_STATE" ""
+          clear_var "LINE_VALUE_SHARE_PENDING_INDEX"
+          clear_var "LINE_VALUE_SHARE_PENDING_AT"
+          clear_var "LINE_VALUE_SHARE_PENDING_STATE"
 
           echo "Cleared LINE value share rotation lock."
 
@@ -446,8 +465,7 @@ jobs:
 
           clear_var() {
             local name="$1"
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/actions/variables/${name}" \
-              -f name="${name}" -f value="" >/dev/null
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/variables/${name}" >/dev/null 2>&1 || true
           }
 
           clear_var "LINE_VALUE_SHARE_PENDING_INDEX"
@@ -504,17 +522,17 @@ jobs:
         if: ${{ failure() }}
         continue-on-error: true
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
           set -euo pipefail
-          if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
-            echo "::notice::DISCORD_WEBHOOK_URL not set. Skipping failure notification."
-            exit 0
+          if [ -z "${DISCORD_SYSTEM_WEBHOOK:-}" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. System failure notification cannot be delivered."
+            exit 1
           fi
           PAYLOAD="$(jq -n \
             --arg content "[LINE Value Share] Workflow failed. Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             '{content: $content}')"
-          HTTP_STATUS="$(curl -sS -X POST "${DISCORD_WEBHOOK_URL}" \
+          HTTP_STATUS="$(curl -sS -X POST "${DISCORD_SYSTEM_WEBHOOK}" \
             --connect-timeout 5 \
             --max-time 20 \
             -o /dev/null \
@@ -522,6 +540,6 @@ jobs:
             -H "Content-Type: application/json" \
             -d "${PAYLOAD}")" || true
           case "${HTTP_STATUS}" in
-            2*) echo "Discord failure notification sent." ;;
-            *)  echo "::warning::Discord failure notification failed (HTTP ${HTTP_STATUS:-N/A})." ;;
+            2*) echo "Discord system failure notification sent." ;;
+            *)  echo "::error::Discord system failure notification failed (HTTP ${HTTP_STATUS:-N/A})."; exit 1 ;;
           esac

--- a/tests/test-delivery-system-discord-routing.sh
+++ b/tests/test-delivery-system-discord-routing.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DELIVERY_AUDIT="${ROOT_DIR}/.github/workflows/delivery-audit.yml"
+ARTICLE_WORKFLOW="${ROOT_DIR}/.github/workflows/line-send-note-article.yml"
+VALUE_WORKFLOW="${ROOT_DIR}/.github/workflows/line-value-share.yml"
+RICHMENU_WORKFLOW="${ROOT_DIR}/.github/workflows/line-richmenu-deploy.yml"
+
+failures=0
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq "${needle}" "${file}"; then
+    echo "PASS [${label}]"
+  else
+    echo "FAIL [${label}]: missing '${needle}' in ${file}" >&2
+    failures=$((failures + 1))
+  fi
+}
+
+assert_not_contains_block() {
+  local file="$1"
+  local start="$2"
+  local end="$3"
+  local needle="$4"
+  local label="$5"
+  if awk -v start="${start}" -v end="${end}" -v needle="${needle}" '
+    index($0, start) { in_block=1 }
+    in_block && index($0, needle) { found=1 }
+    end != "" && in_block && index($0, end) { in_block=0 }
+    END { exit found ? 0 : 1 }
+  ' "${file}"; then
+    echo "FAIL [${label}]: found '${needle}' in ${file}" >&2
+    failures=$((failures + 1))
+  else
+    echo "PASS [${label}]"
+  fi
+}
+
+assert_contains "${DELIVERY_AUDIT}" "Discord System Webhook Health Check" "delivery audit checks system webhook"
+assert_contains "${DELIVERY_AUDIT}" 'DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}' "delivery audit wires system webhook"
+assert_contains "${DELIVERY_AUDIT}" "Discord system anomaly notification sent." "delivery audit reports system notification delivery"
+assert_not_contains_block "${DELIVERY_AUDIT}" "Notify Discord on anomaly" "Remediate transient GHA failures" "DISCORD_WEBHOOK_URL" "delivery audit anomaly does not use client webhook"
+
+assert_contains "${ARTICLE_WORKFLOW}" 'DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}' "article failure notification wires system webhook"
+assert_not_contains_block "${ARTICLE_WORKFLOW}" "Notify Discord on failure" "" "DISCORD_WEBHOOK_URL" "article failure notification does not use client webhook"
+
+assert_contains "${VALUE_WORKFLOW}" 'DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}' "value failure notification wires system webhook"
+assert_not_contains_block "${VALUE_WORKFLOW}" "Notify Discord on failure" "" "DISCORD_WEBHOOK_URL" "value failure notification does not use client webhook"
+
+assert_contains "${RICHMENU_WORKFLOW}" 'DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}' "rich menu failure notification wires system webhook"
+assert_not_contains_block "${RICHMENU_WORKFLOW}" "Notify Discord on failure" "" "DISCORD_WEBHOOK_URL" "rich menu failure notification does not use client webhook"
+
+if (( failures > 0 )); then
+  exit 1
+fi
+
+echo "delivery system Discord routing check passed"

--- a/tests/test-line-delivery-dedup-guards.sh
+++ b/tests/test-line-delivery-dedup-guards.sh
@@ -81,6 +81,13 @@ assert_contains "${VALUE_WORKFLOW}" "Heal rotation index after duplicate guard" 
 assert_contains "${VALUE_WORKFLOW}" "build_retry_key" "value workflow builds deterministic LINE retry key"
 assert_contains "${VALUE_WORKFLOW}" "LINE broadcast request was already accepted for retry key" "value workflow handles duplicate retry-key acceptance"
 assert_contains "${VALUE_WORKFLOW}" "Pause delivery after ambiguous broadcast state" "value workflow pauses on ambiguous receipt persistence"
+assert_contains "${VALUE_WORKFLOW}" "Skipping initialization for \${name} because GitHub Variables cannot store empty strings." "value workflow skips empty variable initialization"
+assert_contains "${VALUE_WORKFLOW}" "gh api -X DELETE \"repos/\${GITHUB_REPOSITORY}/actions/variables/\${name}\" >/dev/null 2>&1 || true" "value workflow deletes variables when clearing empty state"
+assert_contains "${VALUE_WORKFLOW}" "Failed to read GitHub variable \${name}" "value workflow fails on unexpected variable read errors"
+assert_contains "${VALUE_WORKFLOW}" "HTTP 404|Not Found" "value workflow treats deleted optional variables as empty"
+assert_contains "${VALUE_WORKFLOW}" "upsert_var \"LINE_VALUE_SHARE_PENDING_INDEX\" \"\${CURRENT_INDEX}\"" "value workflow still creates prepared rotation lock"
+assert_contains "${VALUE_WORKFLOW}" "|| gh api -X POST \"repos/\${GITHUB_REPOSITORY}/actions/variables\"" "value workflow creates missing GitHub variables when reserving state"
+assert_contains "${VALUE_WORKFLOW}" "clear_var \"LINE_VALUE_SHARE_PENDING_INDEX\"" "value workflow clears success lock via delete semantics"
 
 if (( failures > 0 )); then
   exit 1


### PR DESCRIPTION
## Summary
- route Delivery Audit and LINE failure notifications through DISCORD_SYSTEM_WEBHOOK
- fail closed when the system webhook is missing or returns non-2xx
- harden LINE Value Share variable reads and wire routing regression tests into the orchestration gate

## Verification
- tests/test-line-delivery-dedup-guards.sh
- tests/test-delivery-system-discord-routing.sh
- actionlint -shellcheck= .github/workflows/fugue-orchestration-gate.yml .github/workflows/delivery-audit.yml .github/workflows/line-value-share.yml .github/workflows/line-send-note-article.yml .github/workflows/line-richmenu-deploy.yml
- git diff --check