### PR TITLE
test: harden system Discord routing guards

### DIFF
--- a/.github/workflows/delivery-audit.yml
+++ b/.github/workflows/delivery-audit.yml
@@ -463,19 +463,38 @@ jobs:
           rerun_count=0
 
           for wf_name in "${WORKFLOWS[@]}"; do
-            wf_id=$(gh api "repos/${REPO}/actions/workflows" \
-              --jq ".workflows[] | select(.name == \"${wf_name}\") | .id" \
-              2>/dev/null || echo "")
+            wf_meta=$(gh api "repos/${REPO}/actions/workflows" \
+              --jq ".workflows[] | select(.name == \"${wf_name}\") | {id, path}" \
+              2>/dev/null || echo '{}')
+            wf_id=$(echo "${wf_meta}" | jq -r '.id // empty')
+            workflow_path=$(echo "${wf_meta}" | jq -r '.path // empty')
             [[ -z "${wf_id}" ]] && continue
+            if [[ -z "${workflow_path}" ]]; then
+              echo "::notice::Skipping rerun for '${wf_name}' because workflow path metadata is unavailable."
+              continue
+            fi
 
             # Get the most recent failed run
             last_failed=$(gh api \
               "repos/${REPO}/actions/workflows/${wf_id}/runs?per_page=1&status=completed&conclusion=failure" \
-              --jq '.workflow_runs[0] | {id, run_number, created_at, head_sha}' 2>/dev/null || echo '{}')
+              --jq '.workflow_runs[0] | {id, run_number, created_at, head_sha, path}' 2>/dev/null || echo '{}')
 
             run_id=$(echo "${last_failed}" | jq -r '.id // empty')
             [[ -z "${run_id}" ]] && continue
             failed_head_sha=$(echo "${last_failed}" | jq -r '.head_sha // empty')
+            failed_workflow_path=$(echo "${last_failed}" | jq -r '.path // empty')
+
+            if [[ -z "${failed_workflow_path}" ]]; then
+              echo "::notice::Skipping rerun for '${wf_name}' (run ${run_id}) because workflow path for the failed run is unavailable."
+              continue
+            fi
+
+            workflow_path_normalized="${workflow_path%%@*}"
+            failed_workflow_path_normalized="${failed_workflow_path%%@*}"
+            if [[ "${failed_workflow_path_normalized}" != "${workflow_path_normalized}" ]]; then
+              echo "::notice::Skipping rerun for '${wf_name}' (run ${run_id}) because it was created from workflow path ${failed_workflow_path}, not current ${workflow_path}."
+              continue
+            fi
 
             if [[ -n "${failed_head_sha}" && "${failed_head_sha}" != "${GITHUB_SHA}" ]]; then
               echo "::notice::Skipping rerun for '${wf_name}' (run ${run_id}) because it was created from ${failed_head_sha}, not current ${GITHUB_SHA}."

--- a/.github/workflows/fugue-orchestration-gate.yml
+++ b/.github/workflows/fugue-orchestration-gate.yml
@@ -91,6 +91,7 @@ on:
       - 'tests/test-kernel-canary-plan.sh'
       - 'tests/test-kernel-recovery-console.sh'
       - 'tests/test-watchdog-alert-policy.sh'
+      - 'tests/test-watchdog-alert-routing.sh'
       - 'tests/test-watchdog-waiting-run-workflow.sh'
       - 'tests/test-watchdog-alert-delivery-policy.sh'
       - 'tests/test-delivery-system-discord-routing.sh'
@@ -217,6 +218,7 @@ on:
       - 'tests/test-kernel-canary-plan.sh'
       - 'tests/test-kernel-recovery-console.sh'
       - 'tests/test-watchdog-alert-policy.sh'
+      - 'tests/test-watchdog-alert-routing.sh'
       - 'tests/test-watchdog-waiting-run-workflow.sh'
       - 'tests/test-watchdog-alert-delivery-policy.sh'
       - 'tests/test-delivery-system-discord-routing.sh'
