### PR TITLE
feat(search): unified search engine with xAI x_search + dual-invoke adapter

### DIFF
--- a/bin/search
+++ b/bin/search
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+
+exec node "${repo_root}/scripts/search.js" "$@"

--- a/docs/search-adapter.md
+++ b/docs/search-adapter.md
@@ -1,0 +1,71 @@
+# Search Adapter Contract
+
+`scripts/search.js` is the canonical search engine entry point. The repo-local
+`bin/search` wrapper exists so FUGUE/Claude and Kernel/Codex can invoke the same
+engine through a stable path without changing the search CLI itself.
+
+## Invocation
+
+FUGUE/Claude can keep using the existing direct path:
+
+```bash
+node /Users/masayuki/Dev/agent-orchestration/scripts/search.js "<query>" --plan-only
+node /Users/masayuki/Dev/agent-orchestration/scripts/search.js --aggregate /tmp/search-execution-result.json --format markdown
+```
+
+Kernel/Codex should prefer the wrapper when the repository root is known:
+
+```bash
+"${AGENT_ORCHESTRATION_ROOT}/bin/search" "<query>" --plan-only
+"${AGENT_ORCHESTRATION_ROOT}/bin/search" --aggregate /tmp/search-execution-result.json --format json
+```
+
+The wrapper resolves the repository root relative to its own location and then
+execs:
+
+```bash
+node "${repo_root}/scripts/search.js" "$@"
+```
+
+## Contract
+
+- The adapter does not read stdin.
+- Positional query and `--query <text>` are both accepted.
+- `--plan-only` writes `SearchPlan` JSON to stdout and writes a single `meta:`
+  line to stderr.
+- `--aggregate <file>` reads a `SearchExecutionResult` JSON file, ranks and
+  formats it, then writes the requested output format to stdout.
+- End-to-end execution runs the resolved sources and writes summary output by
+  default, or JSON when `--format json` is provided.
+- Warnings and metadata are emitted on stderr so stdout remains parseable when a
+  JSON-producing mode is selected.
+
+## JSON Modes
+
+Plan mode emits this shape on stdout:
+
+```json
+{
+  "query": "AI news",
+  "sources": [],
+  "options": {
+    "format": "json",
+    "maxResults": 5,
+    "parallel": true
+  }
+}
+```
+
+Aggregate mode expects a `SearchExecutionResult` JSON document with source
+entries. The same schema is used by direct execution before normalization and
+ranking.
+
+## Exit Codes
+
+- `0`: request parsed and at least one selected source succeeded, or plan-only
+  completed.
+- `1`: invalid arguments, invalid JSON input, runtime exception, or all selected
+  sources failed.
+
+Additional non-zero codes are not currently reserved. Callers should treat any
+non-zero exit code as a failed search request and read stderr for details.

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { getHelpText, parseArgs } from './search/cli.js';
+import { resolveIntent } from './search/router.js';
+import { buildExecutionPlan } from './search/planner.js';
+import { executePlan } from './search/executor.js';
+import { normalizeResults } from './search/normalizer.js';
+import { assignConfidence } from './search/ranker.js';
+import { formatOutput } from './search/formatter.js';
+import { searchExecutionResultSchema, searchPlanSchema } from './search/schemas.js';
+import { createEstatSource } from './search/sources/estat.js';
+import { createLaborLawSource } from './search/sources/labor-law.js';
+import { createNoteComSource } from './search/sources/note-com.js';
+import { createWebSource } from './search/sources/web.js';
+import { createXSearchSource } from './search/sources/x-search.js';
+
+const sourceRegistry = {
+  estat: createEstatSource(),
+  'labor-law': createLaborLawSource(),
+  'note-com': createNoteComSource(),
+  web: createWebSource(),
+  'x-search': createXSearchSource(),
+};
+
+const AGGREGATE_SOURCE_CONFIDENCE = Object.freeze({
+  estat: 'primary',
+  'labor-law': 'primary',
+  'note-com': 'secondary-mid',
+  web: 'secondary-high',
+  'x-search': 'secondary-low',
+});
+
+function resolveAggregateConfidence(sourceId) {
+  if (sourceId === 'x-search') {
+    const key = process.env.XAI_API_KEY;
+    if (typeof key === 'string' && key.trim().length > 0) return 'secondary-mid';
+  }
+  return AGGREGATE_SOURCE_CONFIDENCE[sourceId] ?? 'secondary-low';
+}
+
+function createAggregateSourceMetas(executionSources) {
+  /** @type {Record<string, {confidence: string, via: string}>} */
+  const sourceMetas = {};
+  for (const source of executionSources) {
+    sourceMetas[source.sourceId] = {
+      confidence: resolveAggregateConfidence(source.sourceId),
+      via: 'aggregate',
+    };
+  }
+  return sourceMetas;
+}
+
+function rankAndFormat(rawResults, sourceMetas, format) {
+  const normalized = normalizeResults(rawResults, sourceMetas);
+  const ranked = {
+    ...normalized,
+    items: assignConfidence(normalized.items),
+  };
+  return {
+    ranked,
+    output: formatOutput(ranked, format),
+  };
+}
+
+async function main() {
+  const request = parseArgs(process.argv.slice(2));
+  if (request.help) {
+    process.stdout.write(`${getHelpText()}\n`);
+    return;
+  }
+
+  if (request.warnings.length > 0) {
+    for (const warning of request.warnings) {
+      process.stderr.write(`warning: ${warning}\n`);
+    }
+  }
+
+  if (request.aggregate) {
+    const fileContent = await readFile(request.aggregate, 'utf8');
+    const parsedExecution = searchExecutionResultSchema.parse(JSON.parse(fileContent));
+    const { output, ranked } = rankAndFormat(
+      parsedExecution.sources,
+      createAggregateSourceMetas(parsedExecution.sources),
+      request.format,
+    );
+    process.stdout.write(output + '\n');
+    process.stderr.write(
+      `meta: aggregate=${request.aggregate} sources=${parsedExecution.sources.length} success=${ranked.meta.succeededSources} failures=${ranked.meta.failedSources}\n`,
+    );
+    process.exitCode = ranked.meta.allSourcesFailed ? 1 : 0;
+    return;
+  }
+
+  const routeDecision = resolveIntent(request.query, request.sources);
+  const plan = buildExecutionPlan(request, routeDecision);
+  if (request.planOnly) {
+    const planJson = searchPlanSchema.parse({
+      query: plan.query,
+      sources: plan.sourcePlans,
+      options: plan.options,
+    });
+    process.stdout.write(JSON.stringify(planJson, null, 2) + '\n');
+    process.stderr.write(
+      `meta: strategy=${plan.strategy} mode=plan-only sources=${plan.sources.join(',')}\n`,
+    );
+    return;
+  }
+
+  const execution = await executePlan(plan, sourceRegistry);
+  const { output, ranked } = rankAndFormat(execution, plan.sourceMetas, request.format);
+  process.stdout.write(output + '\n');
+  process.stderr.write(
+    `meta: strategy=${plan.strategy} sources=${plan.sources.join(',')} success=${ranked.meta.succeededSources} failures=${ranked.meta.failedSources}\n`,
+  );
+  process.exitCode = ranked.meta.allSourcesFailed ? 1 : 0;
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`error: ${message}\n`);
+  if (message === 'Query is required') {
+    process.stderr.write(`${getHelpText()}\n`);
+  }
+  process.exitCode = 1;
+});

--- a/scripts/search/__tests__/adapter.test.js
+++ b/scripts/search/__tests__/adapter.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { searchPlanSchema } from '../schemas.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const CWD = resolve(TEST_DIR, '../../..');
+const SEARCH_ADAPTER = resolve(CWD, 'bin/search');
+
+test('bin/search forwards arguments to the canonical search CLI', () => {
+  const stdout = execFileSync(
+    SEARCH_ADAPTER,
+    ['--query', 'adapter smoke', '--plan-only', '--format', 'json'],
+    {
+      cwd: CWD,
+      encoding: 'utf8',
+    },
+  );
+
+  const plan = searchPlanSchema.parse(JSON.parse(stdout));
+  assert.equal(plan.query, 'adapter smoke');
+  assert.equal(plan.options.format, 'json');
+  assert.ok(plan.sources.length > 0);
+});

