### PR TITLE
kernel: resolve codex executable dynamically

### DIFF
--- a/scripts/codex-kernel-guard.sh
+++ b/scripts/codex-kernel-guard.sh
@@ -24,6 +24,43 @@ DEFAULT_STALE_HOURS="${KERNEL_STALE_HOURS:-24}"
 STATIC_CHECK_TIMEOUT_SEC="${DOCTOR_STATIC_CHECK_TIMEOUT_SEC:-15}"
 SUMMARY_TIMEOUT_SEC="${KERNEL_DOCTOR_SUMMARY_TIMEOUT_SEC:-15}"
 
+resolve_codex_bin() {
+  local preferred="${CODEX_BIN:-}"
+  local candidate
+
+  if [[ -n "${preferred}" ]]; then
+    candidate="$(type -P "${preferred}" 2>/dev/null || true)"
+    if [[ -n "${candidate}" && -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+    if [[ -x "${preferred}" ]]; then
+      printf '%s\n' "${preferred}"
+      return 0
+    fi
+  fi
+
+  candidate="$(type -P codex 2>/dev/null || true)"
+  if [[ -n "${candidate}" && -x "${candidate}" ]]; then
+    printf '%s\n' "${candidate}"
+    return 0
+  fi
+
+  for candidate in \
+    "$HOME/bin/codex" \
+    "$HOME/.local/bin/codex" \
+    "/usr/local/bin/codex" \
+    "/opt/homebrew/bin/codex"
+  do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -442,7 +479,7 @@ cmd_launch() {
 
   if [[ "${ORCH_DRY_RUN:-0}" == "1" ]]; then
     prompt="$(env KERNEL_RUN_ID="${run_id}" bash "${THREAD_SCRIPT}" prompt "${run_id}")"
-    printf '%s -C %q %q\n' "${CODEX_BIN:-/opt/homebrew/bin/codex}" "${ROOT_DIR}" "${prompt}"
+    printf '%s -C %q %q\n' "$(resolve_codex_bin)" "${ROOT_DIR}" "${prompt}"
     return 0
   fi
 

--- a/scripts/lib/kernel-codex-thread.sh
+++ b/scripts/lib/kernel-codex-thread.sh
@@ -3,7 +3,49 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 COMPACT_SCRIPT="${ROOT_DIR}/scripts/lib/kernel-compact-artifact.sh"
-CODEX_BIN="${CODEX_BIN:-/opt/homebrew/bin/codex}"
+CODEX_BIN="${CODEX_BIN:-}"
+
+resolve_codex_bin() {
+  local preferred="${CODEX_BIN:-}"
+  local candidate
+
+  if [[ -n "${preferred}" ]]; then
+    candidate="$(type -P "${preferred}" 2>/dev/null || true)"
+    if [[ -n "${candidate}" && -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+    if [[ -x "${preferred}" ]]; then
+      printf '%s\n' "${preferred}"
+      return 0
+    fi
+  fi
+
+  candidate="$(type -P codex 2>/dev/null || true)"
+  if [[ -n "${candidate}" && -x "${candidate}" ]]; then
+    printf '%s\n' "${candidate}"
+    return 0
+  fi
+
+  for candidate in \
+    "$HOME/bin/codex" \
+    "$HOME/.local/bin/codex" \
+    "/usr/local/bin/codex" \
+    "/opt/homebrew/bin/codex"
+  do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+CODEX_BIN="$(resolve_codex_bin)" || {
+  echo "codex executable not found. Set CODEX_BIN." >&2
+  exit 1
+}
 
 usage() {
   cat <<'EOF'


### PR DESCRIPTION
## Summary
- resolve the codex executable from CODEX_BIN, PATH, and common install paths
- remove the hard-coded /opt/homebrew/bin/codex fallback from kernel launch/thread paths

## Verification
- bash tests/test-kernel-codex-thread.sh
- bash tests/test-kernel-runtime-launch.sh
- bash -n scripts/codex-kernel-guard.sh scripts/lib/kernel-codex-thread.sh
- git diff --check

## Notes
- tests/test-k-shortcuts.sh was not used as a gate for this slice because it exercises /Users/masayuki_otawara/bin/k outside this worktree rather than the changed scripts.