@@ -364,6 +366,7 @@ jobs:
           bash_n tests/test-canary-trust-policy.sh
           bash_n tests/test-kernel-canary-plan.sh
           bash_n tests/test-kernel-recovery-console.sh
+          bash_n tests/test-watchdog-alert-routing.sh
           bash_n tests/test-watchdog-waiting-run-workflow.sh
           bash_n tests/test-kernel-entrypoint.sh
           bash_n tests/test-kernel-launcher.sh
@@ -430,6 +433,7 @@ jobs:
           bash tests/test-route-task-handoff.sh
           bash tests/test-resolve-orchestration-context.sh
           bash tests/test-watchdog-alert-policy.sh
+          bash tests/test-watchdog-alert-routing.sh
           bash tests/test-watchdog-waiting-run-workflow.sh
           bash tests/test-kernel-recovery-console.sh
           bash tests/test-shared-secrets-failure-smoke.sh

--- a/tests/test-delivery-system-discord-routing.sh
+++ b/tests/test-delivery-system-discord-routing.sh
@@ -6,6 +6,14 @@ DELIVERY_AUDIT="${ROOT_DIR}/.github/workflows/delivery-audit.yml"
 ARTICLE_WORKFLOW="${ROOT_DIR}/.github/workflows/line-send-note-article.yml"
 VALUE_WORKFLOW="${ROOT_DIR}/.github/workflows/line-value-share.yml"
 RICHMENU_WORKFLOW="${ROOT_DIR}/.github/workflows/line-richmenu-deploy.yml"
+WATCHDOG_WORKFLOW="${ROOT_DIR}/.github/workflows/fugue-watchdog.yml"
+
+BLOCKED_DISCORD_WEBHOOKS=(
+  "DISCORD_WEBHOOK_URL"
+  "DISCORD_ADMIN_WEBHOOK_URL"
+  "DISCORD_MANUS_WEBHOOK_URL"
+  "DISCORD_MAINT_WEBHOOK_URL"
+)
 
 failures=0
 
@@ -40,10 +48,25 @@ assert_not_contains_block() {
   fi
 }
 
+assert_not_contains_token() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq "${needle}" "${file}"; then
+    echo "FAIL [${label}]: found '${needle}' in ${file}" >&2
+    failures=$((failures + 1))
+  else
+    echo "PASS [${label}]"
+  fi
+}
+
 assert_contains "${DELIVERY_AUDIT}" "Discord System Webhook Health Check" "delivery audit checks system webhook"
 assert_contains "${DELIVERY_AUDIT}" 'DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}' "delivery audit wires system webhook"
 assert_contains "${DELIVERY_AUDIT}" "Discord system anomaly notification sent." "delivery audit reports system notification delivery"
 assert_contains "${DELIVERY_AUDIT}" "because it was created from \${failed_head_sha}, not current \${GITHUB_SHA}" "delivery audit does not rerun stale failed workflow attempts"
+assert_contains "${DELIVERY_AUDIT}" "because it was created from workflow path \${failed_workflow_path}, not current \${workflow_path}" "delivery audit does not rerun failed workflows from stale workflow paths"
+assert_contains "${DELIVERY_AUDIT}" "{id, run_number, created_at, head_sha, path}" "delivery audit captures failed run workflow path for rerun guard"
+assert_contains "${DELIVERY_AUDIT}" "{id, path}" "delivery audit resolves canonical workflow path metadata"
 assert_not_contains_block "${DELIVERY_AUDIT}" "Notify Discord on anomaly" "Remediate transient GHA failures" "DISCORD_WEBHOOK_URL" "delivery audit anomaly does not use client webhook"
 
 assert_contains "${ARTICLE_WORKFLOW}" 'DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}' "article failure notification wires system webhook"
