### PR TITLE
fix: resume LINE delivery on JST month reset

### DIFF
--- a/.github/workflows/delivery-audit.yml
+++ b/.github/workflows/delivery-audit.yml
@@ -616,8 +616,9 @@ jobs:
             exit 0
           fi
 
-          day_of_month=$(date -u +%-d)
-          if [[ "${day_of_month}" -ne 1 ]]; then
+          day_of_month_jst=$(TZ=Asia/Tokyo date +%-d)
+          month_jst=$(TZ=Asia/Tokyo date +%-m)
+          if [[ "${day_of_month_jst}" -ne 1 ]]; then
             exit 0
           fi
 
@@ -625,7 +626,7 @@ jobs:
             --jq '.value' 2>/dev/null || echo "false")
 
           if [[ "${current_paused}" == "true" && "${LINE_STATUS}" != "ERROR" ]]; then
-            echo "::notice::Month boundary — resuming LINE delivery"
+            echo "::notice::JST month boundary (${month_jst}/1) — resuming LINE delivery"
             gh api -X PATCH "repos/${REPO}/actions/variables/LINE_DELIVERY_PAUSED" \
               -f name="LINE_DELIVERY_PAUSED" \
               -f value="false" >/dev/null

--- a/tests/test-delivery-system-discord-routing.sh
+++ b/tests/test-delivery-system-discord-routing.sh
@@ -70,6 +70,9 @@ assert_contains "${DELIVERY_AUDIT}" "{id, path}" "delivery audit resolves canoni
 assert_contains "${DELIVERY_AUDIT}" "LINE_DELIVERY_PAUSED: \${{ vars.LINE_DELIVERY_PAUSED }}" "delivery audit reads LINE pause state"
 assert_contains "${DELIVERY_AUDIT}" "status=\"PAUSED\"" "delivery audit reports paused LINE state instead of unmitigated errors"
 assert_contains "${DELIVERY_AUDIT}" "LINE quota exhaustion predicted but delivery is already paused" "delivery audit treats paused quota exhaustion as mitigated"
+assert_contains "${DELIVERY_AUDIT}" "day_of_month_jst=\$(TZ=Asia/Tokyo date +%-d)" "delivery audit resumes LINE delivery on JST month boundary"
+assert_contains "${DELIVERY_AUDIT}" "JST month boundary" "delivery audit documents JST month reset resume"
+assert_contains "${DELIVERY_AUDIT}" "LINE_DELIVERY_PAUSED reset to false." "delivery audit can resume paused LINE delivery"
 assert_not_contains_block "${DELIVERY_AUDIT}" "Notify Discord on anomaly" "Remediate transient GHA failures" "DISCORD_WEBHOOK_URL" "delivery audit anomaly does not use client webhook"
 
 assert_contains "${ARTICLE_WORKFLOW}" 'DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}' "article failure notification wires system webhook"


### PR DESCRIPTION
## Summary
- make Delivery Audit auto-resume LINE delivery on the JST month boundary
- keep resume gated by LINE_STATUS != ERROR so quota must be healthy before unpausing
- add static routing test coverage for the JST reset behavior

## Verification
- bash tests/test-delivery-system-discord-routing.sh
- actionlint -ignore 'SC2129' .github/workflows/delivery-audit.yml
- git diff --check