### PR TITLE
chore(sops): migrate import target to canonical `fugue` keychain service

### DIFF
--- a/scripts/sops/import-to-keychain.sh
+++ b/scripts/sops/import-to-keychain.sh
@@ -108,11 +108,11 @@ echo "$DECRYPTED" | while IFS= read -r line; do
 
   # Standard fugue-secrets entries: import with BOTH original key name AND kebab alias
   # This prevents "key not found" when code searches by either naming convention
-  import_secret "$KEY" "fugue-secrets" "$VALUE" "$KEY (canonical)"
+  import_secret "$KEY" "fugue" "$VALUE" "$KEY (canonical)"
 
   ACCT=$(map_to_acct "$KEY")
   if [ -n "$ACCT" ] && [ "$ACCT" != "$KEY" ]; then
-    import_secret "$ACCT" "fugue-secrets" "$VALUE" "$KEY -> $ACCT (alias)"
+    import_secret "$ACCT" "fugue" "$VALUE" "$KEY -> $ACCT (alias)"
   fi
 done
 


### PR DESCRIPTION
## Summary
- Phase 3b of secrets brushup (2026-04-20) consolidated the macOS Keychain canonical service from `fugue-secrets` to `fugue`
- Downstream consumers (`delegate-*.js`, `fugue-notifier.sh`, `spool-router.sh`, `fugue-answer-receiver.mjs`) already read from `fugue` — this was the last deferred piece
- Re-running `import-to-keychain.sh` would have silently repopulated the deprecated `fugue-secrets` namespace, leaking drift back in

## What changed
Only the Keychain **service** argument in two `import_secret` calls. The `fugue-secrets.enc` filename (sops payload on disk) is intentionally unchanged.

## Verification
- `audit-secrets.sh --strict` clean on MacBook (post Phase 3b baseline)
- `fugue-secrets` service retained until 2026-04-27 for rollback; this PR does not delete anything
- Fresh worktree branch off `origin/main`; no unrelated diff

## Context
- `~/.claude/assets/docs/secrets-inventory.md`
- `~/.claude/state/runs/secrets-brushup-20260420/phase-b-summary.md`
- `~/.claude/state/runs/secrets-hardening-20260420/phase-a-summary.md`

## Test plan
- [ ] On a test machine: re-run `scripts/sops/import-to-keychain.sh`; confirm all imported items show up under `security find-generic-password -s fugue` and none are added to `fugue-secrets`
- [ ] Run `~/.claude/assets/scripts/audit-secrets.sh --strict` post-import; expect exit 0 (only `fieldy-*` MacBook-only entries flagged)
- [ ] Spot-check `security find-generic-password -s fugue -a OPENAI_API_KEY -w` returns the re-imported value

Draft until reviewer sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)