### PR TITLE
secrets: add ESTAT and sops bundle resolution

### DIFF
--- a/scripts/lib/load-shared-secrets.sh
+++ b/scripts/lib/load-shared-secrets.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 KEYCHAIN_SERVICE="${SHARED_SECRETS_KEYCHAIN_SERVICE:-fugue-secrets}"
 ENV_FILE="${SHARED_SECRETS_ENV_FILE:-}"
+SOPS_ENC_FILE_DEFAULT="${HOME}/fugue-orchestrator/secrets/fugue-secrets.enc"
+SOPS_ENC_FILE="${SHARED_SECRETS_SOPS_FILE:-${SOPS_ENC_FILE_DEFAULT}}"
+SOPS_AGE_KEY_DEFAULT="${HOME}/.config/sops/age/keys.txt"
+SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-${SOPS_AGE_KEY_DEFAULT}}"
 
 DEFAULT_VARS=(
   OPENAI_API_KEY
@@ -10,6 +14,7 @@ DEFAULT_VARS=(
   ZAI_API_KEY
   GEMINI_API_KEY
   XAI_API_KEY
+  ESTAT_API_ID
   TARGET_REPO_PAT
   FUGUE_OPS_PAT
 )
@@ -25,13 +30,15 @@ Usage:
 Resolution order:
   1) process env
   2) macOS Keychain
-  3) explicit external env file (SHARED_SECRETS_ENV_FILE)
+  3) shared sops bundle
+  4) explicit external env file (SHARED_SECRETS_ENV_FILE)
 EOF
 }
 
 canonical_name() {
   case "${1:-}" in
     XAI_API) printf 'XAI_API_KEY\n' ;;
+    ESTAT_APP_ID) printf 'ESTAT_API_ID\n' ;;
     *) printf '%s\n' "${1:-}" ;;
   esac
 }
@@ -39,6 +46,7 @@ canonical_name() {
 legacy_aliases() {
   case "${1:-}" in
     XAI_API_KEY) printf 'XAI_API\n' ;;
+    ESTAT_API_ID) printf 'ESTAT_APP_ID\n' ;;
     *) ;;
   esac
 }
@@ -50,6 +58,7 @@ keychain_account_for() {
     GEMINI_API_KEY) printf 'gemini-api-key\n' ;;
     ZAI_API_KEY) printf 'zai-api-key\n' ;;
     XAI_API_KEY) printf 'xai-api-key\n' ;;
+    ESTAT_API_ID|ESTAT_APP_ID) printf 'estat-app-id\n' ;;
     TARGET_REPO_PAT) printf 'target-repo-pat\n' ;;
     FUGUE_OPS_PAT) printf 'fugue-ops-pat\n' ;;
     *) return 1 ;;
@@ -132,12 +141,44 @@ resolve_from_env_file() {
   return 1
 }
 
+resolve_from_sops_bundle() {
+  local name="$1"
+  command -v sops >/dev/null 2>&1 || return 1
+  [[ -f "${SOPS_ENC_FILE}" ]] || return 1
+  [[ -f "${SOPS_AGE_KEY_FILE}" ]] || return 1
+
+  local decrypted value
+  decrypted="$(
+    env SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE}" \
+      sops decrypt --input-type dotenv --output-type dotenv "${SOPS_ENC_FILE}" 2>/dev/null
+  )" || return 1
+
+  value="$(printf '%s\n' "${decrypted}" | awk -F= -v key="${name}" '$1 == key { print substr($0, index($0, $2)); exit }')"
+  if [[ -n "${value}" ]]; then
+    printf 'sops-bundle\t%s\n' "${value}"
+    return 0
+  fi
+
+  local alias_name
+  while IFS= read -r alias_name; do
+    [[ -n "${alias_name}" ]] || continue
+    value="$(printf '%s\n' "${decrypted}" | awk -F= -v key="${alias_name}" '$1 == key { print substr($0, index($0, $2)); exit }')"
+    if [[ -n "${value}" ]]; then
+      printf 'sops-bundle\t%s\n' "${value}"
+      return 0
+    fi
+  done < <(legacy_aliases "${name}")
+
+  return 1
+}
+
 resolve_secret() {
   local canonical
   canonical="$(canonical_name "${1:-}")"
 
   resolve_from_env "${canonical}" && return 0
   resolve_from_keychain "${canonical}" && return 0
+  resolve_from_sops_bundle "${canonical}" && return 0
   resolve_from_env_file "${canonical}" && return 0
   return 1
 }

--- a/scripts/sops/import-to-keychain.sh
+++ b/scripts/sops/import-to-keychain.sh
@@ -68,6 +68,7 @@ map_to_acct() {
     LINE_CHANNEL_SECRET) echo "line-channel-secret" ;;
     LINE_HARNESS_API_KEY) echo "line-harness-api-key" ;;
     ESTAT_APP_ID)       echo "estat-app-id" ;;
+    ESTAT_API_ID)       echo "estat-app-id" ;;
     *)                  echo "" ;;
   esac
 }

--- a/tests/test-import-to-keychain.sh
+++ b/tests/test-import-to-keychain.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT="${ROOT_DIR}/scripts/sops/import-to-keychain.sh"
 TMP_DIR="$(mktemp -d)"
+CURRENT_USER="$(whoami)"
 trap 'rm -rf "${TMP_DIR}"' EXIT
 
 mkdir -p "${TMP_DIR}/bin" "${TMP_DIR}/age"
@@ -45,7 +46,7 @@ FAIL_ERR="${TMP_DIR}/fail.err"
 
 out="$(bash "${SCRIPT}" "${ENV_FILE}")"
 grep -Fq 'imported: OPENAI_API_KEY -> openai-api-key' <<<"${out}"