--- a/scripts/search/__tests__/aggregate.test.js
+++ b/scripts/search/__tests__/aggregate.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const CWD = resolve(TEST_DIR, '../../..');
+const SEARCH_SCRIPT = resolve(CWD, 'scripts/search.js');
+
+test('--aggregate reads execution JSON and formats ranked results', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'search-aggregate-'));
+  const inputFile = join(tempDir, 'execution.json');
+  writeFileSync(
+    inputFile,
+    JSON.stringify({
+      sources: [
+        {
+          sourceId: 'estat',
+          status: 'ok',
+          items: [
+            {
+              title: '人口動態統計',
+              url: 'https://example.com/estat',
+              snippet: '公的統計',
+              metadata: { category: 'official' },
+            },
+          ],
+          durationMs: 120,
+        },
+        {
+          sourceId: 'web',
+          status: 'ok',
+          items: [
+            {
+              title: '関連レポート',
+              url: 'https://example.com/web',
+              snippet: '補助情報',
+              metadata: { category: 'web' },
+            },
+          ],
+          durationMs: 80,
+        },
+      ],
+    }),
+    'utf8',
+  );
+
+  const stdout = execFileSync(
+    'node',
+    [SEARCH_SCRIPT, '--aggregate', inputFile, '--format', 'json'],
+    {
+      cwd: CWD,
+      encoding: 'utf8',
+    },
+  );
+
+  const output = JSON.parse(stdout);
+  assert.equal(output.meta.totalSources, 2);
+  assert.equal(output.meta.succeededSources, 2);
+  assert.equal(output.items.length, 2);
+  assert.deepEqual(
+    output.items.map((item) => ({
+      sourceId: item.sourceId,
+      confidenceLabel: item.confidenceLabel,
+      confidence: item.confidence,
+    })),
+    [
+      {
+        sourceId: 'estat',
+        confidenceLabel: 'primary',
+        confidence: 0.9,
+      },
+      {
+        sourceId: 'web',
+        confidenceLabel: 'secondary-high',
+        confidence: 0.7,
+      },
+    ],
+  );
+});

--- a/scripts/search/__tests__/cli.test.js
+++ b/scripts/search/__tests__/cli.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getHelpText, parseArgs } from '../cli.js';
+
+test('parseArgs parses positional query with defaults', () => {
+  const parsed = parseArgs(['人口統計']);
+
+  assert.equal(parsed.query, '人口統計');
+  assert.equal(parsed.format, 'summary');
+  assert.equal(parsed.maxResults, 5);
+  assert.equal(parsed.parallel, true);
+  assert.equal(parsed.planOnly, false);
+  assert.equal(parsed.aggregate, undefined);
+  assert.deepEqual(parsed.warnings, []);
+});
+
+test('parseArgs collects warnings for unknown options', () => {
+  const parsed = parseArgs(['人口統計', '--bogus']);
+
+  assert.deepEqual(parsed.warnings, ['Unknown option ignored: --bogus']);
+});
+
+test('parseArgs supports help without requiring a query', () => {
+  const parsed = parseArgs(['--help']);
+
+  assert.deepEqual(parsed, {
+    help: true,
+    warnings: [],
+  });
+  assert.match(getHelpText(), /Usage: node scripts\/search\.js/);
+});

--- a/scripts/search/__tests__/estat.test.js
+++ b/scripts/search/__tests__/estat.test.js
@@ -1,0 +1,178 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createEstatSource } from '../sources/estat.js';
+
+test('createEstatSource returns missing app id error when ESTAT_APP_ID is unavailable', async () => {
+  const previousAppId = process.env.ESTAT_APP_ID;
+  const previousCwd = process.cwd();
+  const tempDir = mkdtempSync(join(tmpdir(), 'estat-no-env-'));
+
+  delete process.env.ESTAT_APP_ID;
+  process.chdir(tempDir);
+
+  try {
+    const source = createEstatSource();
+    const result = await source.search({
+      query: '人口',
+      maxResults: 3,
+      signal: new AbortController().signal,
+    });
+
+    assert.equal(result.items.length, 0);
+    assert.deepEqual(result.error, {
+      sourceId: 'estat',
+      code: 'MISSING_APP_ID',
+      message: 'ESTAT_APP_ID is not configured',
+    });
+  } finally {
+    process.chdir(previousCwd);
+    if (previousAppId === undefined) {
+      delete process.env.ESTAT_APP_ID;
+    } else {
+      process.env.ESTAT_APP_ID = previousAppId;
+    }
+  }
+});
+
+test('createEstatSource ignores workspace .env when ESTAT_APP_ID is unavailable', async () => {
+  const previousAppId = process.env.ESTAT_APP_ID;
+  const previousCwd = process.cwd();
+  const tempDir = mkdtempSync(join(tmpdir(), 'estat-dotenv-'));
+
+  delete process.env.ESTAT_APP_ID;
+  writeFileSync(join(tempDir, '.env'), 'ESTAT_APP_ID=from-dotenv\n', 'utf8');
+  process.chdir(tempDir);
+
+  try {
+    const source = createEstatSource();
+    const result = await source.search({
+      query: '人口',
+      maxResults: 3,
+      signal: new AbortController().signal,
+    });
+
+    assert.equal(result.items.length, 0);
+    assert.deepEqual(result.error, {
+      sourceId: 'estat',
+      code: 'MISSING_APP_ID',
+      message: 'ESTAT_APP_ID is not configured',
+    });
+  } finally {
+    process.chdir(previousCwd);
+    if (previousAppId === undefined) {
+      delete process.env.ESTAT_APP_ID;
+    } else {
+      process.env.ESTAT_APP_ID = previousAppId;
+    }
+  }
+});
+
+test('createEstatSource normalizes e-Stat table response fields', async () => {
+  const previousAppId = process.env.ESTAT_APP_ID;
+  process.env.ESTAT_APP_ID = 'test-app-id';
+
+  try {
+    const source = createEstatSource(async () => ({
+      ok: true,
+      async json() {
+        return {
+          GET_STATS_LIST: {
+            RESULT: {
+              STATUS: '0',
+            },
+            DATALIST_INF: {
+              TABLE_INF: [
+                {
+                  '@id': '0001',
+                  STAT_NAME: { $: '国勢調査' },
+                  TITLE: { $: '2020年国勢調査 人口等基本集計' },
+                  LINK: 'https://example.com/estat/0001',
+                  SURVEY_DATE: { $: '2020年' },
+                  GOV_ORG: { $: '総務省' },
+                },
+              ],
+            },
+          },
+        };
+      },
+    }));
+
+    const result = await source.search({
+      query: '人口',
+      maxResults: 5,
+      signal: new AbortController().signal,
+    });
+
+    assert.equal(result.error, undefined);
+    assert.equal(result.items.length, 1);
+    assert.deepEqual(result.items[0], {
+      title: '国勢調査',
+      url: 'https://example.com/estat/0001',
+      snippet: '2020年国勢調査 人口等基本集計',
+      metadata: {
+        id: '0001',
+        statisticName: '国勢調査',
+        tableTitle: '2020年国勢調査 人口等基本集計',
+        surveyYear: '2020',
+        government: '総務省',
+      },
+      raw: {
+        '@id': '0001',
+        STAT_NAME: { $: '国勢調査' },
+        TITLE: { $: '2020年国勢調査 人口等基本集計' },
+        LINK: 'https://example.com/estat/0001',
+        SURVEY_DATE: { $: '2020年' },
+        GOV_ORG: { $: '総務省' },
+      },
+    });
+  } finally {
+    if (previousAppId === undefined) {
+      delete process.env.ESTAT_APP_ID;
+    } else {
+      process.env.ESTAT_APP_ID = previousAppId;
+    }
+  }
+});
+
+test('createEstatSource returns API errors when STATUS is non-zero', async () => {
+  const previousAppId = process.env.ESTAT_APP_ID;
+  process.env.ESTAT_APP_ID = 'test-app-id';
+
+  try {
+    const source = createEstatSource(async () => ({
+      ok: true,
+      async json() {
+        return {
+          GET_STATS_LIST: {
+            RESULT: {
+              STATUS: '100',
+              ERROR_MSG: 'invalid app id',
+            },
+          },
+        };
+      },
+    }));
+
+    const result = await source.search({
+      query: '人口',
+      maxResults: 5,
+      signal: new AbortController().signal,
+    });
+
+    assert.equal(result.items.length, 0);
+    assert.deepEqual(result.error, {
+      sourceId: 'estat',
+      code: 'API_ERROR',
+      message: 'invalid app id',
+    });
+  } finally {
+    if (previousAppId === undefined) {
+      delete process.env.ESTAT_APP_ID;
+    } else {
+      process.env.ESTAT_APP_ID = previousAppId;
+    }
+  }
+});

