### PR TITLE
feat(search): auto-inject x-search when XAI_API_KEY is set

### DIFF
--- a/scripts/search/__tests__/planner.test.js
+++ b/scripts/search/__tests__/planner.test.js
@@ -3,6 +3,18 @@ import assert from 'node:assert/strict';
 import { buildExecutionPlan } from '../planner.js';
 import { resolveIntent } from '../router.js';
 
+function setXaiApiKeyForTest(t, value) {
+  const originalXaiApiKey = process.env.XAI_API_KEY;
+  t.before(() => {
+    if (value === undefined) delete process.env.XAI_API_KEY;
+    else process.env.XAI_API_KEY = value;
+  });
+  t.after(() => {
+    if (originalXaiApiKey === undefined) delete process.env.XAI_API_KEY;
+    else process.env.XAI_API_KEY = originalXaiApiKey;
+  });
+}
+
 test('explicit sources disable patterns and fallback', () => {
   const request = {
     query: '市場トレンド',
@@ -15,6 +27,51 @@ test('explicit sources disable patterns and fallback', () => {
   const plan = buildExecutionPlan(request, routeDecision);
   assert.equal(plan.strategy, 'explicit');
   assert.deepEqual(plan.sources, ['labor-law']);
+});
+
+test('router auto-injects x-search for generic queries when XAI_API_KEY is set', (t) => {
+  setXaiApiKeyForTest(t, 'test-key');
+  const request = {
+    query: 'skills',
+    format: 'summary',
+    maxResults: 5,
+    parallel: false,
+  };
+  const routeDecision = resolveIntent(request.query);
+  const plan = buildExecutionPlan(request, routeDecision);
+  assert.equal(plan.strategy, 'router');
+  assert.deepEqual(plan.sources, ['web', 'x-search']);
+  assert.equal(plan.sourceMetas['x-search'].confidence, 'secondary-mid');
+  assert.equal(plan.sourceMetas['x-search'].via, 'auto-xai-key-set');
+});
+
+test('router does not auto-inject x-search for generic queries when XAI_API_KEY is unset', (t) => {
+  setXaiApiKeyForTest(t, undefined);
+  const request = {
+    query: 'skills',
+    format: 'summary',
+    maxResults: 5,
+    parallel: false,
+  };
+  const routeDecision = resolveIntent(request.query);
+  const plan = buildExecutionPlan(request, routeDecision);
+  assert.equal(plan.strategy, 'router');
+  assert.deepEqual(plan.sources, ['web']);
+});
+
+test('explicit web source is respected even when XAI_API_KEY is set', (t) => {
+  setXaiApiKeyForTest(t, 'test-key');
+  const request = {
+    query: 'skills',
+    format: 'summary',
+    maxResults: 5,
+    parallel: true,
+    sources: ['web'],
+  };
+  const routeDecision = resolveIntent(request.query, request.sources);
+  const plan = buildExecutionPlan(request, routeDecision);
+  assert.equal(plan.strategy, 'explicit');
+  assert.deepEqual(plan.sources, ['web']);
 });
 
 test('parallel patterns choose declared source set', () => {
@@ -30,7 +87,8 @@ test('parallel patterns choose declared source set', () => {
   assert.deepEqual(plan.sources, ['web', 'estat', 'x-search']);
 });
 
-test('router adds web fallback only for automatic routing', () => {
+test('router adds web fallback only for automatic routing', (t) => {
+  setXaiApiKeyForTest(t, undefined);
   const request = {
     query: 'GDPを調べる',
     format: 'summary',

--- a/scripts/search/planner.js
+++ b/scripts/search/planner.js
@@ -18,6 +18,20 @@ function promoteConfidence(entries) {
   });
 }
 
+function ensureXSearchInEntries(entries) {
+  if (!isXSearchDirectMode() || entries.some((entry) => entry.sourceId === 'x-search')) {
+    return entries;
+  }
+  return [
+    ...entries,
+    {
+      sourceId: 'x-search',
+      confidence: 'secondary-mid',
+      via: 'auto-xai-key-set',
+    },
+  ];
+}
+
 function dedupeSources(sourceEntries) {
   return Array.from(new Map(sourceEntries.map((entry) => [entry.sourceId, entry])).values());
 }
@@ -94,7 +108,7 @@ export function buildExecutionPlan(request, routeDecision) {
           });
         }
       }
-      return toPlan(request, entries, 'parallel-pattern');
+      return toPlan(request, ensureXSearchInEntries(entries), 'parallel-pattern');
     }
   }
 
@@ -114,5 +128,5 @@ export function buildExecutionPlan(request, routeDecision) {
     });
   }
 
-  return toPlan(request, routedEntries, 'router');
+  return toPlan(request, ensureXSearchInEntries(routedEntries), 'router');
 }


### PR DESCRIPTION
## Summary
- Adds planner-level auto-injection of `x-search` when `XAI_API_KEY` is configured and the plan was produced by router or parallel-pattern routing.
- Keeps explicit `--sources` behavior unchanged so user-specified source lists are respected.
- Covers generic query behavior for key-set/key-unset cases plus explicit `--sources=web` regression protection.

## Tests
- `node --test scripts/search/__tests__/*.test.js`
- Existing cases: 27/27 pass
- New regression cases: 3/3 pass

## Breaking change
- None. Explicit source specification keeps the previous behavior.

## Memory
- Needs manual update: `/Users/masayuki/.claude/projects/-Users-masayuki-Dev/memory/search_xai_x_search_plan.md` is outside the writable sandbox for this task.
- Please append: `Status (2026-04-20): auto-inject for generic queries enabled — when XAI_API_KEY is set, x-search is automatically included in router/parallel-pattern plans without requiring --sources. explicit --sources specification still respected.`