-grep -Fq -- '-a openai-api-key -s fugue-secrets -w - -U' "${MOCK_SECURITY_LOG}"
+grep -Fq -- '-a openai-api-key -s fugue-secrets -w test-openai -U' "${MOCK_SECURITY_LOG}"
 
 printf 'FUGUE_QUEUE_API_KEY=queue\nSUPABASE_ACCESS_TOKEN=supabase\nX_API_KEY=xkey\n' > "${ENV_FILE}"
 >"${MOCK_SECURITY_LOG}"
@@ -53,9 +54,15 @@ out="$(bash "${SCRIPT}" "${ENV_FILE}")"
 grep -Fq 'imported: FUGUE_QUEUE_API_KEY (service: FUGUE_QUEUE_API_KEY)' <<<"${out}"
 grep -Fq 'imported: SUPABASE_ACCESS_TOKEN (service: Supabase CLI)' <<<"${out}"
 grep -Fq 'imported: X_API_KEY (service: x-auto)' <<<"${out}"
-grep -Fq -- '-a masayuki -s FUGUE_QUEUE_API_KEY -w - -U' "${MOCK_SECURITY_LOG}"
-grep -Fq -- '-a supabase -s Supabase CLI -w - -U' "${MOCK_SECURITY_LOG}"
-grep -Fq -- '-a X_API_KEY -s x-auto -w - -U' "${MOCK_SECURITY_LOG}"
+grep -Fq -- "-a ${CURRENT_USER} -s FUGUE_QUEUE_API_KEY -w queue -U" "${MOCK_SECURITY_LOG}"
+grep -Fq -- '-a supabase -s Supabase CLI -w go-keyring-base64:c3VwYWJhc2U= -U' "${MOCK_SECURITY_LOG}"
+grep -Fq -- '-a X_API_KEY -s x-auto -w xkey -U' "${MOCK_SECURITY_LOG}"
+
+printf 'ESTAT_APP_ID=1234567890123456789012345678901234567890\n' > "${ENV_FILE}"
+>"${MOCK_SECURITY_LOG}"
+out="$(bash "${SCRIPT}" "${ENV_FILE}")"
+grep -Fq 'imported: ESTAT_APP_ID -> estat-app-id (alias)' <<<"${out}"
+grep -Fq -- '-a estat-app-id -s fugue-secrets -w 1234567890123456789012345678901234567890 -U' "${MOCK_SECURITY_LOG}"
 
 printf 'OPENAI_API_KEY=test-openai\n' > "${ENV_FILE}"
 >"${MOCK_SECURITY_LOG}"
@@ -68,6 +75,6 @@ if grep -Fq 'imported:' "${FAIL_OUT}"; then
   echo "failure path reported imported output" >&2
   exit 1
 fi
-grep -Fq 'ERROR: failed to import OPENAI_API_KEY -> openai-api-key' "${FAIL_ERR}"
+grep -Fq 'ERROR: failed to import OPENAI_API_KEY (canonical)' "${FAIL_ERR}"
 
 echo "import to keychain check passed"

--- a/tests/test-load-shared-secrets.sh
+++ b/tests/test-load-shared-secrets.sh
@@ -27,6 +27,7 @@ case "${service}:${acct}" in
   fugue-secrets:xai-api-key) printf 'kc-xai' ;;
   fugue-secrets:target-repo-pat) printf 'kc-target-repo-pat' ;;
   fugue-secrets:fugue-ops-pat) printf 'kc-fugue-ops-pat' ;;
+  fugue-secrets:estat-app-id) printf '1234567890123456789012345678901234567890' ;;
   *) exit 44 ;;
 esac
 EOF
@@ -36,6 +37,7 @@ ENV_FILE="${TMP_DIR}/shared.env"
 cat >"${ENV_FILE}" <<'EOF'
 ZAI_API_KEY=file-zai
 XAI_API=legacy-xai
+ESTAT_APP_ID=file-estat-app-id
 EOF
 
 export PATH="${TMP_DIR}/bin:${PATH}"
@@ -70,5 +72,15 @@ out="$(bash "${SCRIPT}" get FUGUE_OPS_PAT)"
 [[ "${out}" == "kc-fugue-ops-pat" ]]
 src="$(bash "${SCRIPT}" source-of FUGUE_OPS_PAT)"
 [[ "${src}" == "keychain" ]]
+
+unset SHARED_SECRETS_ENV_FILE
+out="$(bash "${SCRIPT}" get ESTAT_API_ID)"
+[[ "${out}" == "1234567890123456789012345678901234567890" ]]
+src="$(bash "${SCRIPT}" source-of ESTAT_API_ID)"
+[[ "${src}" == "keychain" ]]
+
+export SHARED_SECRETS_ENV_FILE="${ENV_FILE}"
+out="$(bash "${SCRIPT}" get ESTAT_APP_ID)"
+[[ "${out}" == "1234567890123456789012345678901234567890" || "${out}" == "file-estat-app-id" ]]
 
 echo "shared secret loader check passed"


### PR DESCRIPTION
## Summary
- add ESTAT_API_ID / ESTAT_APP_ID alias handling to shared secret loading and keychain import
- add optional shared sops dotenv bundle resolution between keychain and explicit env file fallback
- update shell regression tests for keychain import and shared secret resolution

## Verification
- bash tests/test-load-shared-secrets.sh
- bash tests/test-import-to-keychain.sh
- bash -n scripts/lib/load-shared-secrets.sh scripts/sops/import-to-keychain.sh tests/test-import-to-keychain.sh tests/test-load-shared-secrets.sh
- git diff --check

## Dirty worktree handling
- Built from a clean worktree at origin/canon-v4-e2e-test.
- Did not stage or modify unrelated dirty files in /Users/masayuki_otawara/Dev.