### PR TITLE
fix: avoid rerunning stale delivery failures

### DIFF
--- a/.github/workflows/delivery-audit.yml
+++ b/.github/workflows/delivery-audit.yml
@@ -471,10 +471,16 @@ jobs:
             # Get the most recent failed run
             last_failed=$(gh api \
               "repos/${REPO}/actions/workflows/${wf_id}/runs?per_page=1&status=completed&conclusion=failure" \
-              --jq '.workflow_runs[0] | {id, run_number, created_at}' 2>/dev/null || echo '{}')
+              --jq '.workflow_runs[0] | {id, run_number, created_at, head_sha}' 2>/dev/null || echo '{}')
 
             run_id=$(echo "${last_failed}" | jq -r '.id // empty')
             [[ -z "${run_id}" ]] && continue
+            failed_head_sha=$(echo "${last_failed}" | jq -r '.head_sha // empty')
+
+            if [[ -n "${failed_head_sha}" && "${failed_head_sha}" != "${GITHUB_SHA}" ]]; then
+              echo "::notice::Skipping rerun for '${wf_name}' (run ${run_id}) because it was created from ${failed_head_sha}, not current ${GITHUB_SHA}."
+              continue
+            fi
 
             # Fetch failed job logs (first 3000 chars to classify)
             job_log=$(gh run view "${run_id}" --log-failed 2>/dev/null | head -100 || echo "")

--- a/tests/test-delivery-system-discord-routing.sh
+++ b/tests/test-delivery-system-discord-routing.sh
@@ -43,6 +43,7 @@ assert_not_contains_block() {
 assert_contains "${DELIVERY_AUDIT}" "Discord System Webhook Health Check" "delivery audit checks system webhook"
 assert_contains "${DELIVERY_AUDIT}" 'DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}' "delivery audit wires system webhook"
 assert_contains "${DELIVERY_AUDIT}" "Discord system anomaly notification sent." "delivery audit reports system notification delivery"
+assert_contains "${DELIVERY_AUDIT}" "because it was created from \${failed_head_sha}, not current \${GITHUB_SHA}" "delivery audit does not rerun stale failed workflow attempts"
 assert_not_contains_block "${DELIVERY_AUDIT}" "Notify Discord on anomaly" "Remediate transient GHA failures" "DISCORD_WEBHOOK_URL" "delivery audit anomaly does not use client webhook"
 
 assert_contains "${ARTICLE_WORKFLOW}" 'DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}' "article failure notification wires system webhook"


### PR DESCRIPTION
## Summary
- skip Delivery Audit auto-reruns when the failed workflow run was created from an older head SHA
- keep old workflow definitions from being re-executed after alert routing fixes land
- extend the system Discord routing regression test for stale rerun protection

## Verification
- tests/test-delivery-system-discord-routing.sh
- actionlint -shellcheck= .github/workflows/delivery-audit.yml .github/workflows/fugue-orchestration-gate.yml
- git diff --check