### PR TITLE
router: add search local execution contracts

### DIFF
--- a/fugue-orchestrator-public/src/domains/content.mjs
+++ b/fugue-orchestrator-public/src/domains/content.mjs
@@ -41,6 +41,69 @@ export const SKILL_IDS = [
 
 const E_STAT_BASE_URL = "https://api.e-stat.go.jp/rest/3.0/app";
 
+function stripHtml(input) {
+  return String(input || "")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function takeSnippet(input, maxLength = 220) {
+  const text = stripHtml(input);
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 1).trim()}…`;
+}
+
+async function executeEstatWebFallback(task) {
+  const url = `https://www.e-stat.go.jp/stat-search?query=${encodeURIComponent(task)}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 30_000);
+  try {
+    const response = await fetch(url, {
+      headers: {
+        "user-agent": "fugue-e-stat-skill/1.0 (+web-fallback)",
+        accept: "text/html,*/*;q=0.8",
+      },
+      signal: controller.signal,
+      redirect: "follow",
+    });
+    if (!response.ok) {
+      return {
+        ok: false,
+        output: `e-stat web fallback failed with HTTP ${response.status}.`,
+        code: null,
+      };
+    }
+    const html = await response.text();
+    const title = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] || "e-Stat";
+    const description = html.match(/<meta[^>]+name="description"[^>]+content="([^"]+)"/i)?.[1]
+      || html.match(/<meta[^>]+property="og:description"[^>]+content="([^"]+)"/i)?.[1]
+      || "";
+    return {
+      ok: true,
+      output: [
+        "e-Stat website fallback",
+        `URL: ${url}`,
+        `Title: ${stripHtml(title)}`,
+        `Snippet: ${takeSnippet(description || html)}`,
+      ].join("\n"),
+      code: 0,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      output: `e-stat web fallback failed: ${error.message}`,
+      code: null,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Internal: skill-specific executors
 // ---------------------------------------------------------------------------
@@ -52,10 +115,14 @@ const E_STAT_BASE_URL = "https://api.e-stat.go.jp/rest/3.0/app";
  * @returns {Promise<{ok: boolean, output: string, code: number | null}>}
  */
 async function executeEstat(task) {
+  const appId = process.env.ESTAT_API_ID || process.env.ESTAT_APP_ID;
+  if (!appId) {
+    return executeEstatWebFallback(task);
+  }
   // e-stat uses curl to query the government statistics API.
   // The task is passed as a search keyword parameter.
   const encodedTask = encodeURIComponent(task);
-  const url = `${E_STAT_BASE_URL}/getStatsList?searchWord=${encodedTask}&lang=J&limit=10`;
+  const url = `${E_STAT_BASE_URL}/json/getStatsList?appId=${encodeURIComponent(appId)}&searchWord=${encodedTask}&lang=J&limit=10`;
 
   return spawnSkill(
     "curl",

--- a/fugue-orchestrator-public/src/domains/dev.mjs
+++ b/fugue-orchestrator-public/src/domains/dev.mjs
@@ -6,6 +6,7 @@
  */
 
 import {
+  spawnSkill,
   checkPrerequisite,
   executeHostPrompt,
   executeHostedSkill,
@@ -14,6 +15,7 @@ import {
   resolveSkillExecutor,
   SKILL_TIMEOUT_MS,
 } from "./shared.mjs";
+import { fileURLToPath } from "node:url";
 
 /** Domain identifier */
 export const DOMAIN = "dev";
@@ -30,6 +32,10 @@ export const SKILL_IDS = [
   "discord-configure",
   "setup-happy-vm-git",
 ];
+
+const LOCAL_SEARCH_SCRIPT = fileURLToPath(
+  new URL("../../../scripts/search/search.js", import.meta.url),
+);
 
 /**
  * Resolve the effective execution host for a dev-domain entry.
@@ -66,6 +72,35 @@ export function buildMcpPrompt(entry, task) {
   ].join("\n");
 }
 
+async function executeLocalSearch(task) {
+  const result = await spawnSkill(
+    "node",
+    [LOCAL_SEARCH_SCRIPT, task, "--execute-local", "--format", "json"],
+    { timeoutMs: SKILL_TIMEOUT_MS },
+  );
+
+  if (!result.ok) {
+    return result;
+  }
+
+  const payload = JSON.parse(result.output);
+
+  return {
+    ok: true,
+    output: payload.output,
+    code: result.code,
+    metadata: {
+      mode: payload.mode,
+      plannedSourceIds: payload.plan.sources.map((source) => source.sourceId),
+      canonicalSourceIds: payload.plan.canonicalSourceIds,
+      referenceSourceIds: payload.plan.referenceSourceIds,
+      executedSources: payload.execution.executedSources,
+      failedSources: payload.execution.failedSources,
+      environmentGaps: payload.execution.environmentGaps,
+    },
+  };
+}
+
 /**
  * Execute a dev-domain skill through the shared adapter.
  *
@@ -93,6 +128,7 @@ export async function execute(params) {
 
   const hostedSkillRef = skillEntry ?? skillId;
   const resolvedExecutor = resolveDevExecutor(executionType, executor);
+
   if (executionType === "skill") {
     const result = await executeHostedSkill({
       task,
@@ -128,6 +164,23 @@ export async function execute(params) {
           executionType,
           executor: resolvedExecutor,
           scriptExecutionAllowed: false,
+        },
+      };
+    }
+
+    if (skillId === "search") {
+      const result = await executeLocalSearch(task);
+      return {
+        ok: result.ok,
+        output: result.output,
+        metadata: {
+          domain: DOMAIN,
+          skillId,
+          skillEntry: hostedSkillRef,
+          executionType,
+          executor: "local",
+          exitCode: result.code,
+          ...result.metadata,
         },
       };
     }

--- a/fugue-orchestrator-public/src/domains/shared.mjs
+++ b/fugue-orchestrator-public/src/domains/shared.mjs
@@ -370,10 +370,19 @@ export function buildSkillCommand({ task, skillId, skillEntry, executor }) {
     });
     return buildPromptCommand(prompt, resolvedExecutor);
   }
+  if (resolvedExecutor === "claude") {
+    const prompt = buildAuthorityPrompt({
+      contractType: "skill",
+      contractRef: hostedSkillRef,
+      authorityPath: authority.resolvedPath ?? authority.candidates[0],
+      task,
+    });
+    return buildPromptCommand(prompt, resolvedExecutor);
+  }
   if (resolvedExecutor === "codex") {
     return ["codex", ["exec", buildCodexPrompt(task, hostedSkillRef)]];
   }
-  return ["claude", ["-p", task, "--skill", hostedSkillRef]];
+  return ["claude", ["-p", task]];
 }
 
 /**

--- a/fugue-orchestrator-public/tests/skill-router.test.mjs
+++ b/fugue-orchestrator-public/tests/skill-router.test.mjs
@@ -27,6 +27,7 @@ import { dirname, resolve } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const SEARCH_FIXTURE_FILE = resolve(__dirname, './fixtures/search-local-execution.json');
 
 // ---------------------------------------------------------------------------
 // Imports under test
@@ -179,6 +180,20 @@ describe('Intent Classifier - Keyword Match', () => {
     assert.ok(result);
     assert.ok(result.alternatives.length > 0, 'Should have alternatives');
   });
+
+  it('should match medical cross-source queries to search', () => {
+    const result = classifyIntent({ text: '病床機能報告と病院報告を横断検索して比較したい' });
+    assert.ok(result);
+    assert.equal(result.skillId, 'search');
+    assert.equal(result.strategy, 'keyword');
+    assert.ok(result.matchedKeywords.includes('病床機能報告'));
+  });
+
+  it('should keep direct government statistics queries on e-stat', () => {
+    const result = classifyIntent({ text: 'e-Statで国勢調査の人口統計を取得して' });
+    assert.ok(result);
+    assert.equal(result.skillId, 'e-stat');
+  });
 });
 
 describe('Intent Classifier - Domain Detection', () => {
@@ -267,6 +282,54 @@ describe('Skill Router - Dry Run', () => {
     });
     assert.ok(result.ok);
     assert.equal(result.skillId, 'bookkeeping');
+  });
+});
+
+describe('Skill Router - Search Local Execution', () => {
+  it('should block search execution without explicit script approval', async () => {
+    const result = await routeSkill({
+      task: '病床機能報告と病院報告を比較したい',
+      source: 'cli',
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.skillId, 'search');
+    assert.match(result.execution.output, /blocked by default/);
+  });
+
+  it('should execute search locally with explicit script approval', async () => {
+    process.env.SEARCH_LOCAL_FIXTURE_FILE = SEARCH_FIXTURE_FILE;
+    const result = await routeSkill({
+      task: '病床機能報告と病院報告を比較したい',
+      source: 'cli',
+      context: { allowScriptExecution: true },
+    });
+    delete process.env.SEARCH_LOCAL_FIXTURE_FILE;
+    assert.equal(result.ok, true);
+    assert.equal(result.skillId, 'search');
+    assert.ok(result.execution.output.includes('Search Execution Report'));
+    assert.equal(result.execution.metadata.mode, 'execute-local');
+    assert.deepEqual(result.execution.metadata.executedSources, [
+      'mhlw-bed-function-report',
+      'mhlw-hospital-report',
+      'dashboard',
+      'web',
+    ]);
+    assert.deepEqual(result.execution.metadata.failedSources, ['medical-info-net']);
+  });
+
+  it('should execute search through dev domain adapter directly', async () => {
+    process.env.SEARCH_LOCAL_FIXTURE_FILE = SEARCH_FIXTURE_FILE;
+    const result = await executeDevDomainSkill({
+      skillId: 'search',
+      task: '病床機能報告と病院報告を比較したい',
+      source: 'cli',
+      executionType: 'script',
+      context: { allowScriptExecution: true },
+    });
+    delete process.env.SEARCH_LOCAL_FIXTURE_FILE;
+    assert.equal(result.ok, true);
+    assert.ok(result.output.includes('厚労省 病床機能報告'));
+    assert.equal(result.metadata.mode, 'execute-local');
   });
 });
 
@@ -398,7 +461,9 @@ describe('Shared Skill Executor Adapter', () => {
       executor: 'claude',
     });
     assert.equal(command, 'claude');
-    assert.deepEqual(args, ['-p', '請求書を発行して', '--skill', 'back-office']);
+    assert.equal(args[0], '-p');
+    assert.ok(args[1].includes('Authoritative SKILL.md contract'));
+    assert.ok(args[1].includes('back-office'));
   });
 
   it('should build codex-hosted skill commands', () => {
@@ -422,7 +487,8 @@ describe('Shared Skill Executor Adapter', () => {
       executor: 'claude',
     });
     assert.equal(command, 'claude');
-    assert.deepEqual(args, ['-p', 'Discord権限を確認して', '--skill', 'discord:access']);
+    assert.equal(args[0], '-p');
+    assert.ok(args[1].includes('discord:access'));
   });
 
   it('should fall back to command contracts when no skill spec exists', () => {

--- a/local-shared-skills/cybersec-lookup/SKILL.md
+++ b/local-shared-skills/cybersec-lookup/SKILL.md
@@ -1,0 +1,17 @@
+# cybersec-lookup
+
+Use this skill when a task asks for security scanning, vulnerability lookup, DevSecOps guidance, or cyber-security knowledge lookup.
+
+## Contract
+
+1. Identify the asset, package, workflow, or security question being checked.
+2. Prefer local repository evidence first: manifests, lockfiles, CI configuration, scripts, and existing security docs.
+3. Use approved lookup tools or primary sources when current vulnerability data is required.
+4. Report findings by severity, affected component, evidence, and concrete remediation.
+5. Distinguish confirmed issues from hypotheses or missing evidence.
+
+## Safety
+
+- Do not run destructive tests, exploit code, credential dumps, or production-impacting probes without explicit approval.
+- Read-only scans and local file inspection do not require user approval.
+- Redact secrets and tokens from all output.

--- a/local-shared-skills/research-loop/SKILL.md
+++ b/local-shared-skills/research-loop/SKILL.md
@@ -1,0 +1,17 @@
+# research-loop
+
+Use this skill when a task asks for an iterative research, hypothesis testing, or optimization loop.
+
+## Contract
+
+1. Restate the working hypothesis, target outcome, and stopping condition.
+2. Run bounded evidence gathering from the available local tools or approved sources.
+3. Compare the evidence against the hypothesis and record what changed.
+4. Propose the next experiment or implementation adjustment.
+5. Stop when the requested outcome is reached, the stopping condition is met, or a blocking dependency is explicit.
+
+## Safety
+
+- Do not request user approval for non-critical routine research steps when an approved local tool or read-only source is available.
+- Escalate only for destructive actions, credential changes, paid/external side effects, or production-impacting writes.
+- Keep artifacts concise and cite local file paths or external sources used.


### PR DESCRIPTION
## Summary
- add e-Stat API key support with web fallback for government-statistics routing
- add local execution path for the search skill with explicit script-approval gating and metadata receipts
- make Claude-hosted skill execution use authoritative SKILL.md prompts instead of implicit skill flags
- add missing authority contracts for research-loop and cybersec-lookup

## Verification
- npm test (from /Users/masayuki_otawara/Dev/fugue-orchestrator-public; 56 tests passed)
- authority-contract scan: no missing enabled skill/script entries
- git diff --cached --check

## Notes
- runtime files under fugue-orchestrator-public/.canon, .claude, and .project-os are intentionally excluded.