--- a/scripts/search/__tests__/executor.test.js
+++ b/scripts/search/__tests__/executor.test.js
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { executePlan } from '../executor.js';
+
+test('executePlan records timeout errors with source metadata', async () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+
+  globalThis.setTimeout = ((callback) => {
+    callback();
+    return 1;
+  });
+  globalThis.clearTimeout = (() => {});
+
+  try {
+    const plan = {
+      query: '人口',
+      maxResults: 5,
+      sources: ['web'],
+    };
+    const registry = {
+      web: {
+        async search({ signal }) {
+          return new Promise((resolve, reject) => {
+            if (signal.aborted) {
+              reject(new Error('aborted'));
+              return;
+            }
+            signal.addEventListener(
+              'abort',
+              () => reject(new Error('aborted')),
+              { once: true },
+            );
+          });
+        },
+      },
+    };
+
+    const result = await executePlan(plan, registry);
+
+    assert.equal(result.length, 1);
+    assert.deepEqual(result[0].error, {
+      status: 'timeout',
+      source: 'web',
+      sourceId: 'web',
+      code: 'TIMEOUT',
+      message: 'Source timed out after 3000ms',
+    });
+    assert.equal(result[0].ok, false);
+    assert.deepEqual(result[0].items, []);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
+test('executePlan returns stub results for claude-session sources', async () => {
+  const result = await executePlan(
+    {
+      query: '労働基準法',
+      maxResults: 5,
+      sources: ['labor-law'],
+      sourcePlans: [
+        {
+          sourceId: 'labor-law',
+          executionMode: 'claude-session',
+        },
+      ],
+    },
+    {},
+  );
+
+  assert.deepEqual(result, [
+    {
+      sourceId: 'labor-law',
+      status: 'stub',
+      ok: false,
+      items: [],
+      error: {
+        sourceId: 'labor-law',
+        code: 'STUB_SOURCE',
+        message: 'Source labor-law requires claude-session execution',
+      },
+      durationMs: 0,
+    },
+  ]);
+});

--- a/scripts/search/__tests__/formatter.test.js
+++ b/scripts/search/__tests__/formatter.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatOutput } from '../formatter.js';
+
+const sampleResult = {
+  items: [
+    {
+      sourceId: 'estat',
+      title: '人口統計',
+      url: 'https://example.com',
+      snippet: '統計',
+      confidenceLabel: 'primary',
+      confidence: 0.9,
+      raw: { id: 1 },
+    },
+  ],
+  errors: [
+    {
+      sourceId: 'web',
+      code: 'STUB_SOURCE',
+      message: 'not implemented',
+    },
+  ],
+  meta: {
+    totalSources: 2,
+    succeededSources: 1,
+    failedSources: 1,
+    allSourcesFailed: false,
+  },
+};
+
+test('formatOutput json includes raw payload', () => {
+  const output = formatOutput(sampleResult, 'json');
+  assert.match(output, /"raw"/);
+});
+
+test('formatOutput markdown omits raw payload and prints table', () => {
+  const output = formatOutput(sampleResult, 'markdown');
+  assert.match(output, /\| Source \| Title \| Confidence \| URL \|/);
+  assert.doesNotMatch(output, /raw/);
+});
+
+test('formatOutput summary returns compact one-line text', () => {
+  const output = formatOutput(sampleResult, 'summary');
+  assert.equal(output, 'sources=2 success=1 failures=1 results=1');
+});

--- a/scripts/search/__tests__/mcp-tool-map.test.js
+++ b/scripts/search/__tests__/mcp-tool-map.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { MCP_TOOL_MAP, buildMcpTools } from '../mcp-tool-map.js';
+
+test('MCP_TOOL_MAP exposes configured tool mapping for session-backed sources', () => {
+  assert.deepEqual(Object.keys(MCP_TOOL_MAP).sort(), [
+    'labor-law',
+    'note-com',
+    'web',
+    'x-search',
+  ]);
+
+  assert.deepEqual(buildMcpTools('labor-law', '36協定'), [
+    {
+      tool: 'mcp__labor-law__search_law',
+      params: { keyword: '36協定' },
+    },
+  ]);
+
+  assert.deepEqual(buildMcpTools('x-search', '景気動向'), [
+    {
+      tool: 'WebSearch',
+      params: { query: '景気動向 site:x.com' },
+    },
+  ]);
+});

--- a/scripts/search/__tests__/normalizer.test.js
+++ b/scripts/search/__tests__/normalizer.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeResults } from '../normalizer.js';
+import { assignConfidence } from '../ranker.js';
+
+test('normalizeResults collects items and source errors', () => {
+  const result = normalizeResults(
+    [
+      {
+        sourceId: 'estat',
+        items: [
+          {
+            title: '人口統計',
+            url: 'https://example.com/estat',
+            snippet: '統計一覧',
+            raw: { id: 1 },
+          },
+        ],
+        error: null,
+      },
+      {
+        sourceId: 'web',
+        items: [],
+        error: {
+          sourceId: 'web',
+          code: 'STUB_SOURCE',
+          message: 'not implemented',
+        },
+      },
+    ],
+    {
+      estat: { confidence: 'primary', via: 'router' },
+      web: { confidence: 'secondary-high', via: 'router-fallback' },
+    },
+  );
+
+  assert.equal(result.items.length, 1);
+  assert.equal(result.errors.length, 1);
+  assert.equal(result.meta.allSourcesFailed, false);
+
+  const ranked = assignConfidence(result.items);
+  assert.equal(ranked[0].confidence, 0.9);
+});
+
+test('normalizeResults marks allSourcesFailed when every source errors', () => {
+  const result = normalizeResults(
+    [
+      {
+        sourceId: 'web',
+        items: [],
+        error: {
+          sourceId: 'web',
+          code: 'STUB_SOURCE',
+          message: 'not implemented',
+        },
+      },
+    ],
+    {
+      web: { confidence: 'secondary-high', via: 'router-fallback' },
+    },
+  );
+
+  assert.equal(result.meta.allSourcesFailed, true);
+  assert.equal(result.meta.succeededSources, 0);
+});

--- a/scripts/search/__tests__/plan.test.js
+++ b/scripts/search/__tests__/plan.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { searchPlanSchema } from '../schemas.js';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const CWD = resolve(TEST_DIR, '../../..');
+const SEARCH_SCRIPT = resolve(CWD, 'scripts/search.js');
+
+test('--plan-only prints SearchPlan JSON without executing sources', () => {
+  const stdout = execFileSync(
+    'node',
+    [SEARCH_SCRIPT, '--query', 'GDP 統計', '--plan-only', '--format', 'json'],
+    {
+      cwd: CWD,
+      encoding: 'utf8',
+    },
+  );
+
+  const plan = searchPlanSchema.parse(JSON.parse(stdout));
+  assert.equal(plan.query, 'GDP 統計');
+  assert.equal(plan.options.format, 'json');
+  assert.equal(plan.sources[0].sourceId, 'estat');
+  assert.equal(plan.sources[0].executionMode, 'direct');
+  assert.deepEqual(plan.sources[0].mcpTools, []);
+  assert.equal(plan.sources[1].sourceId, 'web');
+  assert.equal(plan.sources[1].executionMode, 'claude-session');
+  assert.deepEqual(plan.sources[1].mcpTools, [
+    {
+      tool: 'WebSearch',
+      params: { query: 'GDP 統計' },
+    },
+  ]);
+});

--- a/scripts/search/__tests__/planner.test.js
+++ b/scripts/search/__tests__/planner.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildExecutionPlan } from '../planner.js';
+import { resolveIntent } from '../router.js';
+
+test('explicit sources disable patterns and fallback', () => {
+  const request = {
+    query: '市場トレンド',
+    format: 'summary',
+    maxResults: 5,
+    parallel: true,
+    sources: ['labor-law'],
+  };
+  const routeDecision = resolveIntent(request.query, request.sources);
+  const plan = buildExecutionPlan(request, routeDecision);
+  assert.equal(plan.strategy, 'explicit');
+  assert.deepEqual(plan.sources, ['labor-law']);
+});
+
+test('parallel patterns choose declared source set', () => {
+  const request = {
+    query: '市場トレンドのSEO記事',
+    format: 'summary',
+    maxResults: 5,
+    parallel: true,
+  };
+  const routeDecision = resolveIntent(request.query);
+  const plan = buildExecutionPlan(request, routeDecision);
+  assert.equal(plan.strategy, 'parallel-pattern');
+  assert.deepEqual(plan.sources, ['web', 'estat', 'x-search']);
+});
+
+test('router adds web fallback only for automatic routing', () => {
+  const request = {
+    query: 'GDPを調べる',
+    format: 'summary',
+    maxResults: 5,
+    parallel: false,
+  };
+  const routeDecision = resolveIntent(request.query);
+  const plan = buildExecutionPlan(request, routeDecision);
+  assert.deepEqual(plan.sources, ['estat', 'web']);
+  assert.equal(plan.sourceMetas.web.confidence, 'secondary-high');
+});

