### PR TITLE
ops: add git parent guard verifier

### DIFF
--- a/config/git/dev-root-info-exclude.block
+++ b/config/git/dev-root-info-exclude.block
@@ -1,0 +1,7 @@
+# BEGIN FUGUE DEV ROOT GIT SAFETY
+# This parent repository contains many nested standalone repositories and
+# generated workspaces. Keep broad add/status operations from seeing unrelated
+# untracked trees. Existing tracked files remain tracked; add new parent-repo
+# files deliberately with `git add -f <path>`.
+/*
+# END FUGUE DEV ROOT GIT SAFETY

--- a/docs/gha24-mainframe-flow.md
+++ b/docs/gha24-mainframe-flow.md
@@ -147,3 +147,28 @@ Capture how a GHA24 request gets into the existing FUGUE mainframe path (tutti v
   - JavaScript syntax checks for note/thumbnail/Manus scripts: pass.
 - Current operational note:
   - LINE workflow live `workflow_dispatch` smoke is intentionally not included in this record because it can send external LINE messages. Treat that as a separate, explicitly scheduled production-send smoke if needed.
+
+## Operations Record (2026-04-19 Phase 2)
+- Goal: make the parent-repo Git guard reproducible and auditable without moving repository identities.
+- Added artifact:
+  - `config/git/dev-root-info-exclude.block` is the tracked source of truth for the Dev parent repository's managed `.git/info/exclude` guard block.
+  - `scripts/local/dev-root-git-safety.sh install|verify|audit` installs, verifies, and receipts that managed block while preserving custom exclude lines outside the marked region.
+  - `tests/test-dev-root-git-safety.sh` simulates a fresh repository, verifies install idempotence, preserves custom excludes, and confirms drift detection.
+  - `scripts/local/git-parent-guard.sh verify` checks the active machine state:
+    - routine non-repo directories do not resolve to `$HOME` or `$HOME/Dev`
+    - nested repositories such as `$HOME/Dev/x-auto` still resolve normally
+    - parent repositories keep `status.showUntrackedFiles=no`
+    - parent repository `.git/info/exclude` files contain `/*`
+    - parent repositories expose no untracked paths through `git ls-files --others --exclude-standard`
+  - `scripts/local/git-parent-guard.sh apply` idempotently reapplies the shell startup guard, local parent-repo Git config, `.git/info/exclude` `/*` guard, and best-effort launchd session environment.
+- Validation summary:
+  - `bash -n scripts/local/git-parent-guard.sh`: pass
+  - `scripts/local/git-parent-guard.sh verify`: pass
+  - `bash -n scripts/local/dev-root-git-safety.sh`: pass
+  - `bash tests/test-dev-root-git-safety.sh`: pass
+  - `scripts/local/dev-root-git-safety.sh verify --repo "$HOME/Dev"`: pass
+- Completion definition:
+  - Phase 2 is complete when the script is merged and `verify` passes on the target machine after any shell/profile drift, machine migration, or parent-repo reset.
+  - The current objective completion is 100% for the requested untracked-noise accident prevention and auditability scope.
+- Remaining non-blocking cleanup:
+  - Stale worktree metadata and invalid temporary Git directories may still exist under local `/tmp` or `~/Dev/tmp`. These are cleanup tasks, not parent-repo discovery risks, and deleting their backing directories requires explicit destructive-action approval.

--- a/scripts/local/dev-root-git-safety.sh
+++ b/scripts/local/dev-root-git-safety.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MODE="${1:-verify}"
+shift || true
+
+REPO="${DEV_ROOT:-${FUGUE_DEV_ROOT:-${HOME}/Dev}}"
+TEMPLATE="${ROOT_DIR}/config/git/dev-root-info-exclude.block"
+BEGIN_MARKER="# BEGIN FUGUE DEV ROOT GIT SAFETY"
+END_MARKER="# END FUGUE DEV ROOT GIT SAFETY"
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: scripts/local/dev-root-git-safety.sh [install|verify|audit] [--repo PATH] [--template PATH]
+
+Manages the local .git/info/exclude safety block for a parent Dev repository.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="${2:?--repo requires a path}"
+      shift 2
+      ;;
+    --template)
+      TEMPLATE="${2:?--template requires a path}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+git_dir_for_repo() {
+  local repo="${1:?repo is required}"
+  local git_dir
+  git_dir="$(git -C "${repo}" rev-parse --git-dir)"
+  case "${git_dir}" in
+    /*) printf '%s\n' "${git_dir}" ;;
+    *) printf '%s/%s\n' "${repo}" "${git_dir}" ;;
+  esac
+}
+
+exclude_path_for_repo() {
+  local git_dir
+  git_dir="$(git_dir_for_repo "$1")"
+  printf '%s/info/exclude\n' "${git_dir}"
+}
+
+extract_managed_block() {
+  local exclude_path="${1:?exclude path is required}"
+  [[ -f "${exclude_path}" ]] || return 0
+  awk -v begin="${BEGIN_MARKER}" -v end="${END_MARKER}" '
+    $0 == begin { in_block = 1 }
+    in_block { print }
+    $0 == end { in_block = 0 }
+  ' "${exclude_path}"
+}
+
+write_without_managed_block() {
+  local exclude_path="${1:?exclude path is required}"
+  [[ -f "${exclude_path}" ]] || return 0
+  awk -v begin="${BEGIN_MARKER}" -v end="${END_MARKER}" '
+    $0 == begin { skip = 1; next }
+    $0 == end { skip = 0; next }
+    skip != 1 { print }
+  ' "${exclude_path}"
+}
+
+install_block() {
+  local exclude_path tmp
+  exclude_path="$(exclude_path_for_repo "${REPO}")"
+  mkdir -p "$(dirname "${exclude_path}")"
+  tmp="${exclude_path}.dev-root-git-safety.$$"
+
+  write_without_managed_block "${exclude_path}" | awk '
+    NF {
+      while (blank_lines > 0) {
+        print ""
+        blank_lines--
+      }
+      print
+      next
+    }
+    { blank_lines++ }
+  ' > "${tmp}"
+  if [[ -s "${tmp}" ]]; then
+    printf '\n' >> "${tmp}"
+  fi
+  cat "${TEMPLATE}" >> "${tmp}"
+  printf '\n' >> "${tmp}"
+
+  mv "${tmp}" "${exclude_path}"
+  git -C "${REPO}" config --local status.showUntrackedFiles no
+  echo "PASS installed managed git safety block: ${exclude_path}"
+}
+
+verify_block() {
+  local exclude_path expected actual
+  exclude_path="$(exclude_path_for_repo "${REPO}")"
+  expected="$(cat "${TEMPLATE}")"
+  actual="$(extract_managed_block "${exclude_path}")"
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "FAIL managed block drift: ${exclude_path}" >&2
+    diff -u <(printf '%s\n' "${expected}") <(printf '%s\n' "${actual}") >&2 || true
+    return 1
+  fi
+
+  if [[ "$(git -C "${REPO}" config --local --get status.showUntrackedFiles 2>/dev/null || true)" != "no" ]]; then
+    echo "FAIL status.showUntrackedFiles is not no: ${REPO}" >&2
+    return 1
+  fi
+
+  if git -C "${REPO}" ls-files --others --exclude-standard | grep -q .; then
+    echo "FAIL untracked paths visible to git: ${REPO}" >&2
+    return 1
+  fi
+
+  echo "PASS verified managed git safety block: ${exclude_path}"
+}
+
+audit_block() {
+  local exclude_path template_hash actual_hash
+  exclude_path="$(exclude_path_for_repo "${REPO}")"
+  template_hash="$(shasum -a 256 "${TEMPLATE}" | awk '{print $1}')"
+  actual_hash="$(extract_managed_block "${exclude_path}" | shasum -a 256 | awk '{print $1}')"
+  printf '{"repo":"%s","exclude":"%s","template_sha256":"%s","actual_block_sha256":"%s"}\n' \
+    "${REPO}" "${exclude_path}" "${template_hash}" "${actual_hash}"
+}
+
+if [[ ! -d "${REPO}" ]]; then
+  echo "Repo path does not exist: ${REPO}" >&2
+  exit 2
+fi
+if ! git -C "${REPO}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not a git repository: ${REPO}" >&2
+  exit 2
+fi
+if [[ ! -f "${TEMPLATE}" ]]; then
+  echo "Template not found: ${TEMPLATE}" >&2
+  exit 2
+fi
+
+case "${MODE}" in
+  install) install_block ;;
+  verify) verify_block ;;
+  audit) audit_block ;;
+  *)
+    echo "Unknown mode: ${MODE}" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/local/git-parent-guard.sh
+++ b/scripts/local/git-parent-guard.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+set -eu
+
+MODE="${1:-verify}"
+HOME_DIR="${HOME:?HOME is required}"
+DEV_ROOT="${FUGUE_DEV_ROOT:-$HOME_DIR/Dev}"
+
+SHELL_FILES=".zshenv .bashrc .bash_profile .profile"
+BLOCK_BEGIN="# >>> fugue git-parent-guard >>>"
+BLOCK_END="# <<< fugue git-parent-guard <<<"
+
+pass() {
+  printf 'PASS %s\n' "$1"
+}
+
+fail() {
+  printf 'FAIL %s\n' "$1" >&2
+  return 1
+}
+
+is_git_repo() {
+  git -C "$1" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+repo_toplevel() {
+  git -C "$1" rev-parse --show-toplevel 2>/dev/null
+}
+
+repo_git_dir() {
+  git -C "$1" rev-parse --git-dir 2>/dev/null
+}
+
+repo_info_exclude_path() {
+  repo="$1"
+  git_dir="$(repo_git_dir "$repo")"
+  case "$git_dir" in
+    /*) ;;
+    *) git_dir="$repo/$git_dir" ;;
+  esac
+  printf '%s/info/exclude\n' "$git_dir"
+}
+
+write_shell_guard() {
+  file_path="$1"
+  tmp_file="${file_path}.tmp.git-parent-guard.$$"
+
+  if [ -f "$file_path" ]; then
+    awk -v begin="$BLOCK_BEGIN" -v end="$BLOCK_END" '
+      $0 == begin { skip = 1; next }
+      $0 == end { skip = 0; next }
+      skip == 0 { print }
+    ' "$file_path" > "$tmp_file"
+  else
+    : > "$tmp_file"
+  fi
+
+  {
+    cat "$tmp_file"
+    printf '\n%s\n' "$BLOCK_BEGIN"
+    printf '# Managed by scripts/local/git-parent-guard.sh\n'
+    printf '_fugue_git_guard_dev_root="${FUGUE_DEV_ROOT:-$HOME/Dev}"\n'
+    printf 'case ":${GIT_CEILING_DIRECTORIES:-}:" in *":$HOME:"*) ;; *) export GIT_CEILING_DIRECTORIES="${GIT_CEILING_DIRECTORIES:+$GIT_CEILING_DIRECTORIES:}$HOME" ;; esac\n'
+    printf 'case ":${GIT_CEILING_DIRECTORIES:-}:" in *":${_fugue_git_guard_dev_root}:"*) ;; *) export GIT_CEILING_DIRECTORIES="${GIT_CEILING_DIRECTORIES:+$GIT_CEILING_DIRECTORIES:}${_fugue_git_guard_dev_root}" ;; esac\n'
+    printf 'unset _fugue_git_guard_dev_root\n'
+    printf '%s\n' "$BLOCK_END"
+  } > "${tmp_file}.new"
+
+  mv "${tmp_file}.new" "$file_path"
+  rm -f "$tmp_file"
+}
+
+apply_repo_guard() {
+  repo="$1"
+  label="$2"
+
+  if ! is_git_repo "$repo"; then
+    pass "$label skipped: not a git repo"
+    return 0
+  fi
+
+  git -C "$repo" config --local status.showUntrackedFiles no
+
+  info_exclude="$(repo_info_exclude_path "$repo")"
+  mkdir -p "$(dirname "$info_exclude")"
+  [ -f "$info_exclude" ] || : > "$info_exclude"
+  if ! grep -Fxq '/*' "$info_exclude"; then
+    {
+      printf '\n# Local parent-repo guard: keep broad add/status from picking up unrelated untracked files.\n'
+      printf '/*\n'
+    } >> "$info_exclude"
+  fi
+
+  pass "$label repo guard applied"
+}
+
+verify_discovery_blocked() {
+  path="$1"
+  label="$2"
+
+  if [ ! -d "$path" ]; then
+    pass "$label missing: $path"
+    return 0
+  fi
+
+  top="$(repo_toplevel "$path" || true)"
+  if [ -z "$top" ]; then
+    pass "$label parent discovery blocked"
+    return 0
+  fi
+
+  if [ "$top" = "$HOME_DIR" ] || [ "$top" = "$DEV_ROOT" ]; then
+    fail "$label resolved to parent repo: $top"
+    return 1
+  fi
+
+  pass "$label resolved to non-parent repo: $top"
+}
+
+verify_nested_repo() {
+  repo="$1"
+  label="$2"
+
+  if [ ! -d "$repo" ]; then
+    pass "$label missing: $repo"
+    return 0
+  fi
+  if ! is_git_repo "$repo"; then
+    pass "$label not a git repo: $repo"
+    return 0
+  fi
+
+  top="$(repo_toplevel "$repo" || true)"
+  if [ "$top" = "$repo" ]; then
+    pass "$label resolves correctly"
+    return 0
+  fi
+
+  fail "$label unexpected toplevel: $top"
+}
+
+verify_parent_repo() {
+  repo="$1"
+  label="$2"
+  rc=0
+
+  if ! is_git_repo "$repo"; then
+    pass "$label skipped: not a git repo"
+    return 0
+  fi
+
+  if [ "$(git -C "$repo" config --local --get status.showUntrackedFiles 2>/dev/null || true)" = "no" ]; then
+    pass "$label status.showUntrackedFiles=no"
+  else
+    fail "$label status.showUntrackedFiles is not no"
+    rc=1
+  fi
+
+  info_exclude="$(repo_info_exclude_path "$repo")"
+  if [ -f "$info_exclude" ] && grep -Fxq '/*' "$info_exclude"; then
+    pass "$label info/exclude contains /*"
+  else
+    fail "$label info/exclude missing /*"
+    rc=1
+  fi
+
+  if git -C "$repo" ls-files --others --exclude-standard | grep -q .; then
+    fail "$label has untracked files visible to git"
+    rc=1
+  else
+    pass "$label no untracked files visible to git"
+  fi
+
+  return "$rc"
+}
+
+run_apply() {
+  for rel in $SHELL_FILES; do
+    write_shell_guard "$HOME_DIR/$rel"
+    pass "updated $HOME_DIR/$rel"
+  done
+
+  apply_repo_guard "$HOME_DIR" "HOME"
+  apply_repo_guard "$DEV_ROOT" "DEV_ROOT"
+
+  if command -v launchctl >/dev/null 2>&1; then
+    launchctl setenv GIT_CEILING_DIRECTORIES "$HOME_DIR:$DEV_ROOT" >/dev/null 2>&1 || true
+    pass "launchctl setenv attempted"
+  else
+    pass "launchctl not available"
+  fi
+}
+
+run_verify() {
+  rc=0
+
+  verify_discovery_blocked "$HOME_DIR/.local/share/x-auto" "discovery HOME/.local/share/x-auto" || rc=1
+  verify_discovery_blocked "$HOME_DIR/.codex/skills/x-auto" "discovery HOME/.codex/skills/x-auto" || rc=1
+  verify_discovery_blocked "$DEV_ROOT/tmp" "discovery DEV_ROOT/tmp" || rc=1
+
+  verify_nested_repo "$DEV_ROOT/x-auto" "nested DEV_ROOT/x-auto" || rc=1
+  verify_nested_repo "$HOME_DIR/fugue-orchestrator" "nested HOME/fugue-orchestrator" || rc=1
+
+  verify_parent_repo "$HOME_DIR" "parent HOME" || rc=1
+  verify_parent_repo "$DEV_ROOT" "parent DEV_ROOT" || rc=1
+
+  return "$rc"
+}
+
+case "$MODE" in
+  apply)
+    run_apply
+    ;;
+  verify)
+    run_verify
+    ;;
+  *)
+    printf 'Usage: %s [verify|apply]\n' "$0" >&2
+    exit 2
+    ;;
+esac

--- a/tests/test-dev-root-git-safety.sh
+++ b/tests/test-dev-root-git-safety.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${ROOT_DIR}/scripts/local/dev-root-git-safety.sh"
+
+passed=0
+failed=0
+
+pass() {
+  echo "PASS [$1]"
+  passed=$((passed + 1))
+}
+
+fail() {
+  echo "FAIL [$1]"
+  failed=$((failed + 1))
+}
+
+assert_success() {
+  local name="$1"
+  shift
+  if "$@" >/tmp/dev-root-git-safety-test.$$ 2>&1; then
+    pass "${name}"
+  else
+    fail "${name}"
+    cat /tmp/dev-root-git-safety-test.$$
+  fi
+}
+
+assert_failure() {
+  local name="$1"
+  shift
+  if "$@" >/tmp/dev-root-git-safety-test.$$ 2>&1; then
+    fail "${name}"
+    cat /tmp/dev-root-git-safety-test.$$
+  else
+    pass "${name}"
+  fi
+}
+
+make_repo() {
+  local repo="$1"
+  mkdir -p "${repo}"
+  git -C "${repo}" init -q
+  printf 'custom-cache/\n' > "${repo}/.git/info/exclude"
+}
+
+repo_root="${TMPDIR:-/tmp}/dev-root-git-safety-$$"
+repo="${repo_root}/repo"
+make_repo "${repo}"
+
+echo "=== dev-root-git-safety.sh tests ==="
+echo ""
+
+assert_success "install managed block" "${SCRIPT}" install --repo "${repo}"
+assert_success "verify installed block" "${SCRIPT}" verify --repo "${repo}"
+
+first_state="$(cat "${repo}/.git/info/exclude")"
+assert_success "install idempotent second run" "${SCRIPT}" install --repo "${repo}"
+second_state="$(cat "${repo}/.git/info/exclude")"
+if [[ "${first_state}" == "${second_state}" ]]; then
+  pass "second install leaves exclude unchanged"
+else
+  fail "second install leaves exclude unchanged"
+fi
+
+if grep -Fxq 'custom-cache/' "${repo}/.git/info/exclude"; then
+  pass "preserves custom exclude line"
+else
+  fail "preserves custom exclude line"
+fi
+
+awk '
+  $0 == "# END FUGUE DEV ROOT GIT SAFETY" { print "# drift inside managed block" }
+  { print }
+' "${repo}/.git/info/exclude" > "${repo}/.git/info/exclude.drift"
+mv "${repo}/.git/info/exclude.drift" "${repo}/.git/info/exclude"
+assert_failure "verify detects drift" "${SCRIPT}" verify --repo "${repo}"
+assert_success "audit emits json" "${SCRIPT}" audit --repo "${repo}"
+
+echo ""
+echo "=== Results: ${passed} passed, ${failed} failed ==="
+
+if (( failed > 0 )); then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add a tracked Dev-root info/exclude safety block template
- add install/verify/audit tooling for the Dev parent repository guard
- add a broader local git parent guard verifier/apply helper
- add a shell contract test covering install idempotence, custom exclude preservation, drift detection, and audit output
- record Phase 2 completion in the GHA24 mainframe flow docs

## Validation
- bash -n scripts/local/git-parent-guard.sh && bash -n scripts/local/dev-root-git-safety.sh
- scripts/local/git-parent-guard.sh verify
- bash tests/test-dev-root-git-safety.sh
- scripts/local/dev-root-git-safety.sh verify --repo /Users/masayuki_otawara/Dev
- bash tests/test-workspace-root-policy.sh

## Objective
Current objective completion: 100% for untracked-noise accident prevention and auditability. Remaining cleanup is destructive local temp/worktree cleanup and is outside this PR.