### PR TITLE
test: isolate watchdog waiting-run drill

### DIFF
--- a/scripts/harness/run-watchdog-waiting-run-drill.sh
+++ b/scripts/harness/run-watchdog-waiting-run-drill.sh
@@ -69,6 +69,8 @@ done
 
 bash "${POLICY_SCRIPT}" \
   --event-name schedule \
+  --openai-ok true \
+  --zai-ok true \
   --failover-state healthy \
   --failover-reason primary-heartbeat-fresh \
   --gha-execution-mode full \


### PR DESCRIPTION
## Summary
- make the waiting-run drill deterministic by marking provider connectivity healthy
- keeps the quiet waiting-run scenario focused on waiting-run behavior instead of unrelated connectivity alerts

## Verification
- bash tests/test-watchdog-waiting-run-workflow.sh
- bash tests/test-watchdog-alert-routing.sh
- git diff --check