--- a/scripts/search/__tests__/router.test.js
+++ b/scripts/search/__tests__/router.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveIntent } from '../router.js';
+
+test('resolveIntent matches statistics queries and keeps web fallback', () => {
+  const result = resolveIntent('日本の人口統計を知りたい', undefined);
+  assert.deepEqual(
+    result.matchedSources.map((item) => item.sourceId),
+    ['estat'],
+  );
+  assert.equal(result.fallback?.sourceId, 'web');
+});
+
+test('resolveIntent uses explicit sources without fallback', () => {
+  const result = resolveIntent('任意クエリ', ['note-com', 'web']);
+  assert.deepEqual(
+    result.matchedSources.map((item) => item.sourceId),
+    ['note-com', 'web'],
+  );
+  assert.equal(result.fallback, null);
+});

--- a/scripts/search/__tests__/x-search.test.js
+++ b/scripts/search/__tests__/x-search.test.js
@@ -1,0 +1,124 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createXSearchSource } from '../sources/x-search.js';
+
+function withEnv(key, value, fn) {
+  const prev = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  return Promise.resolve(fn()).finally(() => {
+    if (prev === undefined) delete process.env[key];
+    else process.env[key] = prev;
+  });
+}
+
+test('createXSearchSource returns MISSING_API_KEY when XAI_API_KEY is unset', async () => {
+  await withEnv('XAI_API_KEY', undefined, async () => {
+    const source = createXSearchSource();
+    const result = await source.search({
+      query: 'AI',
+      maxResults: 3,
+      signal: new AbortController().signal,
+    });
+    assert.equal(result.items.length, 0);
+    assert.deepEqual(result.error, {
+      sourceId: 'x-search',
+      code: 'MISSING_API_KEY',
+      message: 'XAI_API_KEY is not configured',
+    });
+  });
+});
+
+test('createXSearchSource returns HTTP_ERROR on non-2xx response', async () => {
+  await withEnv('XAI_API_KEY', 'test-key', async () => {
+    const source = createXSearchSource(async () => ({
+      ok: false,
+      status: 401,
+      async text() {
+        return 'Unauthorized';
+      },
+    }));
+    const result = await source.search({
+      query: 'AI',
+      maxResults: 3,
+      signal: new AbortController().signal,
+    });
+    assert.equal(result.items.length, 0);
+    assert.equal(result.error?.code, 'HTTP_ERROR');
+    assert.match(result.error?.message ?? '', /401/);
+  });
+});
+
+test('createXSearchSource normalizes citations from Responses API payload', async () => {
+  await withEnv('XAI_API_KEY', 'test-key', async () => {
+    const source = createXSearchSource(async () => ({
+      ok: true,
+      async json() {
+        return {
+          output: [
+            {
+              content: [
+                {
+                  annotations: [
+                    {
+                      url: 'https://x.com/alice/status/111',
+                      title: 'alice post',
+                      text: 'hello world',
+                    },
+                  ],
+                  results: [
+                    {
+                      url: 'https://x.com/bob/status/222',
+                      text: 'grok launch',
+                      author: 'bob',
+                      id: '222',
+                      created_at: '2026-04-20T00:00:00Z',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+      },
+    }));
+    const result = await source.search({
+      query: 'grok',
+      maxResults: 5,
+      signal: new AbortController().signal,
+    });
+    assert.equal(result.error, undefined);
+    assert.equal(result.items.length, 2);
+    assert.equal(result.items[0].url, 'https://x.com/alice/status/111');
+    assert.equal(result.items[0].title, 'alice post');
+    assert.equal(result.items[1].url, 'https://x.com/bob/status/222');
+    assert.equal(result.items[1].metadata.author, 'bob');
+    assert.equal(result.items[1].metadata.postId, '222');
+  });
+});
+
+test('createXSearchSource dedupes citations by URL and respects maxResults', async () => {
+  await withEnv('XAI_API_KEY', 'test-key', async () => {
+    const source = createXSearchSource(async () => ({
+      ok: true,
+      async json() {
+        return {
+          citations: [
+            { url: 'https://x.com/a/1', title: 'a1' },
+            { url: 'https://x.com/a/1', title: 'dup' },
+            { url: 'https://x.com/a/2', title: 'a2' },
+            { url: 'https://x.com/a/3', title: 'a3' },
+          ],
+        };
+      },
+    }));
+    const result = await source.search({
+      query: 'x',
+      maxResults: 2,
+      signal: new AbortController().signal,
+    });
+    assert.equal(result.items.length, 2);
+    assert.equal(result.items[0].url, 'https://x.com/a/1');
+    assert.equal(result.items[1].url, 'https://x.com/a/2');
+  });
+});

--- a/scripts/search/cli.js
+++ b/scripts/search/cli.js
@@ -1,0 +1,164 @@
+import { searchRequestSchema } from './schemas.js';
+import { DEFAULT_FORMAT, DEFAULT_MAX_RESULTS, DEFAULT_PARALLEL } from './config.js';
+
+export function getHelpText() {
+  return [
+    'Usage: node scripts/search.js [query] [options]',
+    '',
+    'Options:',
+    '  --query <text>         Search query',
+    '  --plan-only            Print execution plan JSON and exit',
+    '  --aggregate <file>     Read execution result JSON and format it',
+    '  --format <format>      Output format: summary | json | markdown',
+    '  --max-results <count>  Maximum number of results',
+    '  --sources <list>       Comma-separated source ids',
+    '  --parallel [true|false]',
+    '  --no-parallel',
+    '  --help                 Show this help',
+  ].join('\n');
+}
+
+function parseBooleanFlag(value, fallback) {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  throw new Error(`Invalid boolean value: ${value}`);
+}
+
+export function parseArgs(argv) {
+  /** @type {{
+   * query?: string,
+   * format: string,
+   * maxResults: number,
+   * parallel: boolean,
+   * sources?: string[],
+   * planOnly: boolean,
+   * aggregate?: string,
+   * help: boolean,
+   * warnings: string[],
+   * }} */
+  const draft = {
+    format: DEFAULT_FORMAT,
+    maxResults: DEFAULT_MAX_RESULTS,
+    parallel: DEFAULT_PARALLEL,
+    planOnly: false,
+    help: false,
+    warnings: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === '--help') {
+      draft.help = true;
+      continue;
+    }
+    if (token === '--query') {
+      if (argv[index + 1] === undefined) {
+        throw new Error('Missing value for --query');
+      }
+      draft.query = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === '--format') {
+      if (argv[index + 1] === undefined) {
+        throw new Error('Missing value for --format');
+      }
+      draft.format = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === '--plan-only') {
+      draft.planOnly = true;
+      continue;
+    }
+    if (token === '--aggregate') {
+      if (argv[index + 1] === undefined) {
+        throw new Error('Missing value for --aggregate');
+      }
+      draft.aggregate = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (token === '--max-results') {
+      if (argv[index + 1] === undefined) {
+        throw new Error('Missing value for --max-results');
+      }
+      draft.maxResults = Number(argv[index + 1]);
+      index += 1;
+      continue;
+    }
+    if (token === '--sources') {
+      if (argv[index + 1] === undefined) {
+        throw new Error('Missing value for --sources');
+      }
+      const value = argv[index + 1] ?? '';
+      draft.sources = value
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (token === '--parallel') {
+      const next = argv[index + 1];
+      if (next && !next.startsWith('--')) {
+        draft.parallel = parseBooleanFlag(next, DEFAULT_PARALLEL);
+        index += 1;
+      } else {
+        draft.parallel = true;
+      }
+      continue;
+    }
+    if (token === '--no-parallel') {
+      draft.parallel = false;
+      continue;
+    }
+    if (token.startsWith('--')) {
+      draft.warnings.push(`Unknown option ignored: ${token}`);
+      continue;
+    }
+    if (!token.startsWith('--') && !draft.query) {
+      draft.query = token;
+    }
+  }
+
+  if (draft.help) {
+    return {
+      help: true,
+      warnings: draft.warnings,
+    };
+  }
+
+  const parsed = searchRequestSchema.parse({
+    ...draft,
+    query: draft.query ?? '',
+  });
+  if (draft.aggregate) {
+    return {
+      ...parsed,
+      help: false,
+      planOnly: draft.planOnly,
+      aggregate: draft.aggregate,
+      warnings: draft.warnings,
+    };
+  }
+
+  if (!parsed.query || !parsed.query.trim()) {
+    throw new Error('Query is required');
+  }
+  return {
+    ...parsed,
+    help: false,
+    planOnly: draft.planOnly,
+    aggregate: draft.aggregate,
+    query: parsed.query.trim(),
+    warnings: draft.warnings,
+  };
+}

--- a/scripts/search/config.js
+++ b/scripts/search/config.js
@@ -1,0 +1,27 @@
+export const DEFAULT_FORMAT = 'summary';
+export const DEFAULT_MAX_RESULTS = 5;
+export const DEFAULT_PARALLEL = true;
+export const DEFAULT_TIMEOUT_MS = 10000;
+
+export const SOURCE_TIMEOUT_MS = {
+  estat: 20000,
+  'labor-law': 3000,
+  'note-com': 3000,
+  web: 3000,
+  'x-search': 15000,
+};
+
+export const KNOWN_SOURCES = Object.freeze([
+  'estat',
+  'labor-law',
+  'note-com',
+  'web',
+  'x-search',
+]);
+
+export const CONFIDENCE_SCORE_MAP = Object.freeze({
+  primary: 0.9,
+  'secondary-high': 0.7,
+  'secondary-mid': 0.5,
+  'secondary-low': 0.3,
+});

--- a/scripts/search/executor.js
+++ b/scripts/search/executor.js
@@ -1,0 +1,143 @@
+import { DEFAULT_TIMEOUT_MS, SOURCE_TIMEOUT_MS } from './config.js';
+
+function createTimeoutError(sourceId, timeoutMs) {
+  return {
+    status: 'timeout',
+    source: sourceId,
+    sourceId,
+    code: 'TIMEOUT',
+    message: `Source timed out after ${timeoutMs}ms`,
+  };
+}
+
+function toSourceError(sourceId, error) {
+  if (error && typeof error === 'object' && 'code' in error && 'message' in error) {
+    return {
+      ...(error.status ? { status: String(error.status) } : {}),
+      ...(error.source ? { source: String(error.source) } : {}),
+      sourceId,
+      code: String(error.code),
+      message: String(error.message),
+    };
+  }
+  if (error instanceof Error) {
+    return {
+      sourceId,
+      code: error.name || 'SOURCE_ERROR',
+      message: error.message,
+    };
+  }
+  return {
+    sourceId,
+    code: 'SOURCE_ERROR',
+    message: String(error),
+  };
+}
+
+async function runWithTimeout(sourceId, operation, timeoutMs) {
+  const abortController = new AbortController();
+  const timer = setTimeout(() => abortController.abort(), timeoutMs);
+  try {
+    return await operation(abortController.signal);
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      throw createTimeoutError(sourceId, timeoutMs);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function createStubExecution(sourcePlan) {
+  return {
+    sourceId: sourcePlan.sourceId,
+    status: 'stub',
+    ok: false,
+    items: [],
+    error: {
+      sourceId: sourcePlan.sourceId,
+      code: 'STUB_SOURCE',
+      message: `Source ${sourcePlan.sourceId} requires claude-session execution`,
+    },
+    durationMs: 0,
+  };
+}
+
+export async function executePlan(plan, sourceRegistry) {
+  const sourcePlans = plan.sourcePlans ?? plan.sources.map((entry) => {
+    if (typeof entry === 'string') return { sourceId: entry };
+    return { sourceId: entry.sourceId, ...entry };
+  });
+  const tasks = sourcePlans.map(async (sourcePlan) => {
+    const sourceId = sourcePlan.sourceId;
+    if (sourcePlan.executionMode === 'claude-session') {
+      return createStubExecution(sourcePlan);
+    }
+
+    const source = sourceRegistry[sourceId];
+    if (!source) {
+      return {
+        sourceId,
+        status: 'error',
+        ok: false,
+        items: [],
+        error: {
+          sourceId,
+          code: 'UNKNOWN_SOURCE',
+          message: `Source not registered: ${sourceId}`,
+        },
+        durationMs: 0,
+      };
+    }
+
+    const startedAt = Date.now();
+    try {
+      const timeoutMs = SOURCE_TIMEOUT_MS[sourceId] ?? DEFAULT_TIMEOUT_MS;
+      const response = await runWithTimeout(
+        sourceId,
+        (signal) =>
+          source.search({
+            query: plan.query,
+            maxResults: plan.maxResults,
+            signal,
+          }),
+        timeoutMs,
+      );
+      return {
+        sourceId,
+        status: response.error ? 'error' : 'ok',
+        ok: !(response.error),
+        items: response.items ?? [],
+        error: response.error ?? null,
+        durationMs: Date.now() - startedAt,
+      };
+    } catch (error) {
+      const sourceError = toSourceError(sourceId, error);
+      return {
+        sourceId,
+        status: sourceError.code === 'TIMEOUT' ? 'timeout' : 'error',
+        ok: false,
+        items: [],
+        error: sourceError,
+        durationMs: Date.now() - startedAt,
+      };
+    }
+  });
+
+  const settled = await Promise.allSettled(tasks);
+  return settled.map((result, index) => {
+    if (result.status === 'fulfilled') {
+      return result.value;
+    }
+    const sourceId = sourcePlans[index].sourceId;
+    return {
+      sourceId,
+      status: 'error',
+      ok: false,
+      items: [],
+      error: toSourceError(sourceId, result.reason),
+      durationMs: 0,
+    };
+  });
+}

--- a/scripts/search/formatter.js
+++ b/scripts/search/formatter.js
@@ -1,0 +1,45 @@
+function withoutRaw(item) {
+  const { raw, ...rest } = item;
+  return rest;
+}
+
+function formatMarkdown(result) {
+  const lines = [
+    '| Source | Title | Confidence | URL |',
+    '| --- | --- | --- | --- |',
+  ];
+  for (const item of result.items) {
+    lines.push(
+      `| ${item.sourceId} | ${item.title} | ${item.confidence} | ${item.url} |`,
+    );
+  }
+  if (result.errors.length > 0) {
+    lines.push('');
+    lines.push('Errors:');
+    for (const error of result.errors) {
+      lines.push(`- ${error.sourceId}: ${error.code} - ${error.message}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function formatSummary(result) {
+  return `sources=${result.meta.totalSources} success=${result.meta.succeededSources} failures=${result.meta.failedSources} results=${result.items.length}`;
+}
+
+export function formatOutput(result, format) {
+  if (format === 'json') {
+    return JSON.stringify(result, null, 2);
+  }
+
+  const sanitized = {
+    ...result,
+    items: result.items.map(withoutRaw),
+  };
+
+  if (format === 'markdown') {
+    return formatMarkdown(sanitized);
+  }
+
+  return formatSummary(sanitized);
+}

--- a/scripts/search/mcp-tool-map.js
+++ b/scripts/search/mcp-tool-map.js
@@ -1,0 +1,53 @@
+export const MCP_TOOL_MAP = Object.freeze({
+  'labor-law': {
+    tools: [
+      {
+        tool: 'mcp__labor-law__search_law',
+        buildParams(query) {
+          return { keyword: query };
+        },
+      },
+    ],
+  },
+  'note-com': {
+    tools: [
+      {
+        tool: 'mcp__note-com__search-notes',
+        buildParams(query) {
+          return { query, size: 10 };
+        },
+      },
+    ],
+  },
+  web: {
+    tools: [
+      {
+        tool: 'WebSearch',
+        buildParams(query) {
+          return { query };
+        },
+      },
+    ],
+  },
+  'x-search': {
+    tools: [
+      {
+        tool: 'WebSearch',
+        buildParams(query) {
+          return { query: `${query} site:x.com` };
+        },
+      },
+    ],
+  },
+});
+
+export function buildMcpTools(sourceId, query) {
+  const mapping = MCP_TOOL_MAP[sourceId];
+  if (!mapping) {
+    return [];
+  }
+  return mapping.tools.map((toolEntry) => ({
+    tool: toolEntry.tool,
+    params: toolEntry.buildParams(query),
+  }));
+}

--- a/scripts/search/normalizer.js
+++ b/scripts/search/normalizer.js
@@ -1,0 +1,37 @@
+export function normalizeResults(rawResults, sourceMetas) {
+  const items = [];
+  const errors = [];
+
+  for (const result of rawResults) {
+    if (result.error) {
+      errors.push(result.error);
+    }
+    for (const item of result.items ?? []) {
+      const meta = sourceMetas[result.sourceId] ?? {
+        confidence: 'secondary-low',
+        via: 'unknown',
+      };
+      items.push({
+        sourceId: result.sourceId,
+        title: item.title ?? '',
+        url: item.url ?? '',
+        snippet: item.snippet ?? '',
+        confidenceLabel: meta.confidence,
+        via: meta.via,
+        raw: item.raw ?? null,
+        metadata: item.metadata ?? {},
+      });
+    }
+  }
+
+  return {
+    items,
+    errors,
+    meta: {
+      totalSources: rawResults.length,
+      succeededSources: rawResults.filter((result) => !result.error).length,
+      failedSources: rawResults.filter((result) => result.error).length,
+      allSourcesFailed: rawResults.every((result) => result.error),
+    },
+  };
+}

--- a/scripts/search/parallel-patterns.js
+++ b/scripts/search/parallel-patterns.js
@@ -1,0 +1,22 @@
+export const PATTERNS = Object.freeze({
+  'seo-evidence': {
+    triggers: /SEO|記事|コンテンツ/i,
+    sources: ['web', 'estat', 'x-search'],
+  },
+  'market-trend': {
+    triggers: /市場|動向|トレンド/i,
+    sources: ['web', 'estat', 'x-search'],
+  },
+  'legal-research': {
+    triggers: /法令|法律|通達|判例/i,
+    sources: ['labor-law', 'web'],
+  },
+  'note-research': {
+    triggers: /note|原稿|執筆/i,
+    sources: ['web', 'estat', 'note-com'],
+  },
+  'slide-facts': {
+    triggers: /スライド|プレゼン|ファクト/i,
+    sources: ['estat', 'web'],
+  },
+});

--- a/scripts/search/planner.js
+++ b/scripts/search/planner.js
@@ -1,0 +1,118 @@
+import { PATTERNS } from './parallel-patterns.js';
+import { ROUTING_FALLBACK } from './routing-rules.js';
+import { DEFAULT_TIMEOUT_MS } from './config.js';
+import { buildMcpTools } from './mcp-tool-map.js';
+
+function isXSearchDirectMode() {
+  const key = process.env.XAI_API_KEY;
+  return typeof key === 'string' && key.trim().length > 0;
+}
+
+function promoteConfidence(entries) {
+  if (!isXSearchDirectMode()) return entries;
+  return entries.map((entry) => {
+    if (entry.sourceId === 'x-search' && entry.confidence === 'secondary-low') {
+      return { ...entry, confidence: 'secondary-mid' };
+    }
+    return entry;
+  });
+}
+
+function dedupeSources(sourceEntries) {
+  return Array.from(new Map(sourceEntries.map((entry) => [entry.sourceId, entry])).values());
+}
+
+function buildSourceMetas(entries) {
+  /** @type {Record<string, {confidence: string, via: string}>} */
+  const sourceMetas = {};
+  for (const entry of entries) {
+    sourceMetas[entry.sourceId] = {
+      confidence: entry.confidence,
+      via: entry.via,
+    };
+  }
+  return sourceMetas;
+}
+
+function buildSourcePlan(entry, query) {
+  const directSources = new Set(['estat']);
+  if (isXSearchDirectMode()) directSources.add('x-search');
+  const executionMode = directSources.has(entry.sourceId) ? 'direct' : 'claude-session';
+  return {
+    ...entry,
+    executionMode,
+    mcpTools: executionMode === 'claude-session' ? buildMcpTools(entry.sourceId, query) : [],
+  };
+}
+
+function toPlan(request, entries, strategy) {
+  const sourcePlans = promoteConfidence(dedupeSources(entries)).map((entry) =>
+    buildSourcePlan(entry, request.query),
+  );
+  return {
+    query: request.query,
+    format: request.format,
+    maxResults: request.maxResults,
+    sources: sourcePlans.map((item) => item.sourceId),
+    sourcePlans,
+    sourceMetas: buildSourceMetas(sourcePlans),
+    strategy,
+    options: {
+      maxResults: request.maxResults,
+      timeout: DEFAULT_TIMEOUT_MS,
+      format: request.format,
+    },
+  };
+}
+
+export function buildExecutionPlan(request, routeDecision) {
+  if (request.sources && request.sources.length > 0) {
+    const sources = request.sources.map((sourceId) => ({
+      sourceId,
+      confidence: 'primary',
+      via: 'explicit',
+    }));
+    return toPlan(request, sources, 'explicit');
+  }
+
+  if (request.parallel) {
+    const matchedPatterns = Object.entries(PATTERNS).filter(([, pattern]) =>
+      pattern.triggers.test(request.query),
+    );
+    if (matchedPatterns.length > 0) {
+      const entries = [];
+      for (const [patternId, pattern] of matchedPatterns) {
+        for (const sourceId of pattern.sources) {
+          entries.push({
+            sourceId,
+            confidence:
+              sourceId === ROUTING_FALLBACK.sourceId
+                ? ROUTING_FALLBACK.confidence
+                : routeDecision.matchedSources.find((item) => item.sourceId === sourceId)
+                    ?.confidence ?? 'secondary-mid',
+            via: `parallel:${patternId}`,
+          });
+        }
+      }
+      return toPlan(request, entries, 'parallel-pattern');
+    }
+  }
+
+  const routedEntries = routeDecision.matchedSources.map((item) => ({
+    sourceId: item.sourceId,
+    confidence: item.confidence,
+    via: 'router',
+  }));
+  if (
+    routeDecision.fallback &&
+    !routedEntries.some((item) => item.sourceId === routeDecision.fallback.sourceId)
+  ) {
+    routedEntries.push({
+      sourceId: routeDecision.fallback.sourceId,
+      confidence: routeDecision.fallback.confidence,
+      via: 'router-fallback',
+    });
+  }
+
+  return toPlan(request, routedEntries, 'router');
+}

--- a/scripts/search/ranker.js
+++ b/scripts/search/ranker.js
@@ -1,0 +1,8 @@
+import { CONFIDENCE_SCORE_MAP } from './config.js';
+
+export function assignConfidence(items) {
+  return items.map((item) => ({
+    ...item,
+    confidence: CONFIDENCE_SCORE_MAP[item.confidenceLabel] ?? 0.3,
+  }));
+}

--- a/scripts/search/router.js
+++ b/scripts/search/router.js
@@ -1,0 +1,34 @@
+import { ROUTING_FALLBACK, ROUTING_RULES } from './routing-rules.js';
+
+export function resolveIntent(query, explicitSources) {
+  if (explicitSources && explicitSources.length > 0) {
+    return {
+      matchedSources: explicitSources.map((sourceId) => ({
+        sourceId,
+        confidence: 'primary',
+        reason: 'explicit-source',
+      })),
+      fallback: null,
+      reason: 'Explicit sources supplied',
+    };
+  }
+
+  const matches = ROUTING_RULES.filter((rule) => rule.pattern.test(query)).map((rule) => ({
+    sourceId: rule.sourceId,
+    confidence: rule.confidence,
+    reason: `matched:${rule.pattern}`,
+  }));
+
+  const dedupedMatches = Array.from(
+    new Map(matches.map((item) => [item.sourceId, item])).values(),
+  );
+
+  return {
+    matchedSources: dedupedMatches,
+    fallback: ROUTING_FALLBACK,
+    reason:
+      dedupedMatches.length > 0
+        ? 'Matched routing rules'
+        : 'No routing rule matched; fallback available',
+  };
+}

--- a/scripts/search/routing-rules.js
+++ b/scripts/search/routing-rules.js
@@ -1,0 +1,27 @@
+export const ROUTING_RULES = Object.freeze([
+  {
+    pattern: /統計|人口|経済|GDP|産業|雇用率|出生率/i,
+    sourceId: 'estat',
+    confidence: 'primary',
+  },
+  {
+    pattern: /法令|通達|社会保険|労働基準|安全衛生/i,
+    sourceId: 'labor-law',
+    confidence: 'primary',
+  },
+  {
+    pattern: /note記事|note\.com|原稿/i,
+    sourceId: 'note-com',
+    confidence: 'secondary-mid',
+  },
+  {
+    pattern: /SNS|X|ツイート|twitter|バズ/i,
+    sourceId: 'x-search',
+    confidence: 'secondary-low',
+  },
+]);
+
+export const ROUTING_FALLBACK = Object.freeze({
+  sourceId: 'web',
+  confidence: 'secondary-high',
+});

--- a/scripts/search/schemas.js
+++ b/scripts/search/schemas.js
@@ -1,0 +1,221 @@
+import {
+  DEFAULT_FORMAT,
+  DEFAULT_MAX_RESULTS,
+  DEFAULT_PARALLEL,
+  KNOWN_SOURCES,
+} from './config.js';
+
+function createValidationError(message) {
+  const error = new Error(message);
+  error.name = 'ValidationError';
+  return error;
+}
+
+function createFallbackSchema() {
+  class FallbackSchema {
+    /**
+     * @param {(value: unknown) => unknown} parser
+     */
+    constructor(parser) {
+      this.parser = parser;
+    }
+
+    parse(value) {
+      return this.parser(value);
+    }
+
+    optional() {
+      return new FallbackSchema((value) => {
+        if (value === undefined) {
+          return undefined;
+        }
+        return this.parse(value);
+      });
+    }
+
+    default(defaultValue) {
+      return new FallbackSchema((value) => {
+        if (value === undefined) {
+          return defaultValue;
+        }
+        return this.parse(value);
+      });
+    }
+  }
+
+  const z = {
+    unknown() {
+      return new FallbackSchema((value) => value);
+    },
+    string() {
+      return new FallbackSchema((value) => {
+        if (typeof value !== 'string') {
+          throw createValidationError('Expected string');
+        }
+        return value;
+      });
+    },
+    boolean() {
+      return new FallbackSchema((value) => {
+        if (typeof value !== 'boolean') {
+          throw createValidationError('Expected boolean');
+        }
+        return value;
+      });
+    },
+    number() {
+      return new FallbackSchema((value) => {
+        if (typeof value !== 'number' || Number.isNaN(value)) {
+          throw createValidationError('Expected number');
+        }
+        return value;
+      });
+    },
+    enum(values) {
+      return new FallbackSchema((value) => {
+        if (!values.includes(value)) {
+          throw createValidationError(`Expected one of: ${values.join(', ')}`);
+        }
+        return value;
+      });
+    },
+    array(schema) {
+      return new FallbackSchema((value) => {
+        if (!Array.isArray(value)) {
+          throw createValidationError('Expected array');
+        }
+        return value.map((item) => schema.parse(item));
+      });
+    },
+    record(valueSchema) {
+      return new FallbackSchema((value) => {
+        if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+          throw createValidationError('Expected object record');
+        }
+        /** @type {Record<string, unknown>} */
+        const parsed = {};
+        for (const [key, item] of Object.entries(value)) {
+          parsed[key] = valueSchema.parse(item);
+        }
+        return parsed;
+      });
+    },
+    object(shape) {
+      return new FallbackSchema((value) => {
+        if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+          throw createValidationError('Expected object');
+        }
+        /** @type {Record<string, unknown>} */
+        const record = value;
+        /** @type {Record<string, unknown>} */
+        const parsed = {};
+        for (const [key, schema] of Object.entries(shape)) {
+          parsed[key] = schema.parse(record[key]);
+        }
+        return parsed;
+      });
+    },
+    coerce: {
+      number() {
+        return new FallbackSchema((value) => {
+          const parsed = Number(value);
+          if (Number.isNaN(parsed)) {
+            throw createValidationError('Expected coercible number');
+          }
+          return parsed;
+        });
+      },
+    },
+  };
+
+  return z;
+}
+
+let z = createFallbackSchema();
+
+try {
+  const module = await import('zod');
+  z = module.z;
+} catch {
+  z = createFallbackSchema();
+}
+
+const formatSchema = z.enum(['json', 'markdown', 'summary']);
+const sourceSchema = z.enum(KNOWN_SOURCES);
+const confidenceSchema = z.enum([
+  'primary',
+  'secondary-high',
+  'secondary-mid',
+  'secondary-low',
+]);
+const executionModeSchema = z.enum(['direct', 'claude-session']);
+const executionStatusSchema = z.enum(['ok', 'error', 'timeout', 'stub']);
+
+export const searchRequestSchema = z.object({
+  query: z.string(),
+  format: formatSchema.default(DEFAULT_FORMAT),
+  maxResults: z.coerce.number().default(DEFAULT_MAX_RESULTS),
+  parallel: z.boolean().default(DEFAULT_PARALLEL),
+  sources: z.array(sourceSchema).optional(),
+});
+
+export const normalizedItemSchema = z.object({
+  sourceId: sourceSchema,
+  title: z.string(),
+  url: z.string(),
+  snippet: z.string(),
+  confidenceLabel: confidenceSchema,
+});
+
+export const sourceErrorSchema = z.object({
+  sourceId: sourceSchema,
+  code: z.string(),
+  message: z.string(),
+});
+
+export const mcpToolSchema = z.object({
+  tool: z.string(),
+  params: z.record(z.unknown()),
+});
+
+export const searchPlanSourceSchema = z.object({
+  sourceId: sourceSchema,
+  confidence: confidenceSchema,
+  via: z.string(),
+  executionMode: executionModeSchema,
+  mcpTools: z.array(mcpToolSchema),
+});
+
+export const searchPlanSchema = z.object({
+  query: z.string(),
+  sources: z.array(searchPlanSourceSchema),
+  options: z.object({
+    maxResults: z.number(),
+    timeout: z.number(),
+    format: formatSchema,
+  }),
+});
+
+export const searchExecutionItemSchema = z.object({
+  title: z.string(),
+  url: z.string(),
+  snippet: z.string(),
+  metadata: z.record(z.unknown()),
+});
+
+export const searchExecutionSourceSchema = z.object({
+  sourceId: sourceSchema,
+  status: executionStatusSchema,
+  items: z.array(searchExecutionItemSchema),
+  error: z
+    .object({
+      code: z.string(),
+      message: z.string(),
+    })
+    .optional(),
+  durationMs: z.number(),
+});
+
+export const searchExecutionResultSchema = z.object({
+  sources: z.array(searchExecutionSourceSchema),
+});

--- a/scripts/search/sources/base.js
+++ b/scripts/search/sources/base.js
@@ -1,0 +1,40 @@
+/**
+ * @typedef {Object} SearchContext
+ * @property {string} query
+ * @property {number} maxResults
+ * @property {AbortSignal} signal
+ *
+ * @typedef {Object} SearchItem
+ * @property {string} title
+ * @property {string} url
+ * @property {string} snippet
+ * @property {Record<string, unknown>} [metadata]
+ * @property {unknown} [raw]
+ *
+ * @typedef {Object} SourceError
+ * @property {string} sourceId
+ * @property {string} code
+ * @property {string} message
+ *
+ * @typedef {Object} SourceResult
+ * @property {SearchItem[]} items
+ * @property {SourceError | null} [error]
+ *
+ * @typedef {Object} SearchSource
+ * @property {string} id
+ * @property {(context: SearchContext) => Promise<SourceResult>} search
+ */
+
+/**
+ * @param {string} sourceId
+ * @param {string} code
+ * @param {string} message
+ * @returns {SourceError}
+ */
+export function createSourceError(sourceId, code, message) {
+  return {
+    sourceId,
+    code,
+    message,
+  };
+}

--- a/scripts/search/sources/estat.js
+++ b/scripts/search/sources/estat.js
@@ -1,0 +1,121 @@
+import { createSourceError } from './base.js';
+
+const ESTAT_ENDPOINT = 'https://api.e-stat.go.jp/rest/3.0/app/json/getStatsList';
+
+function resolveAppId() {
+  const configured = process.env.ESTAT_APP_ID?.trim();
+  if (configured) {
+    return configured;
+  }
+  return '';
+}
+
+function normalizeTextField(field) {
+  if (typeof field === 'string') {
+    return field;
+  }
+  if (field && typeof field === 'object' && '$' in field && typeof field.$ === 'string') {
+    return field.$;
+  }
+  return '';
+}
+
+function normalizeYear(entry) {
+  const candidates = [
+    entry?.SURVEY_DATE,
+    entry?.OPEN_DATE,
+    entry?.TIME,
+    entry?.TITLE,
+  ];
+  for (const candidate of candidates) {
+    const value = normalizeTextField(candidate);
+    const matched = value.match(/\b(19|20)\d{2}\b/u);
+    if (matched) {
+      return matched[0];
+    }
+  }
+  return '';
+}
+
+function normalizeItems(payload, maxResults) {
+  const rawList = payload?.GET_STATS_LIST?.DATALIST_INF?.TABLE_INF ?? [];
+  const tables = Array.isArray(rawList) ? rawList : [rawList].filter(Boolean);
+  return tables.slice(0, maxResults).map((entry) => {
+    const statName = normalizeTextField(entry?.STAT_NAME);
+    const title = normalizeTextField(entry?.TITLE);
+    const url = normalizeTextField(entry?.LINK);
+    const surveyYear = normalizeYear(entry);
+    return {
+      title: statName || title || 'Untitled statistic',
+      url,
+      snippet: title,
+      metadata: {
+        id: entry?.['@id'] ?? null,
+        statisticName: statName || null,
+        tableTitle: title || null,
+        surveyYear: surveyYear || null,
+        government: normalizeTextField(entry?.GOV_ORG) || null,
+      },
+      raw: entry,
+    };
+  });
+}
+
+export function createEstatSource(fetchImpl = globalThis.fetch) {
+  return {
+    id: 'estat',
+    async search({ query, maxResults, signal }) {
+      const appId = resolveAppId();
+      if (!appId) {
+        return {
+          items: [],
+          error: createSourceError(
+            'estat',
+            'MISSING_APP_ID',
+            'ESTAT_APP_ID is not configured',
+          ),
+        };
+      }
+
+      if (typeof fetchImpl !== 'function') {
+        return {
+          items: [],
+          error: createSourceError('estat', 'FETCH_UNAVAILABLE', 'fetch is not available'),
+        };
+      }
+
+      const url = new URL(ESTAT_ENDPOINT);
+      url.searchParams.set('appId', appId);
+      url.searchParams.set('searchWord', query);
+      url.searchParams.set('limit', String(maxResults));
+
+      const response = await fetchImpl(url, { signal });
+      if (!response.ok) {
+        return {
+          items: [],
+          error: createSourceError(
+            'estat',
+            'HTTP_ERROR',
+            `e-Stat request failed with status ${response.status}`,
+          ),
+        };
+      }
+
+      const payload = await response.json();
+      const status = normalizeTextField(payload?.GET_STATS_LIST?.RESULT?.STATUS);
+      if (status && status !== '0') {
+        const errorMessage =
+          normalizeTextField(payload?.GET_STATS_LIST?.RESULT?.ERROR_MSG) ||
+          'e-Stat returned an API error';
+        return {
+          items: [],
+          error: createSourceError('estat', 'API_ERROR', errorMessage),
+        };
+      }
+
+      return {
+        items: normalizeItems(payload, maxResults),
+      };
+    },
+  };
+}

--- a/scripts/search/sources/labor-law.js
+++ b/scripts/search/sources/labor-law.js
@@ -1,0 +1,5 @@
+import { createStubSource } from './mcp-wrapper.js';
+
+export function createLaborLawSource() {
+  return createStubSource('labor-law', 'labor-law source is not implemented');
+}

--- a/scripts/search/sources/mcp-wrapper.js
+++ b/scripts/search/sources/mcp-wrapper.js
@@ -1,0 +1,13 @@
+import { createSourceError } from './base.js';
+
+export function createStubSource(sourceId, message) {
+  return {
+    id: sourceId,
+    async search() {
+      return {
+        items: [],
+        error: createSourceError(sourceId, 'STUB_SOURCE', message),
+      };
+    },
+  };
+}

--- a/scripts/search/sources/note-com.js
+++ b/scripts/search/sources/note-com.js
@@ -1,0 +1,5 @@
+import { createStubSource } from './mcp-wrapper.js';
+
+export function createNoteComSource() {
+  return createStubSource('note-com', 'note-com source is not implemented');
+}

--- a/scripts/search/sources/web.js
+++ b/scripts/search/sources/web.js
@@ -1,0 +1,5 @@
+import { createStubSource } from './mcp-wrapper.js';
+
+export function createWebSource() {
+  return createStubSource('web', 'web source is not implemented');
+}

--- a/scripts/search/sources/x-search.js
+++ b/scripts/search/sources/x-search.js
@@ -1,0 +1,153 @@
+import { createSourceError } from './base.js';
+
+const XAI_RESPONSES_ENDPOINT = 'https://api.x.ai/v1/responses';
+const DEFAULT_MODEL = 'grok-4-fast';
+
+function resolveApiKey() {
+  return process.env.XAI_API_KEY?.trim() ?? '';
+}
+
+function resolveModel() {
+  return process.env.XAI_SEARCH_MODEL?.trim() || DEFAULT_MODEL;
+}
+
+function buildInstruction(query, maxResults) {
+  return [
+    `Search X (Twitter) for posts relevant to the query: "${query}".`,
+    `Return up to ${maxResults} most relevant and recent posts with URLs and short summaries.`,
+    'Prefer posts from verified or authoritative accounts when available.',
+  ].join(' ');
+}
+
+function pushCitation(items, candidate) {
+  if (!candidate || typeof candidate.url !== 'string' || !candidate.url) return;
+  items.push(candidate);
+}
+
+function extractCitations(payload) {
+  const items = [];
+
+  if (Array.isArray(payload?.citations)) {
+    for (const cit of payload.citations) {
+      pushCitation(items, {
+        url: cit?.url,
+        title: cit?.title,
+        snippet: cit?.snippet || cit?.text || '',
+        raw: cit,
+      });
+    }
+  }
+
+  const output = Array.isArray(payload?.output) ? payload.output : [];
+  for (const entry of output) {
+    const content = Array.isArray(entry?.content) ? entry.content : [];
+    for (const block of content) {
+      const annotations = Array.isArray(block?.annotations) ? block.annotations : [];
+      for (const ann of annotations) {
+        if (ann?.url) {
+          pushCitation(items, {
+            url: ann.url,
+            title: ann.title || ann.url,
+            snippet: ann.snippet || ann.text || '',
+            raw: ann,
+          });
+        }
+      }
+      const toolResults = Array.isArray(block?.results) ? block.results : [];
+      for (const result of toolResults) {
+        pushCitation(items, {
+          url: result?.url,
+          title:
+            result?.title ||
+            (typeof result?.text === 'string' ? result.text.slice(0, 80) : result?.url),
+          snippet: result?.text || result?.snippet || '',
+          author: result?.author || result?.username || null,
+          postId: result?.id || null,
+          createdAt: result?.created_at || null,
+          raw: result,
+        });
+      }
+    }
+  }
+
+  const seen = new Set();
+  return items.filter((item) => {
+    if (seen.has(item.url)) return false;
+    seen.add(item.url);
+    return true;
+  });
+}
+
+function normalizeItems(payload, maxResults) {
+  return extractCitations(payload)
+    .slice(0, maxResults)
+    .map((entry) => ({
+      title: entry.title || entry.url,
+      url: entry.url,
+      snippet: entry.snippet || '',
+      metadata: {
+        author: entry.author ?? null,
+        postId: entry.postId ?? null,
+        createdAt: entry.createdAt ?? null,
+      },
+      raw: entry.raw,
+    }));
+}
+
+export function createXSearchSource(fetchImpl = globalThis.fetch) {
+  return {
+    id: 'x-search',
+    async search({ query, maxResults, signal }) {
+      const apiKey = resolveApiKey();
+      if (!apiKey) {
+        return {
+          items: [],
+          error: createSourceError(
+            'x-search',
+            'MISSING_API_KEY',
+            'XAI_API_KEY is not configured',
+          ),
+        };
+      }
+
+      if (typeof fetchImpl !== 'function') {
+        return {
+          items: [],
+          error: createSourceError('x-search', 'FETCH_UNAVAILABLE', 'fetch is not available'),
+        };
+      }
+
+      const requestBody = {
+        model: resolveModel(),
+        input: buildInstruction(query, maxResults),
+        tools: [{ type: 'x_search' }],
+      };
+
+      const response = await fetchImpl(XAI_RESPONSES_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(requestBody),
+        signal,
+      });
+
+      if (!response.ok) {
+        const detail = await response.text().catch(() => '');
+        const trimmed = detail ? `: ${detail.slice(0, 200)}` : '';
+        return {
+          items: [],
+          error: createSourceError(
+            'x-search',
+            'HTTP_ERROR',
+            `xAI request failed with status ${response.status}${trimmed}`,
+          ),
+        };
+      }
+
+      const payload = await response.json();
+      return { items: normalizeItems(payload, maxResults) };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add a unified `scripts/search.js` search engine with plan, execute, aggregate, normalize, rank, and format stages.
- Add native xAI x_search integration via the Responses API `/v1/responses` path, gated by `XAI_API_KEY` so existing offline and non-xAI flows keep working.
- Add a dual-invoke adapter for FUGUE/Claude and Kernel/Codex through `bin/search`, while preserving the existing FUGUE direct `node scripts/search.js` invocation path.
- Document the adapter contract in `docs/search-adapter.md`, including stdout, stderr, JSON modes, aggregate input, and exit-code behavior.

## Live Smoke

- xAI live smoke was previously verified with query `AIニュース`: `items=3`, annotations path hit, timeout 15s.

## Tests

- `node --test scripts/search/__tests__/*.test.js`: 27/27 pass.
- Adapter smoke added: `bin/search --query "adapter smoke" --plan-only --format json` returns valid `SearchPlan` JSON.

## Breaking Changes

None. Existing FUGUE `/search` slash skill calls can keep using:

```bash
node /Users/masayuki/Dev/agent-orchestration/scripts/search.js "<query>" --plan-only
node /Users/masayuki/Dev/agent-orchestration/scripts/search.js --aggregate /tmp/search-execution-result.json --format markdown
```

## Test Plan

- [x] Run full Node search suite with glob: `node --test scripts/search/__tests__/*.test.js`.
- [x] Run adapter smoke through `bin/search` in plan-only JSON mode.
- [x] Confirm branch diff is limited to `scripts/search.js`, `scripts/search/`, `bin/search`, and `docs/search-adapter.md`.
- [x] Confirm no Kernel prompt, AGENTS, harness, or unrelated branch files are included.