@@ -54,6 +77,14 @@ assert_not_contains_block "${VALUE_WORKFLOW}" "Notify Discord on failure" "" "DI
 
 assert_contains "${RICHMENU_WORKFLOW}" 'DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}' "rich menu failure notification wires system webhook"
 assert_not_contains_block "${RICHMENU_WORKFLOW}" "Notify Discord on failure" "" "DISCORD_WEBHOOK_URL" "rich menu failure notification does not use client webhook"
+
+for blocked_webhook in "${BLOCKED_DISCORD_WEBHOOKS[@]}"; do
+  assert_not_contains_token "${DELIVERY_AUDIT}" "${blocked_webhook}" "delivery audit excludes ${blocked_webhook}"
+  assert_not_contains_token "${ARTICLE_WORKFLOW}" "${blocked_webhook}" "line-send-note-article excludes ${blocked_webhook}"
+  assert_not_contains_token "${VALUE_WORKFLOW}" "${blocked_webhook}" "line-value-share excludes ${blocked_webhook}"
+  assert_not_contains_token "${RICHMENU_WORKFLOW}" "${blocked_webhook}" "line-richmenu-deploy excludes ${blocked_webhook}"
+  assert_not_contains_token "${WATCHDOG_WORKFLOW}" "${blocked_webhook}" "fugue-watchdog excludes ${blocked_webhook}"
+done
 
 if (( failures > 0 )); then
   exit 1

--- a/tests/test-watchdog-alert-routing.sh
+++ b/tests/test-watchdog-alert-routing.sh
@@ -7,13 +7,15 @@ WORKFLOW="${ROOT_DIR}/.github/workflows/fugue-watchdog.yml"
 echo "=== watchdog alert routing policy test ==="
 echo ""
 
+BLOCKED_DISCORD_WEBHOOKS=(
+  "DISCORD_WEBHOOK_URL"
+  "DISCORD_ADMIN_WEBHOOK_URL"
+  "DISCORD_MANUS_WEBHOOK_URL"
+  "DISCORD_MAINT_WEBHOOK_URL"
+)
+
 if grep -Fq 'LINE_WEBHOOK_URL:' "${WORKFLOW}"; then
   echo "FAIL: fugue-watchdog must not wire LINE_WEBHOOK_URL for system alerts" >&2
-  exit 1
-fi
-
-if grep -Fq 'DISCORD_WEBHOOK_URL:' "${WORKFLOW}"; then
-  echo "FAIL: fugue-watchdog must not wire DISCORD_WEBHOOK_URL fallback for system alerts" >&2
   exit 1
 fi
 
@@ -21,6 +23,13 @@ if grep -Fq 'DISCORD_NOTIFY_WEBHOOK_URL:' "${WORKFLOW}"; then
   echo "FAIL: fugue-watchdog must not wire DISCORD_NOTIFY_WEBHOOK_URL for system alerts" >&2
   exit 1
 fi
+
+for blocked_webhook in "${BLOCKED_DISCORD_WEBHOOKS[@]}"; do
+  if grep -Fq "${blocked_webhook}" "${WORKFLOW}"; then
+    echo "FAIL: fugue-watchdog must not reference ${blocked_webhook} in system alert paths" >&2
+    exit 1
+  fi
+done
 
 if grep -Fq 'LINE_CHANNEL_ACCESS_TOKEN:' "${WORKFLOW}"; then
   echo "FAIL: fugue-watchdog must not wire LINE_CHANNEL_ACCESS_TOKEN for system alerts" >&2


### PR DESCRIPTION
## Summary
- add workflow-path guard before Delivery Audit reruns failed workflow runs
- expand system Discord routing tests to ban client/admin/maintenance webhook aliases from audit, delivery, and watchdog paths
- wire watchdog routing policy into fugue-orchestration-gate

## Verification
- bash tests/test-delivery-system-discord-routing.sh
- bash tests/test-watchdog-alert-routing.sh
- actionlint -ignore 'SC2129' .github/workflows/delivery-audit.yml .github/workflows/fugue-watchdog.yml .github/workflows/fugue-orchestration-gate.yml
- git diff --check